### PR TITLE
fix: レートリミットテストのヘッダー検証を復元

### DIFF
--- a/internal/app/middleware/rate_limit_middleware_test.go
+++ b/internal/app/middleware/rate_limit_middleware_test.go
@@ -100,6 +100,8 @@ func TestAPIRateLimitMiddleware_NonAdminLimited(t *testing.T) {
 
 		// ヘッダーが設定されていることを確認
 		assert.Equal(t, "3", rec.Header().Get("X-RateLimit-Limit"))
+		assert.NotEmpty(t, rec.Header().Get("X-RateLimit-Remaining"))
+		assert.NotEmpty(t, rec.Header().Get("X-RateLimit-Reset"))
 	}
 
 	// 制限を超えると429エラー


### PR DESCRIPTION
### Motivation
- テストから誤って削除されていたレートリミット関連ヘッダー（`X-RateLimit-Remaining`, `X-RateLimit-Reset`）の存在検証を復元し、API仕様の検証を保つため。 

### Description
- `internal/app/middleware/rate_limit_middleware_test.go` の `TestAPIRateLimitMiddleware_NonAdminLimited` に `X-RateLimit-Remaining` と `X-RateLimit-Reset` のアサーションを再追加しました。 

### Testing
- `gofmt -w internal/app/middleware/rate_limit_middleware_test.go` を実行しました。 
- `go test ./...` を実行し、全テストが成功しました（`ok`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698176077bb0832dad9f45473d7b7183)