### PR TITLE
update: Go 1.25.6へ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
       - name: Test
         run: go test ./...
       - name: Install and run govulncheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Qman110101/chunisupport-api
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/go-playground/validator/v10 v10.28.0


### PR DESCRIPTION
### Motivation
- プロジェクトのGoバージョンを最新のパッチリリースに合わせ、ローカルとCIで一致させるため。

### Description
- `go.mod` の `go` 指定を `1.25.6` に更新しました。 
- `.github/workflows/ci.yml` の `actions/setup-go` 設定で `go-version` を `'1.25.6'` に更新しました。 

### Testing
- `go test ./...` を実行し、全テストが成功しました。 
- `gofmt` を実行してコード整形を行いました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698177975a2c832d90b99f3b2793bda3)