### PR TITLE
docs: 未プレイ補完設計書を改訂して実装計画を具体化

### DIFF
--- a/_report/unplayed_completion_design.md
+++ b/_report/unplayed_completion_design.md
@@ -50,7 +50,7 @@
 - `clear_lamp`: `null`
 - `updated_at`: `null`
 - `combo_lamp` / `full_chain` / `slot`: 既存ルールどおり `null`
-- `const` / `is_const_unknown` / `title` / `artist` / `difficulty` / `img`: マスタ値を採用
+- `id` / `const` / `is_const_unknown` / `title` / `artist` / `difficulty` / `img`: マスタ値を採用
 
 #### 既存プレイレコード
 - `is_played`: `true`

--- a/_report/unplayed_completion_design.md
+++ b/_report/unplayed_completion_design.md
@@ -1,149 +1,153 @@
-# 未プレイ補完 機能設計書
+# 未プレイ補完 機能設計書（改訂版）
 
 ## 1. 背景と目的
 
 現行のユーザーレコード取得API（`GET /internal/users/:username` / `GET /v1/users/:username`）は、プレイ済み譜面のみを返却します。
-一方でフロントエンドでは、一覧表示・フィルタ・ソート・集計のために「未プレイ譜面を含む全譜面集合」を必要とするケースがあり、クライアント側でマスタデータとの突合実装が必要になっています。
+フロントエンド側では、一覧表示・フィルタ・ソート・集計のために「未プレイ譜面を含む全譜面集合」が必要になるため、APIで未プレイ補完を実施してクライアント実装コストを下げます。
 
-本設計書では、APIが未プレイ譜面を補完して返却する仕様を、後方互換性を維持しながら導入する方針を定義します。
+本改訂版は、既存コード・スキーマ確認結果を反映し、実装時の曖昧性を排除した実装計画を定義します。
 
-## 2. 仕様確定事項
+## 2. 仕様（確定）
 
-API互換性は不要（一部仕様変更あり）とし、`is_played` 追加や一部フィールドの `null` 許容を含めて仕様変更する。
+### 2.1 互換性・対象範囲
+1. **破壊的変更は許容**する。ただし変更規模は最小化し、主変更は `is_played` 追加を中心にする。
+2. 対象APIは以下のみ:
+   - `GET /internal/users/:username`
+   - `GET /v1/users/:username`
+3. **互換エンドポイントは対象外**。
 
-### 2.1 基本ルール
-1. `view=rating` と `include_noplay=true` 併用時は **include_noplay を無視**する（エラーにはしない）。
-2. `records.updated_at` は **従来どおり**（レコード最大更新日時。レコードがない場合は `player.updated_at`）。
-3. 未プレイ補完データの `score` / `rating` / `overpower` は **固定値 0** を返す。
-4. 重複判定キーは以下で統一する。
-   - 通常譜面: `chart_id`
-   - WORLD'S END: `worldsend_chart_id`
-5. 並び順は以下で固定する。
-   - 通常譜面: `songs.id ASC, charts.difficulty_id ASC`
-   - WORLD'S END: `songs.id ASC, worldsend_charts.id ASC`
-6. `is_played` は `all` / `worldsend` だけでなく、同DTOを使う配列（best/new系）にも付与する。
-7. `clear_lamp` / `updated_at` は **未プレイ補完データのみ `null`**。DB 側の NOT NULL 制約は維持する。
-8. 補完対象から削除済み楽曲は除外する。
-9. レスポンスサイズ増加は現時点では許容する（gzip 圧縮前提）。
+### 2.2 クエリ仕様
+- 追加クエリ: `include_noplay` (boolean, optional)
+  - `true`: `records.all` と `records.worldsend` に未プレイ譜面を補完。
+  - `false`（デフォルト）: 従来どおりプレイ済みのみ。
+- `view=rating&include_noplay=true` の場合:
+  - `include_noplay` は**無視**する（エラー化しない）。
+  - API.mdには「無視する」旨を1行追記する。
 
-### 2.2 対象API
-- `GET /internal/users/:username`
-- `GET /v1/users/:username` (および互換エンドポイント)
+### 2.3 補完範囲と非補完範囲
+- 補完対象: `records.all`, `records.worldsend`
+- 非補完対象: `records.best`, `records.best_candidate`, `records.new`, `records.new_candidate`
+  - 上記は既存どおり実レコードのみ。
+  - ただしDTOに `is_played` が追加されるため、既存レコードには `is_played=true` を付与する。
 
-**追加クエリパラメータ**
-- `include_noplay` (boolean, optional)
-  - `true` の場合、通常譜面 (`records.all`) と WORLD'S END (`records.worldsend`) に未プレイ譜面を補完して返却する。
-  - デフォルトは `false` (未プレイを含めない)。
+### 2.4 DTO仕様
+#### `PlayerRecordDTO`
+- 追加: `is_played: boolean`
+- 変更: `clear_lamp: string | null`
+- 変更: `updated_at: string | null`
 
-### 2.3 データ設計
-#### DTO変更
-- `PlayerRecordDTO`
-  - 追加: `is_played: boolean`
-  - 変更: `clear_lamp: string | null`
-  - 変更: `updated_at: string | null`
+#### `WorldsendRecordDTO`
+- 追加: `is_played: boolean`
+- 変更: `clear_lamp: string | null`
+- 変更: `updated_at: string | null`
 
-- `WorldsendRecordDTO`
-  - 追加: `is_played: boolean`
-  - 変更: `clear_lamp: string | null`
-  - 変更: `updated_at: string | null`
-
-#### 未プレイ補完時のフィールド値
+### 2.5 値のルール
+#### 未プレイ補完レコード
 - `is_played`: `false`
 - `score`: `0`
 - `rating`: `0`
 - `overpower`: `0`
 - `clear_lamp`: `null`
 - `updated_at`: `null`
-- `combo_lamp` / `full_chain` / `slot`: 既存ルールに従って `null`
-- `is_const_unknown`: 譜面マスタ値を採用
-- `const` / `title` / `artist` / `difficulty` / `img`: 譜面・楽曲マスタ値を採用
+- `combo_lamp` / `full_chain` / `slot`: 既存ルールどおり `null`
+- `const` / `is_const_unknown` / `title` / `artist` / `difficulty` / `img`: マスタ値を採用
 
-#### 既存プレイデータ
+#### 既存プレイレコード
 - `is_played`: `true`
-- `clear_lamp` / `updated_at`: 既存DB値を返却
+- `clear_lamp` / `updated_at`: DB値
 
-## 3. アーキテクチャ・設計
+### 2.6 ソート・キー・除外ルール
+1. 重複判定キー:
+   - 通常譜面: `chart_id`
+   - WORLD'S END: `worldsend_chart_id`
+2. 並び順:
+   - 通常譜面: `songs.id ASC, charts.difficulty_id ASC`
+   - WORLD'S END: `songs.id ASC, worldsend_charts.id ASC`
+3. 補完対象から削除済み楽曲を除外する（曲の削除状態に依存）。
+4. 難易度文字列はAPI返却時に常に大文字で扱う。
 
-未プレイ補完ロジックは複数リポジトリを横断するため、`UserUsecase` に直接ロジックを寄せず、専用のドメインサービスへ責務を分離する。
+### 2.7 `records.updated_at`
+- 従来仕様を維持:
+  - 実レコード群の最大 `updated_at`
+  - 実レコードがない場合は `player.updated_at`
+- 未プレイ補完レコード（`updated_at=null`）は計算対象外。
 
-- **新設**: `internal/domain/service/record_completion_service.go`
-- **役割**:
-  - 通常譜面 / WORLD'S END の未プレイ補完判定
-  - 補完レコードの組み立て
-  - ソート済み結果の返却
-- **UserUsecase の役割**:
+### 2.8 パフォーマンス方針
+- レスポンスサイズ増加は現時点で許容（gzip前提）。
+- 本件で追加のページング導入は行わない。
+
+## 3. 設計方針（Clean Architecture / DDD準拠）
+
+### 3.1 責務分離
+未プレイ補完は複数データ集合を突合するため、ユースケース直書きではなくドメインサービスに分離する。
+
+- 新設: `internal/domain/service/record_completion_service.go`
+- ドメインサービス責務:
+  - 通常譜面 / WORLD'S END の補完判定
+  - 補完レコード生成
+  - ソート済み配列の返却
+- Usecase責務:
   - 認可/公開範囲チェック
-  - 必要データの取得と引数整形
+  - DB取得（I/O）
   - ドメインサービス呼び出し
-  - DTO組み立てのオーケストレーション
+  - DTO組み立て
 
-### 依存関係の整理
-クリーンアーキテクチャの依存方向を守るため、ドメインサービス自体は具体リポジトリ実装に依存させない。
+### 3.2 依存方向
+- ドメインサービスは純粋ロジックとして実装し、`internal/infra` に依存しない。
+- I/OはUsecase + Repositoryで処理。
+- 必要なら `internal/domain/repository` に最小限の読取IFを追加。
 
-- ドメインサービスは「入力として渡されたデータ集合」を処理する純粋ロジックにする。
-- I/O（DB取得）は Usecase で行う。
-- 必要なら `internal/domain/repository` に最小限の読み取りインターフェースを追加し、Usecase経由で注入する。
+## 4. 実装計画（TDD）
 
-> 注: ドメインサービスが `internal/infra` に直接依存する構造は採用しない。
-
-## 4. 実装計画
-
-### 4.1 実装ステップ
-1. **Handler / Usecase のパラメータ伝播**
-   - `include_noplay` をハンドラで受け取り、Usecase に伝播する。
-   - `view=rating` 時は `include_noplay` を無視する（レスポンスは既存rating表示仕様）。
-
-2. **DTO型と変換関数の更新**
-   - `internal/dto/player_record_dto.go` を更新。
-   - `internal/dto/worldsend_dto.go` を更新。
-   - 既存レコード変換時は `is_played=true` を設定。
-
-3. **ドメインサービス導入**
-   - `RecordCompletionService` を新設。
-   - 入力:
-     - 既存プレイヤーレコード集合
-     - 補完対象マスタ集合（通常譜面 / WORLD'S END）
-   - 出力:
-     - 補完済み通常譜面エンティティ列（`[]*entity.PlayerRecord`）
-     - 補完済みWORLD'S ENDエンティティ列（`[]*entity.PlayerWorldsendRecord`）
-   - キー判定・補完値設定・ソートをサービス内部に集約。
-
-4. **Usecase からの呼び出し**
-   - 既存 `player_records` / `player_worldsend_records` を取得。
-   - 削除済み除外で通常譜面・WORLD'S END母集団を一括取得。
-   - `RecordCompletionService` を呼び出して補完済み配列を得る。
-   - `records.all` / `records.worldsend` に反映。
-
-5. **APIドキュメント更新（`docs/API.md`）**
-   - `include_noplay` クエリを追加。
-   - `view=rating` 併用時は `include_noplay` 無視と明記。
-   - `PlayerRecordDTO` / `WorldsendRecordDTO` に `is_played` を追記。
-   - 未プレイ補完時に `clear_lamp` / `updated_at` が `null` となることを明記。
-
-### 4.2 テスト計画
-1. `include_noplay=false` で既存挙動が維持される。
-2. `include_noplay=true` で通常譜面の未プレイ補完が入る。
-3. `include_noplay=true` で WORLD'S END の未プレイ補完が入る。
-4. 既存レコード `is_played=true` / 補完レコード `is_played=false` を検証。
-5. 補完レコードで `clear_lamp=null` / `updated_at=null` を検証。
-6. `view=rating&include_noplay=true` で include_noplay が無視されることを検証。
-7. ドメインサービス単体テストで以下を検証:
-   - キー重複判定（`chart_id` / `worldsend_chart_id`）
+### 4.1 Red（先にテスト）
+1. Usecaseテスト追加
+   - `include_noplay=false` で既存挙動維持
+   - `include_noplay=true` で `records.all` 補完
+   - `include_noplay=true` で `records.worldsend` 補完
+   - `is_played` の真偽
+   - 補完レコードの `clear_lamp=null` / `updated_at=null`
+   - `view=rating&include_noplay=true` で無視される
+   - `difficulty` が大文字で返る
+2. Domain Service単体テスト追加
+   - 重複判定キー（`chart_id` / `worldsend_chart_id`）
    - 補完件数
    - ソート順
+   - 削除済み楽曲除外
 
-### 4.3 影響範囲
-- Handler: `internal/app/handler/api_internal/user_handler.go` 等
-- Usecase: `internal/usecase/user_usecase.go`
+### 4.2 Green（最小実装）
+1. Handlerで `include_noplay` を受け取りUsecaseへ伝播
+2. DTO更新（`is_played` 追加、`clear_lamp`/`updated_at` nullable化）
+3. `RecordCompletionService` 実装
+4. Usecaseで補完呼び出しを追加
+5. `view=rating` 経路は `include_noplay` を無視して現行仕様維持
+
+### 4.3 Refactor
+- 補完ロジック重複を解消
+- 変換責務（Entity→DTO）と補完責務（補完判定）を明確化
+- テストデータの重複を抑制
+
+## 5. 影響範囲
+- Handler: `internal/app/handler/api_internal/user_handler.go` ほかv1系ハンドラ
+- Usecase: `internal/usecase/user_usecase.go`, `internal/usecase/user_usecase_impl.go`
 - Domain Service: `internal/domain/service/record_completion_service.go`（新規）
 - DTO: `internal/dto/player_record_dto.go`, `internal/dto/worldsend_dto.go`
-- Document: `docs/API.md`
+- Docs: `docs/API.md`
 
-## 5. 意思決定メモ
+## 6. 実装チェックリスト
+- [ ] `include_noplay` が `records.all/worldsend` のみに効いている
+- [ ] `view=rating` で `include_noplay` が無視される
+- [ ] `is_played` が全対象DTOで設定される
+- [ ] 補完レコードの `clear_lamp` / `updated_at` が `null`
+- [ ] `difficulty` が大文字で返る
+- [ ] 削除済み楽曲は補完対象外
+- [ ] API.md 更新済み
+- [ ] `go test` 成功
+- [ ] `gofmt` 実行済み
 
-- **採用**: `include_noplay` の opt-in 方式
-- **補完範囲**: `records.all` と `records.worldsend`
-- **判別子**: `is_played` を追加
-- **`view=rating` との併用**: `include_noplay` 無視
+## 7. 意思決定メモ
+- 採用: `include_noplay` opt-in
+- 補完範囲: `records.all`, `records.worldsend`
+- 判別子: `is_played`
+- `view=rating` 併用時: 無視
+- 互換エンドポイント: 今回対象外
 
-上記により、既存互換性を維持しつつ、フロントエンド実装コストを削減できます。


### PR DESCRIPTION
### Motivation
- 既存のユーザーレコード取得APIでフロント側が必要とする「未プレイ譜面を含む全譜面集合」の要件を満たすために、実装時の曖昧性を排除した具体的な設計方針を提供するためです。 
- マスタ・スキーマ確認結果を反映して `include_noplay` の動作や `view=rating` 併用時の扱いなど互換性判断を明確化するためです。

### Description
- `_report/unplayed_completion_design.md` を改訂して、対象API、`include_noplay` クエリ仕様、補完対象（`records.all`/`records.worldsend`）と非補完対象（`records.best` 等）を明確化しました。 
- DTO仕様に `is_played` の追加と `clear_lamp` / `updated_at` の nullable 化を定義し、未プレイ補完レコードの値ルール（`score=0` 等）とソート／重複判定ルール（`chart_id` / `worldsend_chart_id`）を整理しました。 
- 実装方針として Clean Architecture / DDD に従い、補完ロジックを新規のドメインサービス `internal/domain/service/record_completion_service.go` に分離し、Usecase が I/O とオーケストレーションを担う設計を示しました。 
- TDD に基づく実装ステップ（Red/Green/Refactor）、テスト項目、API ドキュメント更新（`docs/API.md` への追記）と実装チェックリストを追加しました。 

### Testing
- `go test ./...` を複数回実行して全パッケージのテストが成功したことを確認しました（成功）。 
- `gofmt -w $(git ls-files '*.go')` を実行して Go ソースのフォーマットを適用しました（実行済み）。 
- 既存テストは破壊せずキャッシュ含めて全て成功していることを検証しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993dcfbae34832d83f747608a7eb720)