### PR TITLE
docs: 未プレイ補完計画の曖昧点を解消

### DIFF
--- a/_report/noplay_supl.md
+++ b/_report/noplay_supl.md
@@ -101,9 +101,11 @@ API互換性は不要とし、`is_played` 追加や一部フィールドの `nul
   - 既存プレイヤーレコード集合
   - 補完対象マスタ集合（通常譜面 / WORLD'S END）
 - 出力:
-  - 補完済み通常譜面DTO列
-  - 補完済みWORLD'S ENDDTO列
+  - 補完済み通常譜面エンティティ列（`[]*entity.PlayerRecord`）
+  - 補完済みWORLD'S ENDエンティティ列（`[]*entity.PlayerWorldsendRecord`）
 - キー判定・補完値設定・ソートをサービス内部に集約。
+
+※ DTO への変換は Usecase 層で実施し、ドメインサービスは DTO に依存しない。
 
 ### 4. Usecase からの呼び出し
 1. 既存 `player_records` / `player_worldsend_records` を取得。

--- a/_report/noplay_supl.md
+++ b/_report/noplay_supl.md
@@ -1,0 +1,122 @@
+# 未プレイ補完機能 実装計画書（確定版）
+
+## 目的
+`GET /internal/users/:username` で `include_noplay=true` を指定した際に、通常譜面 (`records.all`) と WORLD'S END (`records.worldsend`) の両方で未プレイ譜面を補完して返却する。
+
+API互換性は不要とし、`is_played` 追加や一部フィールドの `null` 許容を含めて仕様変更する。
+
+---
+
+## 仕様確定事項（合意済み）
+1. `view=rating` と `include_noplay=true` 併用時は **include_noplay を無視**する（エラーにはしない）。
+2. `records.updated_at` は **従来どおり**（レコード最大更新日時。レコードがない場合は `player.updated_at`）。
+3. 未プレイ補完データの `score` / `rating` / `overpower` は **固定値 0** を返す。
+4. 重複判定キーは以下で統一する。
+   - 通常譜面: `chart_id`
+   - WORLD'S END: `worldsend_chart_id`
+5. 並び順は以下で固定する。
+   - 通常譜面: `songs.id ASC, charts.difficulty_id ASC`
+   - WORLD'S END: `songs.id ASC, worldsend_charts.id ASC`
+6. `is_played` は `all` / `worldsend` だけでなく、同DTOを使う配列（best/new系）にも付与する。
+7. `clear_lamp` / `updated_at` は **未プレイ補完データのみ `null`**。DB 側の NOT NULL 制約は維持する。
+8. 補完対象から削除済み楽曲は除外する。
+9. レスポンスサイズ増加は現時点では許容する（gzip 圧縮前提）。
+
+---
+
+## 対象API
+- `GET /internal/users/:username`
+  - 追加クエリ: `include_noplay` (boolean, 任意)
+  - `include_noplay=true` のとき:
+    - `records.all` に通常譜面の未プレイ補完を含める
+    - `records.worldsend` に WORLD'S END の未プレイ補完を含める
+
+---
+
+## データ設計
+### DTO変更
+- `PlayerRecordDTO`
+  - 追加: `is_played: boolean`
+  - 変更: `clear_lamp: string | null`
+  - 変更: `updated_at: string | null`
+
+- `WorldsendRecordDTO`
+  - 追加: `is_played: boolean`
+  - 変更: `clear_lamp: string | null`
+  - 変更: `updated_at: string | null`
+
+### 未プレイ補完時のフィールド値
+- `is_played`: `false`
+- `score`: `0`
+- `rating`: `0`
+- `overpower`: `0`
+- `clear_lamp`: `null`
+- `updated_at`: `null`
+- `combo_lamp` / `full_chain` / `slot`: 既存ルールに従って `null`
+
+### 既存プレイデータ
+- `is_played`: `true`
+- `clear_lamp` / `updated_at`: 既存DB値を返却
+
+---
+
+## 実装ステップ
+### 1. Handler / Usecase のパラメータ伝播
+- `include_noplay` をハンドラで受け取り、Usecase に伝播する。
+- `view=rating` 時は `include_noplay` を無視する（レスポンスは既存rating表示仕様）。
+
+### 2. DTO型と変換関数の更新
+- `internal/dto/player_record_dto.go` を更新。
+- `internal/dto/worldsend_dto.go` を更新。
+- 既存レコード変換時は `is_played=true` を設定。
+
+### 3. 未プレイ補完ロジック（通常譜面）
+1. 既存 `player_records` を取得。
+2. 削除済み除外で通常譜面母集団（songs/charts）を一括取得。
+3. `chart_id` をキーに既存レコード存在判定。
+4. 欠損分を未プレイDTOとして生成。
+5. 既存 + 補完を `songs.id ASC, difficulty_id ASC` で返却。
+
+### 4. 未プレイ補完ロジック（WORLD'S END）
+1. 既存 `player_worldsend_records` を取得。
+2. 削除済み除外で WORLD'S END 母集団（songs/worldsend_charts）を一括取得。
+3. `worldsend_chart_id` をキーに既存レコード存在判定。
+4. 欠損分を未プレイDTOとして生成。
+5. 既存 + 補完を `songs.id ASC, worldsend_charts.id ASC` で返却。
+
+### 5. APIドキュメント更新（`docs/API.md`）
+- `include_noplay` クエリを追加。
+- `view=rating` 併用時は `include_noplay` 無視と明記。
+- `PlayerRecordDTO` / `WorldsendRecordDTO` に `is_played` を追記。
+- 未プレイ補完時に `clear_lamp` / `updated_at` が `null` となることを明記。
+
+---
+
+## テスト計画
+1. `include_noplay=false` で既存挙動が維持される。
+2. `include_noplay=true` で通常譜面の未プレイ補完が入る。
+3. `include_noplay=true` で WORLD'S END の未プレイ補完が入る。
+4. 既存レコード `is_played=true` / 補完レコード `is_played=false` を検証。
+5. 補完レコードで `clear_lamp=null` / `updated_at=null` を検証。
+6. `view=rating&include_noplay=true` で include_noplay が無視されることを検証。
+
+---
+
+## 影響範囲
+- Handler:
+  - `internal/app/handler/api_internal/user_handler.go`
+  - 必要に応じて `api_v1` / `compat` の呼び出し箇所
+- Usecase:
+  - `internal/usecase/user_usecase.go`
+  - `internal/usecase/user_usecase_impl.go`
+- DTO:
+  - `internal/dto/player_record_dto.go`
+  - `internal/dto/worldsend_dto.go`
+- Document:
+  - `docs/API.md`
+
+---
+
+## 実装上の注意
+- N+1を避けるため、母集団取得は必ず一括取得で行う。
+- 既存DBスキーマの NOT NULL は変更せず、未プレイ補完時のみアプリ側で `null` を組み立てる。

--- a/_report/noplay_supl.md
+++ b/_report/noplay_supl.md
@@ -24,6 +24,31 @@ API互換性は不要とし、`is_played` 追加や一部フィールドの `nul
 
 ---
 
+## 設計方針（レビュー反映）
+未プレイ補完ロジックは複数リポジトリを横断するため、`UserUsecase` に直接ロジックを寄せず、専用のドメインサービスへ責務を分離する。
+
+- 新設候補: `internal/domain/service/record_completion_service.go`
+- 役割:
+  - 通常譜面 / WORLD'S END の未プレイ補完判定
+  - 補完レコードの組み立て
+  - ソート済み結果の返却
+- `UserUsecase` は以下に専念:
+  - 認可/公開範囲チェック
+  - 必要データの取得と引数整形
+  - ドメインサービス呼び出し
+  - DTO組み立てのオーケストレーション
+
+### 依存関係の整理
+クリーンアーキテクチャの依存方向を守るため、ドメインサービス自体は具体リポジトリ実装に依存させない。
+
+- ドメインサービスは「入力として渡されたデータ集合」を処理する純粋ロジックにする。
+- I/O（DB取得）は Usecase で行う。
+- 必要なら `internal/domain/repository` に最小限の読み取りインターフェースを追加し、Usecase経由で注入する。
+
+> 注: ドメインサービスが `internal/infra` に直接依存する構造は採用しない。
+
+---
+
 ## 対象API
 - `GET /internal/users/:username`
   - 追加クエリ: `include_noplay` (boolean, 任意)
@@ -70,19 +95,21 @@ API互換性は不要とし、`is_played` 追加や一部フィールドの `nul
 - `internal/dto/worldsend_dto.go` を更新。
 - 既存レコード変換時は `is_played=true` を設定。
 
-### 3. 未プレイ補完ロジック（通常譜面）
-1. 既存 `player_records` を取得。
-2. 削除済み除外で通常譜面母集団（songs/charts）を一括取得。
-3. `chart_id` をキーに既存レコード存在判定。
-4. 欠損分を未プレイDTOとして生成。
-5. 既存 + 補完を `songs.id ASC, difficulty_id ASC` で返却。
+### 3. ドメインサービス導入
+- `RecordCompletionService`（仮）を新設。
+- 入力:
+  - 既存プレイヤーレコード集合
+  - 補完対象マスタ集合（通常譜面 / WORLD'S END）
+- 出力:
+  - 補完済み通常譜面DTO列
+  - 補完済みWORLD'S ENDDTO列
+- キー判定・補完値設定・ソートをサービス内部に集約。
 
-### 4. 未プレイ補完ロジック（WORLD'S END）
-1. 既存 `player_worldsend_records` を取得。
-2. 削除済み除外で WORLD'S END 母集団（songs/worldsend_charts）を一括取得。
-3. `worldsend_chart_id` をキーに既存レコード存在判定。
-4. 欠損分を未プレイDTOとして生成。
-5. 既存 + 補完を `songs.id ASC, worldsend_charts.id ASC` で返却。
+### 4. Usecase からの呼び出し
+1. 既存 `player_records` / `player_worldsend_records` を取得。
+2. 削除済み除外で通常譜面・WORLD'S END母集団を一括取得。
+3. `RecordCompletionService` を呼び出して補完済み配列を得る。
+4. `records.all` / `records.worldsend` に反映。
 
 ### 5. APIドキュメント更新（`docs/API.md`）
 - `include_noplay` クエリを追加。
@@ -99,6 +126,10 @@ API互換性は不要とし、`is_played` 追加や一部フィールドの `nul
 4. 既存レコード `is_played=true` / 補完レコード `is_played=false` を検証。
 5. 補完レコードで `clear_lamp=null` / `updated_at=null` を検証。
 6. `view=rating&include_noplay=true` で include_noplay が無視されることを検証。
+7. ドメインサービス単体テストで以下を検証:
+   - キー重複判定（`chart_id` / `worldsend_chart_id`）
+   - 補完件数
+   - ソート順
 
 ---
 
@@ -109,6 +140,8 @@ API互換性は不要とし、`is_played` 追加や一部フィールドの `nul
 - Usecase:
   - `internal/usecase/user_usecase.go`
   - `internal/usecase/user_usecase_impl.go`
+- Domain Service:
+  - `internal/domain/service/record_completion_service.go`（新規）
 - DTO:
   - `internal/dto/player_record_dto.go`
   - `internal/dto/worldsend_dto.go`
@@ -120,3 +153,4 @@ API互換性は不要とし、`is_played` 追加や一部フィールドの `nul
 ## 実装上の注意
 - N+1を避けるため、母集団取得は必ず一括取得で行う。
 - 既存DBスキーマの NOT NULL は変更せず、未プレイ補完時のみアプリ側で `null` を組み立てる。
+- 依存関係は「外側 → 内側」を維持し、Usecase から Infra 実装への直接依存を増やさない。

--- a/docs/API.md
+++ b/docs/API.md
@@ -713,6 +713,7 @@ curl -X POST \
 - **パスパラメータ**: `username` - 対象ユーザーのユーザー名
 - **クエリパラメータ**:
     - `view` (任意): `rating` を指定すると、`records` は `updated_at`/`best`/`best_candidate`/`new`/`new_candidate` のみを返します（`all`/`worldsend` は返しません）。
+    - `include_noplay` (任意): `true` を指定すると、`records.all` と `records.worldsend` に未プレイ譜面を補完して返します。未プレイ補完データは `is_played=false` となり、`updated_at` / `clear_lamp` は `null` になります。`view=rating` と併用した場合は `include_noplay` は無視されます。
 - **レスポンス**: ユーザープロファイルとプレイヤーレコードを一括で返します。非公開設定のユーザーは本人以外 404 を返します。
 
 #### レスポンス例
@@ -745,6 +746,7 @@ curl -X POST \
     "new_candidate": [...],
     "all": [
       {
+        "is_played": true,
         "updated_at": "2025-11-28T22:23:32+09:00",
         "difficulty": "MASTER",
         "id": "d3b6f3dd66b06bf4",
@@ -791,7 +793,8 @@ curl -X POST \
 
 | フィールド | 型 | 説明 |
 | ---------- | -- | ---- |
-| `updated_at` | string | 更新日時 (ISO8601) |
+| `is_played` | boolean | プレイ済みかどうか（未プレイ補完データは `false`） |
+| `updated_at` | string \\| null | 更新日時 (ISO8601)。未プレイ補完データは `null` |
 | `difficulty` | string | 難易度名称 |
 | `id` | string | 楽曲表示用ID |
 | `title` | string | 楽曲タイトル |
@@ -802,10 +805,28 @@ curl -X POST \
 | `rating` | number | 単曲レーティング（譜面定数とスコアから計算） |
 | `overpower` | number | 単曲OVER POWER（譜面定数・スコア・コンボランプから計算） |
 | `img` | string | 楽曲画像ID |
-| `clear_lamp` | string | クリアランプ名称 |
+| `clear_lamp` | string \\| null | クリアランプ名称。未プレイ補完データは `null` |
 | `combo_lamp` | string \| null | コンボランプ名称（マスタ値が「NONE」の場合は `null`） |
 | `full_chain` | string \| null | フルチェイン名称（マスタ値が「NONE」の場合は `null`） |
 | `slot` | string \| null | スロット名称（マスタ値が「none」の場合は `null`） |
+
+#### WorldsendRecordDTO スキーマ
+
+| フィールド | 型 | 説明 |
+| ---------- | -- | ---- |
+| `is_played` | boolean | プレイ済みかどうか（未プレイ補完データは `false`） |
+| `updated_at` | string \| null | 更新日時 (ISO8601)。未プレイ補完データは `null` |
+| `id` | string | 楽曲表示用ID |
+| `title` | string | 楽曲タイトル |
+| `artist` | string | アーティスト名 |
+| `we_star` | number \| null | WORLD'S END 星の数 |
+| `we_kanji` | string \| null | WORLD'S END カテゴリ漢字 |
+| `notes` | number \| null | ノーツ数 |
+| `score` | number | スコア |
+| `img` | string | 楽曲画像ID |
+| `clear_lamp` | string \| null | クリアランプ名称。未プレイ補完データは `null` |
+| `combo_lamp` | string \| null | コンボランプ名称（マスタ値が「NONE」の場合は `null`） |
+| `full_chain` | string \| null | フルチェイン名称（マスタ値が「NONE」の場合は `null`） |
 
 - **主なエラー**:
   - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
@@ -1792,7 +1813,8 @@ interface HonorDTO {
 
 // レコード関連
 interface PlayerRecordDTO {
-  updated_at: string;
+  is_played: boolean;
+  updated_at: string | null;
   difficulty: string;
   id: string;
   title: string;
@@ -1803,7 +1825,7 @@ interface PlayerRecordDTO {
   rating: number;
   overpower: number;
   img: string;
-  clear_lamp: string;
+  clear_lamp: string | null;
   combo_lamp: string | null;  // マスタ値が「NONE」の場合はnull
   full_chain: string | null;  // マスタ値が「NONE」の場合はnull
   slot: string | null;        // マスタ値が「none」の場合はnull
@@ -1821,7 +1843,8 @@ interface UserRecordResponseDTO {
 
 // WORLD'S END レコード（スロット分類なし、レーティング計算なし）
 interface WorldsendRecordDTO {
-  updated_at: string;
+  is_played: boolean;
+  updated_at: string | null;
   id: string;
   title: string;
   artist: string;
@@ -1830,7 +1853,7 @@ interface WorldsendRecordDTO {
   notes: number | null;
   score: number;
   img: string;
-  clear_lamp: string;
+  clear_lamp: string | null;
   combo_lamp: string | null;      // マスタ値が「NONE」の場合はnull
   full_chain: string | null;      // マスタ値が「NONE」の場合はnull
 }


### PR DESCRIPTION
### Motivation
- `GET /internal/users/:username` の `include_noplay` 機能実装に際して、未プレイ補完の振る舞い（`is_played` の扱い、固定値、ソート、キー、`null` 方針、削除済み除外など）が曖昧だったため仕様を確定する必要がありました。 
- 既存クライアントや実装者が迷わないように DTO 変更や `view=rating` 併用時の挙動を明文化しました。 

### Description
- `_report/noplay_supl.md` を確定版として全面更新し、未プレイ補完の仕様確定事項を明記しました。 
- DTO 変更方針を明確化し、`PlayerRecordDTO` / `WorldsendRecordDTO` に `is_played` を追加し、未プレイ補完時は `score/rating/overpower=0`、`clear_lamp/updated_at=null` とすることを定義しました。 
- `view=rating` と `include_noplay=true` の併用時は `include_noplay` を無視する点、重複判定キー（`chart_id` / `worldsend_chart_id`）、ソート順、削除済み楽曲の除外などの振る舞いを明記しました。 
- 実装ステップ、影響範囲（ハンドラ・ユースケース・DTO・ドキュメント）およびテスト計画を追加しました。 

### Testing
- コード整形として `gofmt -w $(rg --files -g '*.go')` を実行しました。 
- 自動テストは `go test ./...` を実行し、テストは全パッケージで実行されて成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a70238224832d8b719e9606f3b0ba)