### PR TITLE
update: 未プレイ譜面の補完をユーザー取得APIに実装

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1582,6 +1582,9 @@ curl -X POST \
 | ---------- | -- | ---- |
 | `username` | string | ユーザー名 |
 
+- **クエリパラメータ**:
+    - `include_noplay` (任意): `true` を指定すると、`records.all` と `records.worldsend` に未プレイ譜面を補完して返します。未プレイ補完データは `is_played=false` となり、`updated_at` / `clear_lamp` は `null` になります。
+
 - **レスポンス**: 200 OK
 
 ```json

--- a/internal/app/handler/api_internal/user_handler.go
+++ b/internal/app/handler/api_internal/user_handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -38,7 +39,9 @@ func (h *UserHandler) GetUserProfileWithRecords(c echo.Context) error {
 		return c.JSON(http.StatusOK, result)
 	}
 
-	result, err := h.userUsecase.GetUserProfileWithRecords(c.Request().Context(), username, requester)
+	includeNoPlay, _ := strconv.ParseBool(c.QueryParam("include_noplay"))
+
+	result, err := h.userUsecase.GetUserProfileWithRecords(c.Request().Context(), username, requester, includeNoPlay)
 	if err != nil {
 		return h.handleUserProfileError(err, username, "user profile with records")
 	}

--- a/internal/app/handler/api_internal/user_handler_test.go
+++ b/internal/app/handler/api_internal/user_handler_test.go
@@ -23,8 +23,8 @@ type mockUserService struct {
 	mock.Mock
 }
 
-func (m *mockUserService) GetUserProfileWithRecords(ctx context.Context, username string, requester *entity.User) (*dto_internal.UserProfileWithRecordsDTO, error) {
-	args := m.Called(ctx, username, requester)
+func (m *mockUserService) GetUserProfileWithRecords(ctx context.Context, username string, requester *entity.User, includeNoPlay bool) (*dto_internal.UserProfileWithRecordsDTO, error) {
+	args := m.Called(ctx, username, requester, includeNoPlay)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -99,7 +99,7 @@ func TestUserHandler_GetUserProfileWithRecords(t *testing.T) {
 	}
 
 	t.Run("viewなしは全レコードを返す", func(t *testing.T) {
-		mockService.On("GetUserProfileWithRecords", mock.Anything, "testuser", (*entity.User)(nil)).Return(result, nil).Once()
+		mockService.On("GetUserProfileWithRecords", mock.Anything, "testuser", (*entity.User)(nil), false).Return(result, nil).Once()
 
 		req := httptest.NewRequest(http.MethodGet, "/users/testuser", nil)
 		rec := httptest.NewRecorder()

--- a/internal/app/handler/api_v1/user_handler.go
+++ b/internal/app/handler/api_v1/user_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -29,7 +30,8 @@ func (h *V1UserHandler) GetUser(c echo.Context) error {
 	if userEntity, ok := c.Get("userEntity").(*entity.User); ok {
 		requester = userEntity
 	}
-	result, err := h.userUsecase.GetUserProfileWithRecords(c.Request().Context(), username, requester)
+	includeNoPlay, _ := strconv.ParseBool(c.QueryParam("include_noplay"))
+	result, err := h.userUsecase.GetUserProfileWithRecords(c.Request().Context(), username, requester, includeNoPlay)
 	if err != nil {
 		switch {
 		case errors.Is(err, usecase.ErrUserNotFound):

--- a/internal/app/handler/compat/chunirec/chunirec_handler.go
+++ b/internal/app/handler/compat/chunirec/chunirec_handler.go
@@ -107,7 +107,7 @@ func (h *ChunirecHandler) GetUserShow(c echo.Context) error {
 	}
 
 	// ユーザープロファイルとレコードを取得
-	result, err := h.userUsecase.GetUserProfileWithRecords(ctx, username, requester)
+	result, err := h.userUsecase.GetUserProfileWithRecords(ctx, username, requester, false)
 	if err != nil {
 		switch {
 		case errors.Is(err, usecase.ErrUserNotFound):

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -126,7 +126,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	authUsecase := usecase.NewAuthService(db, tm, userRepo, sessionRepo, recoveryCodeRepo, playerRecordRepo, cfg.JWTSecret, cfg.Auth.JWTExpirationHour, cfg.Auth.SessionExpirationHour, cfg.PwPepper, masterCache)
 	apiTokenUsecase := usecase.NewAPITokenService(db, apiTokenRepo, userRepo)
 	playerUsecase := usecase.NewPlayerService(db, playerRepo)
-	userUsecase := usecase.NewUserService(db, userRepo, playerRecordRepo, playerUsecase, songRepo, worldsendChartRepo)
+	userUsecase := usecase.NewUserService(db, userRepo, playerRecordRepo, playerUsecase, songRepo, worldsendChartRepo, masterCache)
 	// userUsecase に worldsendRecordRepo を設定（通常レコードとの依存関係を避けるため後から設定）
 	if uu, ok := userUsecase.(interface {
 		SetWorldsendRecordRepository(repository.WorldsendRecordRepository)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -126,7 +126,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	authUsecase := usecase.NewAuthService(db, tm, userRepo, sessionRepo, recoveryCodeRepo, playerRecordRepo, cfg.JWTSecret, cfg.Auth.JWTExpirationHour, cfg.Auth.SessionExpirationHour, cfg.PwPepper, masterCache)
 	apiTokenUsecase := usecase.NewAPITokenService(db, apiTokenRepo, userRepo)
 	playerUsecase := usecase.NewPlayerService(db, playerRepo)
-	userUsecase := usecase.NewUserService(db, userRepo, playerRecordRepo, playerUsecase)
+	userUsecase := usecase.NewUserService(db, userRepo, playerRecordRepo, playerUsecase, songRepo, worldsendChartRepo)
 	// userUsecase に worldsendRecordRepo を設定（通常レコードとの依存関係を避けるため後から設定）
 	if uu, ok := userUsecase.(interface {
 		SetWorldsendRecordRepository(repository.WorldsendRecordRepository)

--- a/internal/domain/service/record_completion_service.go
+++ b/internal/domain/service/record_completion_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"math"
 	"sort"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -21,7 +22,7 @@ func NewRecordCompletionService() *RecordCompletionService {
 }
 
 // CompletePlayerRecords は通常譜面レコードを未プレイ補完し、ソート済み配列を返します。
-func (s *RecordCompletionService) CompletePlayerRecords(records []*entity.PlayerRecord, songs []*entity.Song) []*entity.PlayerRecord {
+func (s *RecordCompletionService) CompletePlayerRecords(records []*entity.PlayerRecord, songs []*entity.Song, difficultyNamesByID map[int]string) []*entity.PlayerRecord {
 	completed := make([]*entity.PlayerRecord, 0, len(records))
 	playedByChartID := make(map[int]struct{}, len(records))
 
@@ -50,7 +51,7 @@ func (s *RecordCompletionService) CompletePlayerRecords(records []*entity.Player
 				Song:    song,
 				ChartDifficulty: &entity.ChartDifficulty{
 					ID:   chart.DifficultyID,
-					Name: difficultyNameByID(chart.DifficultyID),
+					Name: difficultyNameByID(chart.DifficultyID, difficultyNamesByID),
 				},
 			})
 		}
@@ -107,47 +108,37 @@ func (s *RecordCompletionService) CompleteWorldsendRecords(records []*entity.Pla
 	return completed
 }
 
-func difficultyNameByID(difficultyID int) string {
-	switch difficultyID {
-	case 1:
-		return "BASIC"
-	case 2:
-		return "ADVANCED"
-	case 3:
-		return "EXPERT"
-	case 4:
-		return "MASTER"
-	case 5:
-		return "ULTIMA"
-	default:
+func difficultyNameByID(difficultyID int, difficultyNamesByID map[int]string) string {
+	if difficultyNamesByID == nil {
 		return ""
 	}
+	return difficultyNamesByID[difficultyID]
 }
 
 func playerRecordSongID(record *entity.PlayerRecord) int {
 	if record == nil || record.Song == nil {
-		return int(^uint(0) >> 1)
+		return math.MaxInt
 	}
 	return record.Song.ID
 }
 
 func playerRecordDifficultyID(record *entity.PlayerRecord) int {
 	if record == nil || record.Chart == nil {
-		return int(^uint(0) >> 1)
+		return math.MaxInt
 	}
 	return record.Chart.DifficultyID
 }
 
 func worldsendRecordSongID(record *entity.PlayerWorldsendRecord) int {
 	if record == nil || record.Song == nil {
-		return int(^uint(0) >> 1)
+		return math.MaxInt
 	}
 	return record.Song.ID
 }
 
 func worldsendRecordChartID(record *entity.PlayerWorldsendRecord) int {
 	if record == nil {
-		return int(^uint(0) >> 1)
+		return math.MaxInt
 	}
 	if record.WorldsendChart != nil {
 		return record.WorldsendChart.ID

--- a/internal/domain/service/record_completion_service.go
+++ b/internal/domain/service/record_completion_service.go
@@ -1,0 +1,156 @@
+package service
+
+import (
+	"sort"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+)
+
+// WorldsendSongChartPair は WORLD'S END 楽曲と譜面の組を表します。
+type WorldsendSongChartPair struct {
+	Song  *entity.Song
+	Chart *entity.WorldsendChart
+}
+
+// RecordCompletionService は未プレイレコード補完を行うドメインサービスです。
+type RecordCompletionService struct{}
+
+// NewRecordCompletionService は RecordCompletionService を生成します。
+func NewRecordCompletionService() *RecordCompletionService {
+	return &RecordCompletionService{}
+}
+
+// CompletePlayerRecords は通常譜面レコードを未プレイ補完し、ソート済み配列を返します。
+func (s *RecordCompletionService) CompletePlayerRecords(records []*entity.PlayerRecord, songs []*entity.Song) []*entity.PlayerRecord {
+	completed := make([]*entity.PlayerRecord, 0, len(records))
+	playedByChartID := make(map[int]struct{}, len(records))
+
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		playedByChartID[record.ChartID] = struct{}{}
+		completed = append(completed, record)
+	}
+
+	for _, song := range songs {
+		if song == nil || song.IsDeleted {
+			continue
+		}
+		for _, chart := range song.Charts {
+			if chart == nil {
+				continue
+			}
+			if _, ok := playedByChartID[chart.ID]; ok {
+				continue
+			}
+			completed = append(completed, &entity.PlayerRecord{
+				ChartID: chart.ID,
+				Chart:   chart,
+				Song:    song,
+				ChartDifficulty: &entity.ChartDifficulty{
+					ID:   chart.DifficultyID,
+					Name: difficultyNameByID(chart.DifficultyID),
+				},
+			})
+		}
+	}
+
+	sort.Slice(completed, func(i, j int) bool {
+		leftSongID := playerRecordSongID(completed[i])
+		rightSongID := playerRecordSongID(completed[j])
+		if leftSongID != rightSongID {
+			return leftSongID < rightSongID
+		}
+		return playerRecordDifficultyID(completed[i]) < playerRecordDifficultyID(completed[j])
+	})
+
+	return completed
+}
+
+// CompleteWorldsendRecords は WORLD'S END レコードを未プレイ補完し、ソート済み配列を返します。
+func (s *RecordCompletionService) CompleteWorldsendRecords(records []*entity.PlayerWorldsendRecord, songCharts []*WorldsendSongChartPair) []*entity.PlayerWorldsendRecord {
+	completed := make([]*entity.PlayerWorldsendRecord, 0, len(records))
+	playedByChartID := make(map[int]struct{}, len(records))
+
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		playedByChartID[record.WorldsendChartID] = struct{}{}
+		completed = append(completed, record)
+	}
+
+	for _, songChart := range songCharts {
+		if songChart == nil || songChart.Song == nil || songChart.Chart == nil || songChart.Song.IsDeleted {
+			continue
+		}
+		if _, ok := playedByChartID[songChart.Chart.ID]; ok {
+			continue
+		}
+		completed = append(completed, &entity.PlayerWorldsendRecord{
+			WorldsendChartID: songChart.Chart.ID,
+			Song:             songChart.Song,
+			WorldsendChart:   songChart.Chart,
+		})
+	}
+
+	sort.Slice(completed, func(i, j int) bool {
+		leftSongID := worldsendRecordSongID(completed[i])
+		rightSongID := worldsendRecordSongID(completed[j])
+		if leftSongID != rightSongID {
+			return leftSongID < rightSongID
+		}
+		return worldsendRecordChartID(completed[i]) < worldsendRecordChartID(completed[j])
+	})
+
+	return completed
+}
+
+func difficultyNameByID(difficultyID int) string {
+	switch difficultyID {
+	case 1:
+		return "BASIC"
+	case 2:
+		return "ADVANCED"
+	case 3:
+		return "EXPERT"
+	case 4:
+		return "MASTER"
+	case 5:
+		return "ULTIMA"
+	default:
+		return ""
+	}
+}
+
+func playerRecordSongID(record *entity.PlayerRecord) int {
+	if record == nil || record.Song == nil {
+		return int(^uint(0) >> 1)
+	}
+	return record.Song.ID
+}
+
+func playerRecordDifficultyID(record *entity.PlayerRecord) int {
+	if record == nil || record.Chart == nil {
+		return int(^uint(0) >> 1)
+	}
+	return record.Chart.DifficultyID
+}
+
+func worldsendRecordSongID(record *entity.PlayerWorldsendRecord) int {
+	if record == nil || record.Song == nil {
+		return int(^uint(0) >> 1)
+	}
+	return record.Song.ID
+}
+
+func worldsendRecordChartID(record *entity.PlayerWorldsendRecord) int {
+	if record == nil {
+		return int(^uint(0) >> 1)
+	}
+	if record.WorldsendChart != nil {
+		return record.WorldsendChart.ID
+	}
+	return record.WorldsendChartID
+}

--- a/internal/domain/service/record_completion_service_test.go
+++ b/internal/domain/service/record_completion_service_test.go
@@ -44,7 +44,7 @@ func TestRecordCompletionService_CompletePlayerRecords(t *testing.T) {
 		},
 	}
 
-	completed := svc.CompletePlayerRecords(records, songs)
+	completed := svc.CompletePlayerRecords(records, songs, map[int]string{2: "ADVANCED", 4: "MASTER"})
 
 	if len(completed) != 3 {
 		t.Fatalf("expected 3 records, got %d", len(completed))

--- a/internal/domain/service/record_completion_service_test.go
+++ b/internal/domain/service/record_completion_service_test.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+)
+
+func TestRecordCompletionService_CompletePlayerRecords(t *testing.T) {
+	svc := NewRecordCompletionService()
+
+	songs := []*entity.Song{
+		{
+			ID: 1,
+			Charts: []*entity.Chart{
+				{ID: 11, SongID: 1, DifficultyID: 3},
+				{ID: 12, SongID: 1, DifficultyID: 4},
+			},
+		},
+		{
+			ID: 2,
+			Charts: []*entity.Chart{
+				{ID: 21, SongID: 2, DifficultyID: 2},
+			},
+		},
+		{
+			ID:        3,
+			IsDeleted: true,
+			Charts: []*entity.Chart{
+				{ID: 31, SongID: 3, DifficultyID: 4},
+			},
+		},
+	}
+
+	records := []*entity.PlayerRecord{
+		{
+			ChartID: 11,
+			Song:    songs[0],
+			Chart:   songs[0].Charts[0],
+			ChartDifficulty: &entity.ChartDifficulty{
+				ID:   3,
+				Name: "expert",
+			},
+		},
+	}
+
+	completed := svc.CompletePlayerRecords(records, songs)
+
+	if len(completed) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(completed))
+	}
+	if completed[0].ChartID != 11 || completed[1].ChartID != 12 || completed[2].ChartID != 21 {
+		t.Fatalf("unexpected sorted chart ids: %d, %d, %d", completed[0].ChartID, completed[1].ChartID, completed[2].ChartID)
+	}
+	if completed[1].ChartDifficulty == nil || completed[1].ChartDifficulty.Name != "MASTER" {
+		t.Fatalf("expected completed difficulty MASTER, got %+v", completed[1].ChartDifficulty)
+	}
+	if completed[2].ChartDifficulty == nil || completed[2].ChartDifficulty.Name != "ADVANCED" {
+		t.Fatalf("expected completed difficulty ADVANCED, got %+v", completed[2].ChartDifficulty)
+	}
+}
+
+func TestRecordCompletionService_CompleteWorldsendRecords(t *testing.T) {
+	svc := NewRecordCompletionService()
+
+	song1 := &entity.Song{ID: 1}
+	song2 := &entity.Song{ID: 2}
+	song3 := &entity.Song{ID: 3, IsDeleted: true}
+	chart1 := &entity.WorldsendChart{ID: 101, SongID: 1}
+	chart2 := &entity.WorldsendChart{ID: 102, SongID: 2}
+	chart3 := &entity.WorldsendChart{ID: 103, SongID: 3}
+
+	records := []*entity.PlayerWorldsendRecord{
+		{WorldsendChartID: 101, Song: song1, WorldsendChart: chart1},
+	}
+	songCharts := []*WorldsendSongChartPair{
+		{Song: song1, Chart: chart1},
+		{Song: song2, Chart: chart2},
+		{Song: song3, Chart: chart3},
+	}
+
+	completed := svc.CompleteWorldsendRecords(records, songCharts)
+
+	if len(completed) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(completed))
+	}
+	if completed[0].WorldsendChartID != 101 || completed[1].WorldsendChartID != 102 {
+		t.Fatalf("unexpected sorted worldsend chart ids: %d, %d", completed[0].WorldsendChartID, completed[1].WorldsendChartID)
+	}
+}

--- a/internal/dto/api_v1/user_dto.go
+++ b/internal/dto/api_v1/user_dto.go
@@ -34,7 +34,8 @@ type V1PlayerDTO struct {
 
 // V1PlayerRecordDTO は外部API v1 用のプレイヤーレコードDTOです。
 type V1PlayerRecordDTO struct {
-	UpdatedAt      time.Time                   `json:"updated_at"`
+	UpdatedAt      *time.Time                  `json:"updated_at"`
+	IsPlayed       bool                        `json:"is_played"`
 	Difficulty     string                      `json:"difficulty"`
 	ID             string                      `json:"id"`
 	Title          string                      `json:"title"`
@@ -45,7 +46,7 @@ type V1PlayerRecordDTO struct {
 	Rating         float64                     `json:"rating"`
 	Overpower      float64                     `json:"overpower"`
 	Img            string                      `json:"img"`
-	ClearLamp      string                      `json:"clear_lamp"`
+	ClearLamp      *string                     `json:"clear_lamp"`
 	ComboLamp      *string                     `json:"combo_lamp"`
 	FullChain      *string                     `json:"full_chain"`
 	Slot           *string                     `json:"slot"`
@@ -53,18 +54,19 @@ type V1PlayerRecordDTO struct {
 
 // V1WorldsendRecordDTO は外部API v1 用の WORLD'S END レコードDTOです。
 type V1WorldsendRecordDTO struct {
-	UpdatedAt time.Time `json:"updated_at"`
-	ID        string    `json:"id"`
-	Title     string    `json:"title"`
-	Artist    string    `json:"artist"`
-	WeStar    *int      `json:"we_star"`
-	WeKanji   *string   `json:"we_kanji"`
-	Notes     *int      `json:"notes"`
-	Score     uint32    `json:"score"`
-	Img       string    `json:"img"`
-	ClearLamp string    `json:"clear_lamp"`
-	ComboLamp *string   `json:"combo_lamp"`
-	FullChain *string   `json:"full_chain"`
+	UpdatedAt *time.Time `json:"updated_at"`
+	IsPlayed  bool       `json:"is_played"`
+	ID        string     `json:"id"`
+	Title     string     `json:"title"`
+	Artist    string     `json:"artist"`
+	WeStar    *int       `json:"we_star"`
+	WeKanji   *string    `json:"we_kanji"`
+	Notes     *int       `json:"notes"`
+	Score     uint32     `json:"score"`
+	Img       string     `json:"img"`
+	ClearLamp *string    `json:"clear_lamp"`
+	ComboLamp *string    `json:"combo_lamp"`
+	FullChain *string    `json:"full_chain"`
 }
 
 // V1UserRecordResponseDTO は外部API v1 用のユーザーレコードレスポンスDTOです。
@@ -128,6 +130,7 @@ func ToV1PlayerRecordDTO(record *dto.PlayerRecordDTO) *V1PlayerRecordDTO {
 	}
 	return &V1PlayerRecordDTO{
 		UpdatedAt:      record.UpdatedAt,
+		IsPlayed:       record.IsPlayed,
 		Difficulty:     record.Difficulty,
 		ID:             record.ID,
 		Title:          record.Title,
@@ -152,6 +155,7 @@ func ToV1WorldsendRecordDTO(record *dto.WorldsendRecordDTO) *V1WorldsendRecordDT
 	}
 	return &V1WorldsendRecordDTO{
 		UpdatedAt: record.UpdatedAt,
+		IsPlayed:  record.IsPlayed,
 		ID:        record.ID,
 		Title:     record.Title,
 		Artist:    record.Artist,

--- a/internal/dto/player_record_dto.go
+++ b/internal/dto/player_record_dto.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"strings"
 	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -10,7 +11,8 @@ import (
 
 // PlayerRecordDTO はプレイヤーレコードを外部へ公開するためのDTOです。
 type PlayerRecordDTO struct {
-	UpdatedAt      time.Time                   `json:"updated_at"`
+	UpdatedAt      *time.Time                  `json:"updated_at"`
+	IsPlayed       bool                        `json:"is_played"`
 	Difficulty     string                      `json:"difficulty"`
 	ID             string                      `json:"id"`
 	Title          string                      `json:"title"`
@@ -21,7 +23,7 @@ type PlayerRecordDTO struct {
 	Rating         float64                     `json:"rating"`
 	Overpower      float64                     `json:"overpower"`
 	Img            string                      `json:"img"`
-	ClearLamp      string                      `json:"clear_lamp"`
+	ClearLamp      *string                     `json:"clear_lamp"`
 	ComboLamp      *string                     `json:"combo_lamp"`
 	FullChain      *string                     `json:"full_chain"`
 	Slot           *string                     `json:"slot"`
@@ -43,20 +45,23 @@ func ToPlayerRecordDTO(record *entity.PlayerRecord) *PlayerRecordDTO {
 	}
 
 	dto := &PlayerRecordDTO{
-		UpdatedAt:      record.UpdatedAt,
 		Const:          chartConst,
 		IsConstUnknown: isConstUnknown,
 		Score:          score,
 		Rating:         service.CalcSingleRating(score, float64(chartConst)),
 		Overpower:      service.CalcSingleOverpower(score, float64(chartConst), record.ComboLampID),
-		ClearLamp:      toMasterName(record.ClearLamp),
+		ClearLamp:      toMasterNamePtr(record.ClearLamp),
 		ComboLamp:      toMasterNamePtr(record.ComboLamp),
 		FullChain:      toMasterNamePtr(record.FullChain),
 		Slot:           toMasterNamePtr(record.Slot),
 	}
+	if !record.UpdatedAt.IsZero() {
+		dto.UpdatedAt = &record.UpdatedAt
+		dto.IsPlayed = true
+	}
 
 	if record.ChartDifficulty != nil {
-		dto.Difficulty = record.ChartDifficulty.Name
+		dto.Difficulty = strings.ToUpper(record.ChartDifficulty.Name)
 	}
 
 	if record.Song != nil {

--- a/internal/dto/worldsend_dto.go
+++ b/internal/dto/worldsend_dto.go
@@ -10,18 +10,19 @@ import (
 // WorldsendRecordDTO は WORLD'S END レコードを外部へ公開するための DTO です。
 // WORLD'S END はレーティング計算の対象外であり、スロット（Best/New等）の概念を持ちません。
 type WorldsendRecordDTO struct {
-	UpdatedAt time.Time `json:"updated_at"`
-	ID        string    `json:"id"`         // 楽曲の DisplayID
-	Title     string    `json:"title"`      // 楽曲タイトル
-	Artist    string    `json:"artist"`     // アーティスト名
-	WeStar    *int      `json:"we_star"`    // WORLD'S END 星の数（1～5）
-	WeKanji   *string   `json:"we_kanji"`   // WORLD'S END カテゴリ漢字（光、蔵、改、狂、etc.）
-	Notes     *int      `json:"notes"`      // ノーツ数
-	Score     uint32    `json:"score"`      // スコア
-	Img       string    `json:"img"`        // ジャケット画像URL
-	ClearLamp string    `json:"clear_lamp"` // クリアランプ
-	ComboLamp *string   `json:"combo_lamp"` // コンボランプ（マスタ値が「NONE」の場合はnull）
-	FullChain *string   `json:"full_chain"` // フルチェイン（マスタ値が「NONE」の場合はnull）
+	UpdatedAt *time.Time `json:"updated_at"`
+	IsPlayed  bool       `json:"is_played"`
+	ID        string     `json:"id"`         // 楽曲の DisplayID
+	Title     string     `json:"title"`      // 楽曲タイトル
+	Artist    string     `json:"artist"`     // アーティスト名
+	WeStar    *int       `json:"we_star"`    // WORLD'S END 星の数（1～5）
+	WeKanji   *string    `json:"we_kanji"`   // WORLD'S END カテゴリ漢字（光、蔵、改、狂、etc.）
+	Notes     *int       `json:"notes"`      // ノーツ数
+	Score     uint32     `json:"score"`      // スコア
+	Img       string     `json:"img"`        // ジャケット画像URL
+	ClearLamp *string    `json:"clear_lamp"` // クリアランプ
+	ComboLamp *string    `json:"combo_lamp"` // コンボランプ（マスタ値が「NONE」の場合はnull）
+	FullChain *string    `json:"full_chain"` // フルチェイン（マスタ値が「NONE」の場合はnull）
 }
 
 // ToWorldsendRecordDTO は PlayerWorldsendRecord エンティティを DTO へ変換します。
@@ -37,11 +38,14 @@ func ToWorldsendRecordDTO(record *entity.PlayerWorldsendRecord) *WorldsendRecord
 	}
 
 	dto := &WorldsendRecordDTO{
-		UpdatedAt: record.UpdatedAt,
 		Score:     score,
-		ClearLamp: toMasterName(record.ClearLamp),
+		ClearLamp: toMasterNamePtr(record.ClearLamp),
 		ComboLamp: toMasterNamePtr(record.ComboLamp),
 		FullChain: toMasterNamePtr(record.FullChain),
+	}
+	if !record.UpdatedAt.IsZero() {
+		dto.UpdatedAt = &record.UpdatedAt
+		dto.IsPlayed = true
 	}
 
 	// WORLD'S END 譜面情報を設定

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -12,7 +12,7 @@ type UserUsecase interface {
 	// GetUserProfileWithRecords はユーザー名をキーにプロファイルとレコードを一括取得します。
 	// 対象ユーザーが非公開設定の場合は、本人以外は ErrUserPrivate を返します。
 	// プレイヤーが紐付いていない場合は ErrPlayerNotLinked を返します。
-	GetUserProfileWithRecords(ctx context.Context, username string, requester *entity.User) (*api_internal.UserProfileWithRecordsDTO, error)
+	GetUserProfileWithRecords(ctx context.Context, username string, requester *entity.User, includeNoPlay bool) (*api_internal.UserProfileWithRecordsDTO, error)
 
 	// GetUserProfileRatingView はユーザー名をキーにレーティング表示向けのプロファイルとレコードを取得します。
 	// 対象ユーザーが非公開設定の場合は、本人以外は ErrUserPrivate を返します。

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -24,11 +24,12 @@ type userUsecase struct {
 	songRepo            repository.SongRepository
 	worldsendChartRepo  repository.WorldsendChartRepository
 	recordCompletionSvc *service.RecordCompletionService
+	songMasterProvider  repository.SongMasterProvider
 	playerUsecase       PlayerUsecase
 }
 
 // NewUserService は UserUsecase の実装を生成します。
-func NewUserService(db repository.Executor, userRepo repository.UserRepository, playerRecordRepo repository.PlayerRecordRepository, playerUsecase PlayerUsecase, songRepo repository.SongRepository, worldsendChartRepo repository.WorldsendChartRepository) UserUsecase {
+func NewUserService(db repository.Executor, userRepo repository.UserRepository, playerRecordRepo repository.PlayerRecordRepository, playerUsecase PlayerUsecase, songRepo repository.SongRepository, worldsendChartRepo repository.WorldsendChartRepository, songMasterProvider repository.SongMasterProvider) UserUsecase {
 	return &userUsecase{
 		db:                  db,
 		userRepo:            userRepo,
@@ -36,6 +37,7 @@ func NewUserService(db repository.Executor, userRepo repository.UserRepository, 
 		songRepo:            songRepo,
 		worldsendChartRepo:  worldsendChartRepo,
 		recordCompletionSvc: service.NewRecordCompletionService(),
+		songMasterProvider:  songMasterProvider,
 		playerUsecase:       playerUsecase,
 	}
 }
@@ -78,7 +80,16 @@ func (s *userUsecase) GetUserProfileWithRecords(ctx context.Context, username st
 			slog.Error("failed to find songs for no-play completion", "player_id", *user.PlayerID, "error", err)
 			return nil, err
 		}
-		allRecords = s.recordCompletionSvc.CompletePlayerRecords(records, songs)
+
+		var difficultyNamesByID map[int]string
+		if s.songMasterProvider != nil {
+			masters := s.songMasterProvider.SongMasters()
+			if masters != nil {
+				difficultyNamesByID = masters.DifficultyNamesByID
+			}
+		}
+
+		allRecords = s.recordCompletionSvc.CompletePlayerRecords(records, songs, difficultyNamesByID)
 	}
 
 	// スロット別にグルーピング

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -69,21 +69,27 @@ func (s *userUsecase) GetUserProfileWithRecords(ctx context.Context, username st
 		return nil, err
 	}
 
+	slotSourceRecords := records
+	allRecords := records
+
 	if includeNoPlay && s.songRepo != nil {
 		songs, err := s.songRepo.FindAllExcludingWorldsend(ctx, s.db, false)
 		if err != nil {
 			slog.Error("failed to find songs for no-play completion", "player_id", *user.PlayerID, "error", err)
 			return nil, err
 		}
-		records = s.recordCompletionSvc.CompletePlayerRecords(records, songs)
+		allRecords = s.recordCompletionSvc.CompletePlayerRecords(records, songs)
 	}
 
 	// スロット別にグルーピング
 	slotMap := initializeSlotMap()
+	for _, record := range allRecords {
+		slotMap["all"] = append(slotMap["all"], dto.ToPlayerRecordDTO(record))
+	}
+
 	var latestRecordUpdatedAt time.Time
-	for _, record := range records {
+	for _, record := range slotSourceRecords {
 		dtoRecord := dto.ToPlayerRecordDTO(record)
-		slotMap["all"] = append(slotMap["all"], dtoRecord)
 
 		slotKey := record.SlotKey()
 		if slotKey != "" {

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/domain/service"
 	"github.com/chunisupport/chunisupport-api/internal/dto"
 	"github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
 	"github.com/chunisupport/chunisupport-api/internal/info"
@@ -20,16 +21,22 @@ type userUsecase struct {
 	userRepo            repository.UserRepository
 	playerRecordRepo    repository.PlayerRecordRepository
 	worldsendRecordRepo repository.WorldsendRecordRepository
+	songRepo            repository.SongRepository
+	worldsendChartRepo  repository.WorldsendChartRepository
+	recordCompletionSvc *service.RecordCompletionService
 	playerUsecase       PlayerUsecase
 }
 
 // NewUserService は UserUsecase の実装を生成します。
-func NewUserService(db repository.Executor, userRepo repository.UserRepository, playerRecordRepo repository.PlayerRecordRepository, playerUsecase PlayerUsecase) UserUsecase {
+func NewUserService(db repository.Executor, userRepo repository.UserRepository, playerRecordRepo repository.PlayerRecordRepository, playerUsecase PlayerUsecase, songRepo repository.SongRepository, worldsendChartRepo repository.WorldsendChartRepository) UserUsecase {
 	return &userUsecase{
-		db:               db,
-		userRepo:         userRepo,
-		playerRecordRepo: playerRecordRepo,
-		playerUsecase:    playerUsecase,
+		db:                  db,
+		userRepo:            userRepo,
+		playerRecordRepo:    playerRecordRepo,
+		songRepo:            songRepo,
+		worldsendChartRepo:  worldsendChartRepo,
+		recordCompletionSvc: service.NewRecordCompletionService(),
+		playerUsecase:       playerUsecase,
 	}
 }
 
@@ -45,7 +52,7 @@ func (s *userUsecase) SetWorldsendRecordRepository(repo repository.WorldsendReco
 //
 // TODO: 最適化の余地あり - 現在はユーザー→プレイヤー→称号→レコードで4回クエリを発行している。
 // PlayerRepository.FindByIDWithHonors() のようなJOINクエリを作成して3回に削減できる可能性がある。
-func (s *userUsecase) GetUserProfileWithRecords(ctx context.Context, username string, requester *entity.User) (*api_internal.UserProfileWithRecordsDTO, error) {
+func (s *userUsecase) GetUserProfileWithRecords(ctx context.Context, username string, requester *entity.User, includeNoPlay bool) (*api_internal.UserProfileWithRecordsDTO, error) {
 	user, player, err := s.getUserAndPlayer(ctx, username, requester)
 	if err != nil {
 		return nil, err
@@ -60,6 +67,15 @@ func (s *userUsecase) GetUserProfileWithRecords(ctx context.Context, username st
 			slog.Error("failed to find player records", "player_id", *user.PlayerID, "error", err)
 		}
 		return nil, err
+	}
+
+	if includeNoPlay && s.songRepo != nil {
+		songs, err := s.songRepo.FindAllExcludingWorldsend(ctx, s.db, false)
+		if err != nil {
+			slog.Error("failed to find songs for no-play completion", "player_id", *user.PlayerID, "error", err)
+			return nil, err
+		}
+		records = s.recordCompletionSvc.CompletePlayerRecords(records, songs)
 	}
 
 	// スロット別にグルーピング
@@ -91,6 +107,21 @@ func (s *userUsecase) GetUserProfileWithRecords(ctx context.Context, username st
 			// WORLD'S END レコードの取得失敗は致命的ではないため、空配列で続行
 			worldsendRecords = []*dto.WorldsendRecordDTO{}
 		} else {
+			if includeNoPlay && s.worldsendChartRepo != nil {
+				worldsendSongs, wsErr := s.worldsendChartRepo.FindAll(ctx, s.db, false)
+				if wsErr != nil {
+					slog.Error("failed to find worldsend songs for no-play completion", "player_id", *user.PlayerID, "error", wsErr)
+					return nil, wsErr
+				}
+				pairs := make([]*service.WorldsendSongChartPair, 0, len(worldsendSongs))
+				for _, ws := range worldsendSongs {
+					if ws == nil {
+						continue
+					}
+					pairs = append(pairs, &service.WorldsendSongChartPair{Song: ws.Song, Chart: ws.Chart})
+				}
+				weRecords = s.recordCompletionSvc.CompleteWorldsendRecords(weRecords, pairs)
+			}
 			worldsendRecords = make([]*dto.WorldsendRecordDTO, len(weRecords))
 			for i, r := range weRecords {
 				worldsendRecords[i] = dto.ToWorldsendRecordDTO(r)

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -383,6 +383,18 @@ func TestUserService_GetUserProfileWithRecords_IncludeNoPlay(t *testing.T) {
 	if result.Records.All[1].IsPlayed != false {
 		t.Fatal("expected second record is unplayed")
 	}
+	if len(result.Records.Best) != 0 {
+		t.Fatalf("expected 0 best records, got %d", len(result.Records.Best))
+	}
+	if len(result.Records.New) != 0 {
+		t.Fatalf("expected 0 new records, got %d", len(result.Records.New))
+	}
+	if len(result.Records.NewCandidate) != 0 {
+		t.Fatalf("expected 0 new_candidate records, got %d", len(result.Records.NewCandidate))
+	}
+	if len(result.Records.BestCandidate) != 0 {
+		t.Fatalf("expected 0 best_candidate records, got %d", len(result.Records.BestCandidate))
+	}
 	if result.Records.All[1].UpdatedAt != nil {
 		t.Fatal("expected unplayed updated_at nil")
 	}
@@ -397,6 +409,11 @@ func TestUserService_GetUserProfileWithRecords_IncludeNoPlay(t *testing.T) {
 	}
 	if result.Records.WorldsEnd[0].IsPlayed {
 		t.Fatal("expected worldsend completion record is unplayed")
+	}
+
+	// include_noplay=true でも slot ベースの並びは補完前レコードに依存する
+	if len(result.Records.All) > 0 && result.Records.All[0].Slot != nil {
+		t.Fatalf("expected all record slot nil, got %v", result.Records.All[0].Slot)
 	}
 }
 

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -94,6 +94,78 @@ type stubPlayerService struct {
 	err    error
 }
 
+type stubWorldsendRecordRepository struct {
+	records []*entity.PlayerWorldsendRecord
+	err     error
+}
+
+func (s *stubWorldsendRecordRepository) FindByPlayerID(ctx context.Context, exec repository.Executor, playerID int) ([]*entity.PlayerWorldsendRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.records, nil
+}
+
+type stubSongRepository struct {
+	songs []*entity.Song
+	err   error
+}
+
+func (s *stubSongRepository) FindAllExcludingWorldsend(ctx context.Context, exec repository.Executor, includeDeleted bool) ([]*entity.Song, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.songs, nil
+}
+
+func (s *stubSongRepository) FindByDisplayID(ctx context.Context, exec repository.Executor, displayID string) (*entity.Song, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubSongRepository) FindByDisplayIDs(ctx context.Context, exec repository.Executor, displayIDs []string) ([]*entity.Song, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubSongRepository) DeleteSong(ctx context.Context, exec repository.Executor, displayID string) error {
+	return errors.New("not implemented")
+}
+
+func (s *stubSongRepository) RestoreSong(ctx context.Context, exec repository.Executor, displayID string) error {
+	return errors.New("not implemented")
+}
+
+func (s *stubSongRepository) UpdateSongs(ctx context.Context, exec repository.Executor, songs []*entity.Song) error {
+	return errors.New("not implemented")
+}
+
+type stubWorldsendChartRepository struct {
+	records []*repository.WorldsendSongWithChart
+	err     error
+}
+
+func (s *stubWorldsendChartRepository) FindAll(ctx context.Context, exec repository.Executor, includeDeleted bool) ([]*repository.WorldsendSongWithChart, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.records, nil
+}
+
+func (s *stubWorldsendChartRepository) FindByDisplayID(ctx context.Context, exec repository.Executor, displayID string) (*repository.WorldsendSongWithChart, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubWorldsendChartRepository) DeleteSong(ctx context.Context, exec repository.Executor, displayID string) error {
+	return errors.New("not implemented")
+}
+
+func (s *stubWorldsendChartRepository) RestoreSong(ctx context.Context, exec repository.Executor, displayID string) error {
+	return errors.New("not implemented")
+}
+
+func (s *stubWorldsendChartRepository) UpdateSongs(ctx context.Context, exec repository.Executor, songs []*entity.Song, charts []*entity.WorldsendChart) error {
+	return errors.New("not implemented")
+}
+
 func (s *stubPlayerService) CreatePlayer(ctx context.Context, name string) (*dto.PlayerDTO, error) {
 	return nil, errors.New("not implemented")
 }
@@ -106,9 +178,9 @@ func (s *stubPlayerService) GetPlayerByID(ctx context.Context, id int) (*dto.Pla
 }
 
 func TestUserService_GetUserProfileWithRecords_UserNotFound(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{err: sql.ErrNoRows}, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, &stubUserRepository{err: sql.ErrNoRows}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
-	_, err := service.GetUserProfileWithRecords(context.Background(), "missing", nil)
+	_, err := service.GetUserProfileWithRecords(context.Background(), "missing", nil, false)
 	if !errors.Is(err, ErrUserNotFound) {
 		t.Fatalf("expected ErrUserNotFound, got %v", err)
 	}
@@ -116,9 +188,9 @@ func TestUserService_GetUserProfileWithRecords_UserNotFound(t *testing.T) {
 
 func TestUserService_GetUserProfileWithRecords_PlayerNotLinked(t *testing.T) {
 	user := &entity.User{ID: 1}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
-	_, err := service.GetUserProfileWithRecords(context.Background(), "no-player", nil)
+	_, err := service.GetUserProfileWithRecords(context.Background(), "no-player", nil, false)
 	if !errors.Is(err, ErrPlayerNotLinked) {
 		t.Fatalf("expected ErrPlayerNotLinked, got %v", err)
 	}
@@ -138,9 +210,9 @@ func TestUserService_GetUserProfileWithRecords_PrivateSelf(t *testing.T) {
 		Level:     1,
 		UpdatedAt: now,
 	}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{player: player})
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{player: player}, nil, nil)
 
-	_, err := service.GetUserProfileWithRecords(context.Background(), "selfuser", &entity.User{ID: 1})
+	_, err := service.GetUserProfileWithRecords(context.Background(), "selfuser", &entity.User{ID: 1}, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,9 +298,9 @@ func TestUserService_GetUserProfileWithRecords_Success(t *testing.T) {
 		UpdatedAt: playerUpdatedAt,
 	}
 	user := &entity.User{ID: 1, PlayerID: intPointer(1)}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{records: records}, &stubPlayerService{player: player})
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{records: records}, &stubPlayerService{player: player}, nil, nil)
 
-	result, err := service.GetUserProfileWithRecords(context.Background(), "tester", nil)
+	result, err := service.GetUserProfileWithRecords(context.Background(), "tester", nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -265,6 +337,66 @@ func TestUserService_GetUserProfileWithRecords_Success(t *testing.T) {
 	}
 	if bestRecord.Difficulty != "EXPERT" {
 		t.Fatalf("expected difficulty EXPERT, got %v", bestRecord.Difficulty)
+	}
+}
+
+func TestUserService_GetUserProfileWithRecords_IncludeNoPlay(t *testing.T) {
+	now := time.Now()
+	scorePlayed, _ := score.NewScore(1000000)
+	chartConst, _ := chartconstant.NewChartConstant(12.4)
+
+	user := &entity.User{ID: 1, PlayerID: intPointer(1)}
+	player := &dto.PlayerDTO{Name: "TestPlayer", Level: 1, UpdatedAt: now.Add(-time.Hour)}
+	playedSong := &entity.Song{ID: 10, DisplayID: "song10", Charts: []*entity.Chart{{ID: 1001, SongID: 10, DifficultyID: 3, Const: chartConst}}}
+	unplayedSong := &entity.Song{ID: 20, DisplayID: "song20", Charts: []*entity.Chart{{ID: 2001, SongID: 20, DifficultyID: 4, Const: chartConst}}}
+	weSong := &entity.Song{ID: 30, DisplayID: "we30"}
+	weChart := &entity.WorldsendChart{ID: 3001, SongID: 30}
+
+	service := NewUserService(
+		nil,
+		&stubUserRepository{user: user},
+		&stubPlayerRecordRepository{records: []*entity.PlayerRecord{{
+			ChartID:         1001,
+			Score:           scorePlayed,
+			UpdatedAt:       now,
+			Chart:           playedSong.Charts[0],
+			Song:            playedSong,
+			ChartDifficulty: &entity.ChartDifficulty{ID: 3, Name: "expert"},
+		}}},
+		&stubPlayerService{player: player},
+		&stubSongRepository{songs: []*entity.Song{playedSong, unplayedSong}},
+		&stubWorldsendChartRepository{records: []*repository.WorldsendSongWithChart{{Song: weSong, Chart: weChart}}},
+	)
+	service.(*userUsecase).SetWorldsendRecordRepository(&stubWorldsendRecordRepository{})
+
+	result, err := service.GetUserProfileWithRecords(context.Background(), "tester", nil, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Records.All) != 2 {
+		t.Fatalf("expected 2 all records, got %d", len(result.Records.All))
+	}
+	if result.Records.All[0].IsPlayed != true {
+		t.Fatal("expected first record is played")
+	}
+	if result.Records.All[1].IsPlayed != false {
+		t.Fatal("expected second record is unplayed")
+	}
+	if result.Records.All[1].UpdatedAt != nil {
+		t.Fatal("expected unplayed updated_at nil")
+	}
+	if result.Records.All[1].ClearLamp != nil {
+		t.Fatal("expected unplayed clear_lamp nil")
+	}
+	if result.Records.All[0].Difficulty != "EXPERT" || result.Records.All[1].Difficulty != "MASTER" {
+		t.Fatalf("expected uppercase difficulties, got %s and %s", result.Records.All[0].Difficulty, result.Records.All[1].Difficulty)
+	}
+	if len(result.Records.WorldsEnd) != 1 {
+		t.Fatalf("expected 1 worldsend record, got %d", len(result.Records.WorldsEnd))
+	}
+	if result.Records.WorldsEnd[0].IsPlayed {
+		t.Fatal("expected worldsend completion record is unplayed")
 	}
 }
 
@@ -346,7 +478,7 @@ func TestUserService_GetUserProfileRatingView_Success(t *testing.T) {
 		UpdatedAt: playerUpdatedAt,
 	}
 	user := &entity.User{ID: 1, PlayerID: intPointer(1)}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{ratingRecords: records}, &stubPlayerService{player: player})
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{ratingRecords: records}, &stubPlayerService{player: player}, nil, nil)
 
 	result, err := service.GetUserProfileRatingView(context.Background(), "tester", nil)
 	if err != nil {
@@ -407,7 +539,7 @@ func TestUserService_GetAllUsersForAdmin(t *testing.T) {
 	repo := &stubUserRepository{
 		usersWithPlayer: usersWithPlayer,
 	}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	list, err := service.GetAllUsersForAdmin(context.Background(), 1, 10, "")
 	if err != nil {
@@ -454,7 +586,7 @@ func TestUserService_DeleteUser_Success(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "testuser")
 	if err != nil {
@@ -473,7 +605,7 @@ func TestUserService_DeleteUser_Success(t *testing.T) {
 func TestUserService_DeleteUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{err: sql.ErrNoRows}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "missing")
 	if !errors.Is(err, ErrUserNotFound) {
@@ -490,7 +622,7 @@ func TestUserService_DeleteUser_AlreadyDeleted(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "deleteduser")
 	if !errors.Is(err, ErrUserAlreadyDeleted) {
@@ -500,7 +632,7 @@ func TestUserService_DeleteUser_AlreadyDeleted(t *testing.T) {
 
 func TestUserService_DeleteUser_AdminRequired(t *testing.T) {
 	normalUser := &entity.User{ID: 1, AccountTypeID: 1}
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.DeleteUser(context.Background(), normalUser, "testuser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -509,7 +641,7 @@ func TestUserService_DeleteUser_AdminRequired(t *testing.T) {
 }
 
 func TestUserService_DeleteUser_NilRequester(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.DeleteUser(context.Background(), nil, "testuser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -526,7 +658,7 @@ func TestUserService_RestoreUser_Success(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "deleteduser")
 	if err != nil {
@@ -545,7 +677,7 @@ func TestUserService_RestoreUser_Success(t *testing.T) {
 func TestUserService_RestoreUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{err: sql.ErrNoRows}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "missing")
 	if !errors.Is(err, ErrUserNotFound) {
@@ -562,7 +694,7 @@ func TestUserService_RestoreUser_NotDeleted(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "activeuser")
 	if !errors.Is(err, ErrUserNotDeleted) {
@@ -572,7 +704,7 @@ func TestUserService_RestoreUser_NotDeleted(t *testing.T) {
 
 func TestUserService_RestoreUser_AdminRequired(t *testing.T) {
 	normalUser := &entity.User{ID: 1, AccountTypeID: 1}
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.RestoreUser(context.Background(), normalUser, "deleteduser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -581,7 +713,7 @@ func TestUserService_RestoreUser_AdminRequired(t *testing.T) {
 }
 
 func TestUserService_RestoreUser_NilRequester(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{})
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
 
 	err := service.RestoreUser(context.Background(), nil, "deleteduser")
 	if !errors.Is(err, ErrAdminRequired) {

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/chartconstant"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/notes"
@@ -138,6 +139,14 @@ func (s *stubSongRepository) UpdateSongs(ctx context.Context, exec repository.Ex
 	return errors.New("not implemented")
 }
 
+type stubSongMasterProvider struct {
+	masters *masterdata.SongMasters
+}
+
+func (s *stubSongMasterProvider) SongMasters() *masterdata.SongMasters {
+	return s.masters
+}
+
 type stubWorldsendChartRepository struct {
 	records []*repository.WorldsendSongWithChart
 	err     error
@@ -178,7 +187,7 @@ func (s *stubPlayerService) GetPlayerByID(ctx context.Context, id int) (*dto.Pla
 }
 
 func TestUserService_GetUserProfileWithRecords_UserNotFound(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{err: sql.ErrNoRows}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{err: sql.ErrNoRows}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	_, err := service.GetUserProfileWithRecords(context.Background(), "missing", nil, false)
 	if !errors.Is(err, ErrUserNotFound) {
@@ -188,7 +197,7 @@ func TestUserService_GetUserProfileWithRecords_UserNotFound(t *testing.T) {
 
 func TestUserService_GetUserProfileWithRecords_PlayerNotLinked(t *testing.T) {
 	user := &entity.User{ID: 1}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	_, err := service.GetUserProfileWithRecords(context.Background(), "no-player", nil, false)
 	if !errors.Is(err, ErrPlayerNotLinked) {
@@ -210,7 +219,7 @@ func TestUserService_GetUserProfileWithRecords_PrivateSelf(t *testing.T) {
 		Level:     1,
 		UpdatedAt: now,
 	}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{player: player}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{player: player}, nil, nil, nil)
 
 	_, err := service.GetUserProfileWithRecords(context.Background(), "selfuser", &entity.User{ID: 1}, false)
 	if err != nil {
@@ -298,7 +307,7 @@ func TestUserService_GetUserProfileWithRecords_Success(t *testing.T) {
 		UpdatedAt: playerUpdatedAt,
 	}
 	user := &entity.User{ID: 1, PlayerID: intPointer(1)}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{records: records}, &stubPlayerService{player: player}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{records: records}, &stubPlayerService{player: player}, nil, nil, nil)
 
 	result, err := service.GetUserProfileWithRecords(context.Background(), "tester", nil, false)
 	if err != nil {
@@ -366,6 +375,7 @@ func TestUserService_GetUserProfileWithRecords_IncludeNoPlay(t *testing.T) {
 		&stubPlayerService{player: player},
 		&stubSongRepository{songs: []*entity.Song{playedSong, unplayedSong}},
 		&stubWorldsendChartRepository{records: []*repository.WorldsendSongWithChart{{Song: weSong, Chart: weChart}}},
+		&stubSongMasterProvider{masters: &masterdata.SongMasters{CommonMasters: masterdata.CommonMasters{DifficultyNamesByID: map[int]string{3: "EXPERT", 4: "MASTER"}}}},
 	)
 	service.(*userUsecase).SetWorldsendRecordRepository(&stubWorldsendRecordRepository{})
 
@@ -495,7 +505,7 @@ func TestUserService_GetUserProfileRatingView_Success(t *testing.T) {
 		UpdatedAt: playerUpdatedAt,
 	}
 	user := &entity.User{ID: 1, PlayerID: intPointer(1)}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{ratingRecords: records}, &stubPlayerService{player: player}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{ratingRecords: records}, &stubPlayerService{player: player}, nil, nil, nil)
 
 	result, err := service.GetUserProfileRatingView(context.Background(), "tester", nil)
 	if err != nil {
@@ -556,7 +566,7 @@ func TestUserService_GetAllUsersForAdmin(t *testing.T) {
 	repo := &stubUserRepository{
 		usersWithPlayer: usersWithPlayer,
 	}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	list, err := service.GetAllUsersForAdmin(context.Background(), 1, 10, "")
 	if err != nil {
@@ -603,7 +613,7 @@ func TestUserService_DeleteUser_Success(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "testuser")
 	if err != nil {
@@ -622,7 +632,7 @@ func TestUserService_DeleteUser_Success(t *testing.T) {
 func TestUserService_DeleteUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{err: sql.ErrNoRows}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "missing")
 	if !errors.Is(err, ErrUserNotFound) {
@@ -639,7 +649,7 @@ func TestUserService_DeleteUser_AlreadyDeleted(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "deleteduser")
 	if !errors.Is(err, ErrUserAlreadyDeleted) {
@@ -649,7 +659,7 @@ func TestUserService_DeleteUser_AlreadyDeleted(t *testing.T) {
 
 func TestUserService_DeleteUser_AdminRequired(t *testing.T) {
 	normalUser := &entity.User{ID: 1, AccountTypeID: 1}
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), normalUser, "testuser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -658,7 +668,7 @@ func TestUserService_DeleteUser_AdminRequired(t *testing.T) {
 }
 
 func TestUserService_DeleteUser_NilRequester(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), nil, "testuser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -675,7 +685,7 @@ func TestUserService_RestoreUser_Success(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "deleteduser")
 	if err != nil {
@@ -694,7 +704,7 @@ func TestUserService_RestoreUser_Success(t *testing.T) {
 func TestUserService_RestoreUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{err: sql.ErrNoRows}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "missing")
 	if !errors.Is(err, ErrUserNotFound) {
@@ -711,7 +721,7 @@ func TestUserService_RestoreUser_NotDeleted(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "activeuser")
 	if !errors.Is(err, ErrUserNotDeleted) {
@@ -721,7 +731,7 @@ func TestUserService_RestoreUser_NotDeleted(t *testing.T) {
 
 func TestUserService_RestoreUser_AdminRequired(t *testing.T) {
 	normalUser := &entity.User{ID: 1, AccountTypeID: 1}
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), normalUser, "deleteduser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -730,7 +740,7 @@ func TestUserService_RestoreUser_AdminRequired(t *testing.T) {
 }
 
 func TestUserService_RestoreUser_NilRequester(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), nil, "deleteduser")
 	if !errors.Is(err, ErrAdminRequired) {


### PR DESCRIPTION
### Motivation

- フロントエンドが「未プレイ譜面を含む全譜面集合」を必要としているため、`GET /internal/users/:username` / `GET /v1/users/:username` に未プレイ補完を追加するため。 
- 補完ロジックをユースケースに直書きせずドメインサービスに分離して責務を明確化するため。 

### Description

- 新規ドメインサービス `internal/domain/service/record_completion_service.go` を追加し、通常譜面と WORLD'S END の未プレイ補完・重複除外・ソート・削除済み楽曲除外を実装しました。 
- ユースケースの API を拡張して `GetUserProfileWithRecords(..., includeNoPlay bool)` を受け取り、`include_noplay=true` 時に `songRepo` / `worldsendChartRepo` を使って補完ロジックを呼び出すようにしました（`internal/usecase/*`）。 
- DTO を拡張して `PlayerRecordDTO` / `WorldsendRecordDTO` と v1 DTO に `is_played` を追加し、`updated_at` と `clear_lamp` を nullable に変更し、既存実レコードは `is_played=true`、補完レコードは `is_played=false` となるようにしました（大文字化された `difficulty` を返却）。 
- ハンドラでクエリ `include_noplay` を受け取るようにし、`view=rating` ルートは従来どおり `include_noplay` を無視する仕様を維持しました（`internal/app/handler` と互換ハンドラは `false` 固定）。 
- ドキュメント `docs/API.md` に `/v1/users/:username` の `include_noplay` 仕様を追記しました。 

### Testing

- 追加ユニットテスト `internal/domain/service/record_completion_service_test.go` と統合的なユースケーステストを `internal/usecase/user_usecase_impl_test.go` に追加し、補完件数・重複除外・ソート順・削除済み除外・`is_played`・nullable 振る舞い・難易度大文字化・WORLD'S END 補完を検証しました。 
- 開発中に `gofmt -w` を実行してコード整形を行い、`go test ./...` を実行したところテストはすべて成功しました。 
- 変更に伴う既存ハンドラテストのモックシグネチャ修正も行い、`go test ./...` は成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699410b2e490832dad4e5b329c776a3d)