### PR TITLE
docs: READMEのGoバージョンを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## 技術スタック
 
-- **言語**: [Go](https://golang.org/) (1.25.5)
+- **言語**: [Go](https://golang.org/) (1.25.7)
 - **Webフレームワーク**: [Echo](https://echo.labstack.com/)
 - **データベース**: [MySQL](https://www.mysql.com/)
 - **O/Rマッパー**: [sqlx](https://github.com/jmoiron/sqlx)


### PR DESCRIPTION
### Motivation
- `go.mod` に合わせてドキュメントのGoバージョン表記を最新に揃えるため、READMEのGoバージョン表記を更新しました。

### Description
- `README.md` の技術スタック項目にある `Go` のバージョン表記を `1.25.5` から `1.25.7` に変更しました。

### Testing
- `gofmt -w $(rg --files -g '*.go')` を実行してコード整形を行い成功しました。
- `go test ./...` を実行し、全パッケージのテストが成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69890f8732f8832dab1ee30b1f31c860)