### PR TITLE
docs: 開発セットアップとAPI説明を簡潔化

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,119 +26,54 @@
 
 ## 開発環境のセットアップ
 
-### 1. リポジトリのクローン
+### 手順
 
-```bash
-git clone https://github.com/Qman110101/chunisupport-api.git
-cd chunisupport-api
-```
-
-### 2. 設定ファイルの準備
-
-このアプリケーションは、**環境変数 (.env)** と **JSON設定ファイル** の2種類を組み合わせて設定を読み込みます。
-
-#### a. `.env` ファイルの作成 (機密情報・DB接続情報)
-
-プロジェクトのルートディレクトリに `.env` ファイルを作成し、以下の情報を設定します。
-
-```bash
-# .env
-
-# アプリケーション環境 (必須)
-APP_ENV=develop
-
-# セキュリティ (必須: 32文字以上の強力なランダム文字列)
-JWT_SECRET=your_super_secret_jwt_key_at_least_32_characters_long_here
-PW_PEPPER=your_super_secret_pepper_value_at_least_32_characters_long
-
-# データベース接続情報 (必須)
-DB_NAME=chunisupport
-DB_HOST=localhost
-DB_PORT=3306
-DB_USER=your_user
-DB_PASS=your_password
-```
-
-> **注意**: `.env` ファイルは `.gitignore` で除外されています。**このファイルは絶対にリポジトリにコミットしないでください。**
-
-#### b. JSON設定ファイルの作成 (アプリケーション動作設定)
-
-次に、プロジェクトルートに `.config` ディレクトリを作成し、その中に環境に応じた設定ファイルを作成します。ファイル名は `(develop|staging|production).settings.json` の形式です。
-
-まずは `.config/develop.settings.json` を作成します。
-
-```bash
-mkdir .config
-```
-
-**`.config/develop.settings.json` の内容例:**
-
-```json
-{
-  "app_port": 3002,
-  "log_level": "debug",
-  "log_paths": {
-    "app": "log",
-    "echo": "log"
-  },
-  "shutdown_timeout_seconds": 20,
-  "auth": {
-    "jwt_expiration_hour": 24,
-    "session_expiration_hour": 24,
-    "cookie_secure": false,
-    "cookie_same_site": "lax"
-  },
-  "cors": {
-    "allow_origins": [
-      "http://localhost:3000",
-      "http://localhost:5173"
-    ],
-    "allow_credentials": true,
-    "max_age": 3600
-  }
-}
-```
-
-**設定項目の補足:**
-- `log_paths`: ログを出力する**ディレクトリ**を指定します（例: `"log"` とすると `log/YYYYMMDD-HHMMSS.log` が生成されます）。
-- `shutdown_timeout_seconds`: シャットダウン時に待機する秒数を指定します。
-- `cookie_secure`: HTTPSを使用する場合は`true`に設定（開発環境では`false`）。
-- `cors.allow_origins`: フロントエンドアプリケーションのオリジンを指定。
-
-### 3. データベースのセットアップ
-
-ローカル環境にMySQLサーバーを準備し、`.env` で指定したデータベース名（例: `chunisupport`）でデータベースを作成してください。
-
-### 4. 依存関係のインストール
-
-```bash
-go mod tidy
-```
-
-### 5. データベースマイグレーション
-
-**ツールのインストール（未導入の場合）:**
-```bash
-go install -tags 'mysql sqlite' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
-```
-
-**マイグレーションの実行:**
-
-以下のコマンドで、`migration/mysql` ディレクトリ内のマイグレーションファイルをデータベースに適用します。
-DB接続情報は `.env` の設定値に合わせて変更してください。
-
-```bash
-migrate -database "mysql://<DB_USER>:<DB_PASS>@tcp(<DB_HOST>:<DB_PORT>)/<DB_NAME>" -path migration/mysql up
-```
-
-SQLiteはまだ利用していないため、コマンドの記載はありません。
-
-### 6. アプリケーションの起動
-
-実行時には `APP_ENV` 環境変数の指定が必須です（`.env` に記載していても、コマンド実行時に明示するか、`godotenv` による読み込みに依存します）。
-
-```bash
-APP_ENV=develop go run main.go
-```
-
-サーバーの起動ポートは JSON設定ファイルの `app_port` に従います（例: `3002`）。
+1. リポジトリをクローンする。
+   ```bash
+   git clone https://github.com/Qman110101/chunisupport-api.git
+   cd chunisupport-api
+   ```
+2. 設定ファイルを用意する（詳細は `docs/configuration.md` を参照）。
+   ```bash
+   mkdir -p .config
+   ```
+   ```bash
+   # .env
+   APP_ENV=develop
+   JWT_SECRET=your_secret_32_chars_min
+   PW_PEPPER=your_pepper_32_chars_min
+   DB_NAME=chunisupport
+   DB_HOST=localhost
+   DB_PORT=3306
+   DB_USER=your_user
+   DB_PASS=your_password
+   ```
+   ```json
+   // .config/develop.settings.json
+   {
+     "app_port": 3002,
+     "log_level": "debug",
+     "log_paths": { "app": "log", "echo": "log" },
+     "shutdown_timeout_seconds": 20,
+     "auth": {
+       "jwt_expiration_hour": 24,
+       "session_expiration_hour": 24,
+       "cookie_secure": false,
+       "cookie_same_site": "lax"
+     },
+     "cors": {
+       "allow_origins": ["http://localhost:3000"],
+       "allow_credentials": true,
+       "max_age": 3600
+     }
+   }
+   ```
+3. データベースを用意してマイグレーションする。
+   ```bash
+   go install -tags 'mysql sqlite' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+   migrate -database "mysql://<DB_USER>:<DB_PASS>@tcp(<DB_HOST>:<DB_PORT>)/<DB_NAME>" -path migration/mysql up
+   ```
+4. 起動する。
+   ```bash
+   APP_ENV=develop go run main.go
+   ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@
    git clone https://github.com/Qman110101/chunisupport-api.git
    cd chunisupport-api
    ```
-2. 設定ファイルを用意する（詳細は `docs/configuration.md` を参照）。
+2. 依存関係を取得する。
+   ```bash
+   go mod tidy
+   ```
+3. 設定ファイルを用意する（詳細は `docs/configuration.md` を参照）。
    ```bash
    mkdir -p .config
    ```
@@ -68,12 +72,15 @@
      }
    }
    ```
-3. データベースを用意してマイグレーションする。
+4. データベースを作成してマイグレーションする。
+   ```bash
+   mysql -u <DB_USER> -p -e "CREATE DATABASE IF NOT EXISTS <DB_NAME>;"
+   ```
    ```bash
    go install -tags 'mysql sqlite' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
    migrate -database "mysql://<DB_USER>:<DB_PASS>@tcp(<DB_HOST>:<DB_PORT>)/<DB_NAME>" -path migration/mysql up
    ```
-4. 起動する。
+5. 起動する。
    ```bash
    APP_ENV=develop go run main.go
    ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,19 +6,9 @@
 
 ## ベースURLと環境
 
-アプリケーションは `.config/<environment>.settings.json` の `app_port` で待ち受けポートを決定します。ローカル開発で `app_port` に `3002` を設定した場合のベースURLは `http://localhost:3002` になります。
+アプリケーションは `.config/<environment>.settings.json` の `app_port` で待ち受けポートを決定します。`APP_ENV=<name> go run main.go` で環境を切り替えます。
 
-想定している環境名は以下の3種類です。
-
-| 環境名 | 設定ファイル | 例示ポート |
-| ------ | ------------ | ---------- |
-| develop | `.config/develop.settings.json` | `http://localhost:<app_port>` |
-| staging | `.config/staging.settings.json` | `https://staging.example.com:<app_port>` |
-| production | `.config/production.settings.json` | `https://api.example.com:<app_port>` |
-
-`APP_ENV=<name> go run main.go` で設定ファイルを切り替えます（環境変数は必須です）。
-
-以降のリクエスト例では `${APP_PORT}` を設定済みポート番号のプレースホルダーとして使用します。
+ローカル開発の例: `http://localhost:${APP_PORT}`
 
 主要なパス構成:
 
@@ -28,58 +18,20 @@
 
 ## CORS
 
-すべてのエンドポイントでCORSが有効化されています。設定は環境ごとの設定ファイルで管理されます。
-
-| 設定項目 | 説明 |
-| -------- | ---- |
-| `cors.allow_origins` | 許可するオリジンの配列 |
-| `cors.allow_credentials` | Cookie送信を許可するか (内部APIでは `true` 必須) |
-| `cors.max_age` | プリフライトキャッシュ秒数 |
-
-**許可メソッド**: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`
-
-**許可ヘッダー**: `Origin`, `Content-Type`, `Accept`, `Authorization`
-
-**公開ヘッダー**: `Content-Length`
-
-フロントエンドからのリクエストでは、Cookie認証を使用する場合 `credentials: 'include'` を必ず設定してください。
-
-```javascript
-// fetch の例
-fetch('http://localhost:3002/internal/me', {
-  credentials: 'include'
-});
-```
+すべてのエンドポイントでCORSが有効です。設定は `cors.*` を参照してください（設定方法は `docs/configuration.md` を参照）。
 
 ## 認証
 
 ### 内部API (`/internal`)
 
 - ログイン成功時に `token` という名前の HTTPOnly Cookie を発行します。
-- Cookie属性は以下の通りです。
-  - `Path=/`
-  - `HttpOnly` は常に付与
-  - `Secure` は `auth.cookie_secure` 設定値に追従 (開発環境では `false`, HTTPS運用時は `true` を推奨)
-  - `SameSite` は `auth.cookie_same_site` の値 (`lax`/`strict`/`none`)
-- セッションはサーバー側 (`sessions` テーブル) に保存され、JWTにはセッションIDが含まれます。
-- すべての認証必須エンドポイントでは `JWTMiddleware` が Cookie を検証し、`userEntity`（`entity.User`）をリクエストコンテキストに格納します。
-- `/internal/users/:username` `/internal/songs` `/internal/songs/:displayid` `/internal/songs/worldsend` `/internal/songs/worldsend/:displayid` は Cookie 任意です。未認証時は1分10回/IPのレートリミットが適用されます。
+- 認証必須エンドポイントでは Cookie を検証し、ユーザー情報をリクエストコンテキストに格納します。
+- Cookie 任意のエンドポイントでは、未認証時にレートリミットが適用されます。
 
 ### 公開API (`/v1`)
 
 - `Authorization: Bearer <token>` ヘッダーで API トークンを送信します。
-- ミドルウェアがトークンを検証し、認証済みユーザーとトークン情報をコンテキストに格納します。
-- トークンは `/internal/auth/api-tokens` で発行します。1ユーザーにつき1件のみ保持され、再発行すると旧トークンは無効化されます。
-- **レートリミット**: ADMINアカウントは無制限、その他のアカウントは15分間に150リクエストまでに制限されます。
-
-```javascript
-// fetch の例
-fetch('http://localhost:3002/v1/songs', {
-  headers: {
-    'Authorization': 'Bearer your-api-token-here'
-  }
-});
-```
+- トークンは `/internal/auth/api-tokens` で発行します。
 
 ## 共通レスポンス仕様
 
@@ -97,51 +49,9 @@ fetch('http://localhost:3002/v1/songs', {
 
 `error` オブジェクト内の `code` フィールドには機械処理しやすいスネークケースのエラーコードが入ります。`status` フィールドにはHTTPステータスコードが入ります。詳細なエラーメッセージはサーバーログにのみ記録され、クライアントには返却されません。
 
-### エラーコード一覧
-
-| カテゴリ | コード | HTTPステータス | 発生条件 |
-| -------- | ------ | -------------- | -------- |
-| 汎用 | `bad_request` | 400 | リクエスト形式不正、JSON構文エラー |
-| 汎用 | `internal_error` | 500 | サーバー内部エラー |
-| 認証 | `unauthorized` | 401 | 認証が必要 |
-| 認証 | `invalid_credentials` | 401 | ユーザー名またはパスワードが不正 |
-| 認証 | `invalid_token` | 401 | トークンが無効 |
-| 認証 | `token_expired` | 401 | トークン期限切れ |
-| 認証 | `missing_token` | 401 | トークン未指定 |
-| 認証 | `invalid_session` | 401 | セッション無効/期限切れ（詳細隠蔽） |
-| 認証 | `invalid_recovery_credentials` | 401 | リカバリーコードが無効/使用済み/ユーザー不在 |
-| 権限 | `forbidden` | 403 | アクセス権限なし |
-| ユーザー | `registration_failed` | 400 | ユーザー登録失敗（詳細隠蔽） |
-| ユーザー | `user_not_found` | 404 | ユーザーが見つからない（非公開含む） |
-| ユーザー | `operation_failed` | 400 | 操作失敗（詳細隠蔽） |
-| プレイヤー | `player_not_found` | 404 | プレイヤーが見つからない |
-| データ | `validation_failed` | 422 | 入力値バリデーションエラー |
-| データ | `resource_not_found` | 400 | マスターデータが見つからない |
-| データ | `conflict` | 409 | データ競合（例: 別ユーザーのプレイヤーデータと衝突） |
-| データ | `api_token_not_found` | 404 | APIトークンが見つからない |
-| データ | `payload_too_large` | 413 | リクエストボディサイズ超過 |
-| 入力検証 | `username_empty` | 400 | ユーザー名が空 |
-| 入力検証 | `username_too_short` | 400 | ユーザー名が短すぎる（5文字未満） |
-| 入力検証 | `username_too_long` | 400 | ユーザー名が長すぎる（50文字超過） |
-| 入力検証 | `username_invalid_char` | 400 | ユーザー名に使用できない文字が含まれている（小文字英数字のみ可） |
-| 入力検証 | `password_too_short` | 400 | パスワードが短すぎる（8文字未満） |
-| 入力検証 | `password_too_long` | 400 | パスワードが長すぎる（128文字超過） |
-| 入力検証 | `invalid_password` | 400 | パスワードが無効（詳細隠蔽） |
-| その他 | `not_found` | 404 | リソースが存在しない |
-| その他 | `method_not_allowed` | 405 | HTTPメソッドが許可されていない |
-| その他 | `unsupported_media_type` | 415 | サポートされていないメディアタイプ |
-| その他 | `too_many_requests` | 429 | リクエスト制限超過 |
-| その他 | `service_unavailable` | 503 | サービス利用不可 |
-
 ## マスターデータ概要
 
 主なマスタ定義は `migration/mysql/000001_init_schema.up.sql` に記載されています。
-
-- アカウント種別: `PLAYER`, `EDITOR`, `ADMIN`
-- クリアランプ: `FAILED`, `CLEAR`, `HARD`, `BRAVE`, `ABSOLUTE`, `CATASTROPHY`
-- コンボランプ: `NONE`, `FULL COMBO`, `ALL JUSTICE`
-- フルチェイン: `NONE`, `FULL CHAIN GOLD`, `FULL CHAIN PLATINUM`
-- スロット: `none`, `best`, `best_candidate`, `new`, `new_candidate`
 
 ## エンドポイント一覧
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,6 +49,33 @@
 
 `error` オブジェクト内の `code` フィールドには機械処理しやすいスネークケースのエラーコードが入ります。`status` フィールドにはHTTPステータスコードが入ります。詳細なエラーメッセージはサーバーログにのみ記録され、クライアントには返却されません。
 
+## エラーコード一覧（主要）
+
+主要なエラーコードは以下の通りです。全一覧は `internal/app/apierror/codes.go` を参照してください。
+
+| エラーコード | 説明 |
+| --- | --- |
+| `bad_request` | リクエスト形式不正（JSONパースエラーなど） |
+| `validation_failed` | 入力バリデーション失敗 |
+| `unauthorized` | 認証が必要 |
+| `invalid_token` | トークンが不正 |
+| `token_expired` | トークン期限切れ |
+| `missing_token` | トークン未指定 |
+| `forbidden` | 権限不足 |
+| `invalid_credentials` | ユーザー名またはパスワード不正 |
+| `invalid_recovery_credentials` | リカバリーコード不正/使用済み |
+| `username_empty` | ユーザー名が空 |
+| `username_too_short` | ユーザー名が短すぎる |
+| `username_too_long` | ユーザー名が長すぎる |
+| `username_invalid_char` | ユーザー名に使用できない文字が含まれる |
+| `password_too_short` | パスワードが短すぎる |
+| `password_too_long` | パスワードが長すぎる |
+| `invalid_password` | パスワードが無効 |
+| `not_found` | エンドポイントが見つからない |
+| `too_many_requests` | レートリミット超過 |
+| `service_unavailable` | サービス利用不可（DB接続失敗など） |
+| `internal_error` | 予期しないサーバーエラー |
+
 ## マスターデータ概要
 
 主なマスタ定義は `migration/mysql/000001_init_schema.up.sql` に記載されています。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,31 @@
+# 設定ファイル概要
+
+アプリケーションは `.env` と `.config/<環境>.settings.json` を読み込みます。最低限必要な項目だけを記載しています。
+
+## `.env` (必須)
+
+- `APP_ENV` (例: `develop`)
+- `JWT_SECRET` (32文字以上)
+- `PW_PEPPER` (32文字以上)
+- `DB_NAME`
+- `DB_HOST`
+- `DB_PORT`
+- `DB_USER`
+- `DB_PASS`
+
+## `.config/<環境>.settings.json` (必須)
+
+最低限、以下のキーを持つJSONを用意してください。
+
+- `app_port`
+- `log_level`
+- `log_paths.app`
+- `log_paths.echo`
+- `shutdown_timeout_seconds` (1以上)
+- `auth.jwt_expiration_hour`
+- `auth.session_expiration_hour`
+- `auth.cookie_secure`
+- `auth.cookie_same_site`
+- `cors.allow_origins`
+- `cors.allow_credentials`
+- `cors.max_age`


### PR DESCRIPTION
### Motivation

- README の「開発環境のセットアップ」が冗長で初回導入時に要点が埋もれていたため、まず動かすための最小手順に整理しました。 
- 設定項目は別ファイルに集約して参照性を高め、README は導入の入口に特化させる目的です。 
- API仕様書はエンドポイントとレスポンス例の確認を最優先とし、周辺説明を圧縮して必要箇所へ誘導するために簡潔化しました。

### Description

- `README.md` の「開発環境のセットアップ」セクションを手順化し、`git clone`、設定ファイルの最小例、マイグレーション、起動コマンドなどを短くまとめました。 
- 必須設定キーのみをまとめた新規ファイル `docs/configuration.md` を追加し、`.env` と `.config/<environment>.settings.json` の最低限の項目を列挙しました。 
- `docs/API.md` の冒頭説明を簡潔化し、設定参照先を `docs/configuration.md` に誘導するとともに、エンドポイント一覧と代表的なレスポンス例は保持しました。 
- ドキュメントの記述量を減らしつつ、開発に必要なコマンドや設定値がすぐ分かる構成に変更しました（例: `mkdir -p .config`、`.env` の最小例、`migrate` 実行例、`APP_ENV=develop go run main.go`）。

### Testing

- `gofmt -w .` を実行してフォーマット整形を行い、問題ありませんでした。 
- `go test ./...` を実行し、テストは全パッケージで成功（該当パッケージは `ok` / キャッシュ利用）しました。 
- ドキュメントのみの変更であるため既存のテストに影響はなく、テストはすべて通過しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69785fd43730832d84cce9440404d0ad)