### PR TITLE
update: static_db_pathを設定で指定可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
      "app_port": 3002,
      "log_level": "debug",
      "log_paths": { "app": "log", "echo": "log" },
+     "static_db_path": "./static.db",
      "shutdown_timeout_seconds": 20,
     "auth": {
       "jwt_expiration_hour": 24,
@@ -73,8 +74,7 @@
   }
   ```
 4. データベースを作成してマイグレーションする。
-   - `static.db` は実行バイナリと同じディレクトリに配置する運用です。
-     - `go run` の場合はカレントディレクトリが実行バイナリ相当になるため、`static.db` も同じ場所に作成してください。
+   - `static.db` の配置先は `.config/<環境>.settings.json` の `static_db_path` で指定します。
    ```bash
    mysql -u <DB_USER> -p -e "CREATE DATABASE IF NOT EXISTS <DB_NAME>;"
    ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
   }
   ```
 4. データベースを作成してマイグレーションする。
-   - `static.db` の配置先は `.config/<環境>.settings.json` の `static_db_path` で指定します。
+   - `static.db` の配置先は `.config/<環境>.settings.json` の `static_db_path` で指定します。マイグレーションを実行する際は、コマンド内のパスをこの設定値と一致させてください。
    ```bash
    mysql -u <DB_USER> -p -e "CREATE DATABASE IF NOT EXISTS <DB_NAME>;"
    ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@
 - `log_level`
 - `log_paths.app`
 - `log_paths.echo`
+- `static_db_path`
 - `shutdown_timeout_seconds` (1以上)
 - `auth.jwt_expiration_hour`
 - `auth.session_expiration_hour`

--- a/example.setting.json
+++ b/example.setting.json
@@ -1,0 +1,23 @@
+{
+  "app_port": 3002,
+  "log_level": "debug",
+  "log_paths": {
+    "app": "log",
+    "echo": "log"
+  },
+  "static_db_path": "./static.db",
+  "shutdown_timeout_seconds": 20,
+  "auth": {
+    "jwt_expiration_hour": 24,
+    "session_expiration_hour": 24,
+    "cookie_secure": false,
+    "cookie_same_site": "lax"
+  },
+  "cors": {
+    "allow_origins": [
+      "http://localhost:3000"
+    ],
+    "allow_credentials": true,
+    "max_age": 3600
+  }
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/Qman110101/chunisupport-api/internal/info"
 	"github.com/joho/godotenv"
@@ -34,6 +35,8 @@ type Config struct {
 	AppPort  int      `json:"app_port"`
 	LogLevel string   `json:"log_level"`
 	LogPaths LogPaths `json:"log_paths"`
+	// StaticDBPath は静的データ用SQLiteのファイルパスです
+	StaticDBPath string `json:"static_db_path"`
 	// ShutdownTimeoutSeconds はシャットダウンのタイムアウト秒数
 	ShutdownTimeoutSeconds int      `json:"shutdown_timeout_seconds"`
 	PwPepper               string   // 環境変数から読み込み
@@ -86,6 +89,10 @@ func LoadConfig() (Config, error) {
 
 	if config.ShutdownTimeoutSeconds <= 0 {
 		return config, fmt.Errorf("shutdown_timeout_seconds must be greater than 0")
+	}
+
+	if strings.TrimSpace(config.StaticDBPath) == "" {
+		return config, fmt.Errorf("static_db_path is required")
 	}
 
 	// 環境変数から秘密情報を取得

--- a/internal/infra/db/static_connection.go
+++ b/internal/infra/db/static_connection.go
@@ -5,24 +5,16 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Qman110101/chunisupport-api/internal/info"
 	"github.com/jmoiron/sqlx"
 	_ "modernc.org/sqlite"
 )
 
 // ConnectStatic は静的データ用SQLiteデータベースに接続します。
-func ConnectStatic() (*sqlx.DB, error) {
-	executablePath, err := os.Executable()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get executable path: %w", err)
-	}
-
-	dir := filepath.Dir(executablePath)
-	if err := os.MkdirAll(dir, 0750); err != nil {
+func ConnectStatic(dbPath string) (*sqlx.DB, error) {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0750); err != nil {
 		return nil, fmt.Errorf("failed to create static database directory: %w", err)
 	}
 
-	dbPath := filepath.Join(dir, info.StaticDBFilename)
 	dsn := fmt.Sprintf("file:%s?_foreign_keys=on&_busy_timeout=5000", dbPath)
 	db, err := sqlx.Open("sqlite", dsn)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	slog.Info("Connected to the database")
 
-	staticDatabase, err := db.ConnectStatic()
+	staticDatabase, err := db.ConnectStatic(cfg.StaticDBPath)
 	if err != nil {
 		slog.Error("Failed to connect to static database", "error", err)
 		return


### PR DESCRIPTION
### Motivation

- _report/stat_remain.md にある `static.db` の配置に関する指摘に対応するため、静的DBの配置先をコードで固定せず設定で指定できるようにします。

### Description

- 設定構造体に `static_db_path`（`Config.StaticDBPath`）を追加し、設定ファイルでパスを指定するようにしました (`internal/config/config.go`)。 
- `static_db_path` が空の場合は起動時にエラーとして起動を停止する必須チェックを追加しました (`LoadConfig` 内)。
- 静的DB接続関数のシグネチャを変更し、外部から渡されたパスを使って接続するようにしました (`internal/infra/db/static_connection.go` の `ConnectStatic(dbPath string)` )。 
- 起動処理で設定から渡された `cfg.StaticDBPath` を使うように変更しました (`main.go`)。 
- ドキュメントを更新し `static_db_path` を必須項目に追記しました (`docs/configuration.md` / `README.md`) と、サンプルの `example.setting.json` を追加しました。

### Testing

- 自動テストを実行して `go test ./...` が成功することを確認しました（全パッケージのテストが正常終了しました）。
- 変更箇所に対して `gofmt` を実行してフォーマット整形を行いました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69830eeaec60832db20a848f8a706c2b)