### PR TITLE
fix: 不要なSQLite goalマイグレーションを削除

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1277,11 +1277,59 @@ curl -X POST \
 
 ---
 
+
+## `/internal/me/goals` グループ
+
+### GET `/internal/me/goals`
+- **認証**: Cookie 必須
+- **概要**: 自分の目標一覧を取得します。
+- **レスポンス**: 200 OK
+
+```json
+{
+  "goals": [
+    {
+      "id": 1,
+      "title": "マスター14+ 100枚",
+      "achievement_type": "score_count",
+      "achievement_params": { "score": 1007500, "count": 100 },
+      "attributes": { "diff": 4, "const": { "min": 14.0, "max": 14.9 } },
+      "invert": false,
+      "created_at": "2026-01-01T09:00:00+09:00"
+    }
+  ]
+}
+```
+
+### POST `/internal/me/goals`
+- **認証**: Cookie 必須
+- **概要**: 目標を新規作成します（1ユーザー100件上限）。
+- **レスポンス**: 201 Created
+
+### PUT `/internal/me/goals/:id`
+- **認証**: Cookie 必須
+- **概要**: 指定した目標を更新します。
+- **レスポンス**: 204 No Content
+
+### DELETE `/internal/me/goals/:id`
+- **認証**: Cookie 必須
+- **概要**: 指定した目標を削除します。
+- **レスポンス**: 204 No Content
+
+- **主なエラー**:
+  - 400 Bad Request (`invalid_goal_request`): リクエスト内容が不正
+  - 400 Bad Request (`invalid_achievement_type`): 成果種別が不正
+  - 400 Bad Request (`goal_limit_exceeded`): 目標上限100件を超過
+  - 404 Not Found (`goal_not_found`): 目標が見つからない
+  - 401 Unauthorized (`unauthorized`): 認証が必要
+
+---
+
 ## `/internal/master` グループ
 
 ### GET `/internal/master`
 - **認証**: Cookie 必須
-- **概要**: フロントエンド向けにマスタデータ（ジャンル、難易度、アカウント種別、バージョン）を返却します。
+- **概要**: フロントエンド向けにマスタデータ（ジャンル、難易度、アカウント種別、成果種別、バージョン）を返却します。
 - **レスポンス**: 200 OK
 
 ```json
@@ -1303,6 +1351,11 @@ curl -X POST \
     { "id": 2, "name": "EDITOR" },
     { "id": 3, "name": "ADMIN" }
   ],
+  "achievement_types": [
+    { "id": 1, "name": "rank_count" },
+    { "id": 2, "name": "score_count" },
+    { "id": 3, "name": "avg_score" }
+  ],
   "versions": [
     { "id": 1, "name": "CHUNITHM", "released_at": "2015-07-16T00:00:00+09:00" },
     { "id": 2, "name": "CHUNITHM PLUS", "released_at": "2016-02-04T00:00:00+09:00" },
@@ -1323,6 +1376,7 @@ curl -X POST \
 | `genres` | MasterItemDTO[] | ジャンル一覧（ID順） |
 | `difficulties` | MasterItemDTO[] | 難易度一覧（ID順） |
 | `account_types` | MasterItemDTO[] | アカウント種別一覧（ID順） |
+| `achievement_types` | MasterItemDTO[] | 目標機能の成果種別一覧（ID順） |
 | `versions` | VersionDTO[] | バージョン一覧（ID順） |
 | `rating_bands` | RatingBandDTO[] | レーティング帯マスタ一覧（sort_order順） |
 

--- a/internal/app/apierror/api_error.go
+++ b/internal/app/apierror/api_error.go
@@ -95,14 +95,18 @@ var (
 	ErrServiceUnavailable = New(CodeServiceUnavailable, http.StatusServiceUnavailable)
 
 	// 入力バリデーション詳細エラー
-	ErrUsernameEmpty         = New(CodeUsernameEmpty, http.StatusBadRequest)
-	ErrUsernameTooShort      = New(CodeUsernameTooShort, http.StatusBadRequest)
-	ErrUsernameTooLong       = New(CodeUsernameTooLong, http.StatusBadRequest)
-	ErrUsernameInvalidChar   = New(CodeUsernameInvalidChar, http.StatusBadRequest)
-	ErrPasswordTooShort      = New(CodePasswordTooShort, http.StatusBadRequest)
-	ErrPasswordTooLong       = New(CodePasswordTooLong, http.StatusBadRequest)
-	ErrInvalidPassword       = New(CodeInvalidPassword, http.StatusBadRequest)       // パスワード無効（詳細隠蔽）
-	ErrAppVersionUnsupported = New(CodeAppVersionUnsupported, http.StatusBadRequest) // 対応していないアプリバージョン
+	ErrUsernameEmpty          = New(CodeUsernameEmpty, http.StatusBadRequest)
+	ErrUsernameTooShort       = New(CodeUsernameTooShort, http.StatusBadRequest)
+	ErrUsernameTooLong        = New(CodeUsernameTooLong, http.StatusBadRequest)
+	ErrUsernameInvalidChar    = New(CodeUsernameInvalidChar, http.StatusBadRequest)
+	ErrPasswordTooShort       = New(CodePasswordTooShort, http.StatusBadRequest)
+	ErrPasswordTooLong        = New(CodePasswordTooLong, http.StatusBadRequest)
+	ErrInvalidPassword        = New(CodeInvalidPassword, http.StatusBadRequest)       // パスワード無効（詳細隠蔽）
+	ErrAppVersionUnsupported  = New(CodeAppVersionUnsupported, http.StatusBadRequest) // 対応していないアプリバージョン
+	ErrGoalNotFound           = New(CodeGoalNotFound, http.StatusNotFound)
+	ErrGoalLimitExceeded      = New(CodeGoalLimitExceeded, http.StatusBadRequest)
+	ErrInvalidGoalRequest     = New(CodeInvalidGoalRequest, http.StatusBadRequest)
+	ErrInvalidAchievementType = New(CodeInvalidAchievementType, http.StatusBadRequest)
 )
 
 // ErrorResponse はエラーレスポンスの構造体です

--- a/internal/app/apierror/codes.go
+++ b/internal/app/apierror/codes.go
@@ -46,12 +46,16 @@ const (
 	CodeServiceUnavailable = "service_unavailable"
 
 	// 入力バリデーション詳細エラー
-	CodeUsernameEmpty         = "username_empty"
-	CodeUsernameTooShort      = "username_too_short"
-	CodeUsernameTooLong       = "username_too_long"
-	CodeUsernameInvalidChar   = "username_invalid_char"
-	CodePasswordTooShort      = "password_too_short"
-	CodePasswordTooLong       = "password_too_long"
-	CodeInvalidPassword       = "invalid_password"        // パスワードが無効（詳細を隠蔽）
-	CodeAppVersionUnsupported = "app_version_unsupported" // 対応していないアプリバージョン
+	CodeUsernameEmpty          = "username_empty"
+	CodeUsernameTooShort       = "username_too_short"
+	CodeUsernameTooLong        = "username_too_long"
+	CodeUsernameInvalidChar    = "username_invalid_char"
+	CodePasswordTooShort       = "password_too_short"
+	CodePasswordTooLong        = "password_too_long"
+	CodeInvalidPassword        = "invalid_password"        // パスワードが無効（詳細を隠蔽）
+	CodeAppVersionUnsupported  = "app_version_unsupported" // 対応していないアプリバージョン
+	CodeGoalNotFound           = "goal_not_found"
+	CodeGoalLimitExceeded      = "goal_limit_exceeded"
+	CodeInvalidGoalRequest     = "invalid_goal_request"
+	CodeInvalidAchievementType = "invalid_achievement_type"
 )

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -73,6 +73,14 @@ func FromUsecaseError(err error) *APIError {
 	// アプリバージョンバリデーションエラー
 	case errors.Is(err, usecase.ErrAppVersionUnsupported):
 		return ErrAppVersionUnsupported.WithInternal(err)
+	case errors.Is(err, usecase.ErrGoalNotFound):
+		return ErrGoalNotFound.WithInternal(err)
+	case errors.Is(err, usecase.ErrGoalLimitExceeded):
+		return ErrGoalLimitExceeded.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidGoalRequest):
+		return ErrInvalidGoalRequest.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidAchievementType):
+		return ErrInvalidAchievementType.WithInternal(err)
 	}
 
 	// PlayerDataValidationError

--- a/internal/app/handler/api_internal/goal_handler.go
+++ b/internal/app/handler/api_internal/goal_handler.go
@@ -1,0 +1,84 @@
+package api_internal
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
+	"github.com/chunisupport/chunisupport-api/internal/auth"
+	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
+	"github.com/chunisupport/chunisupport-api/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+// GoalHandler は目標関連のHTTPリクエストを処理します。
+type GoalHandler struct {
+	goalUsecase usecase.GoalUsecase
+}
+
+func NewGoalHandler(goalUsecase usecase.GoalUsecase) *GoalHandler {
+	return &GoalHandler{goalUsecase: goalUsecase}
+}
+
+func (h *GoalHandler) ListGoals(c echo.Context) error {
+	claims, ok := c.Get("user").(*auth.Claims)
+	if !ok || claims == nil {
+		return apierror.ErrUnauthorized.WithInternal(errors.New("JWT claims not found in context"))
+	}
+	goals, err := h.goalUsecase.List(c.Request().Context(), claims.UserID)
+	if err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	return c.JSON(http.StatusOK, &dto_internal.GoalListResponseDTO{Goals: goals})
+}
+
+func (h *GoalHandler) CreateGoal(c echo.Context) error {
+	claims, ok := c.Get("user").(*auth.Claims)
+	if !ok || claims == nil {
+		return apierror.ErrUnauthorized.WithInternal(errors.New("JWT claims not found in context"))
+	}
+	var req dto_internal.UpsertGoalRequestDTO
+	if err := c.Bind(&req); err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	created, err := h.goalUsecase.Create(c.Request().Context(), claims.UserID, &req)
+	if err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	return c.JSON(http.StatusCreated, created)
+}
+
+func (h *GoalHandler) UpdateGoal(c echo.Context) error {
+	claims, ok := c.Get("user").(*auth.Claims)
+	if !ok || claims == nil {
+		return apierror.ErrUnauthorized.WithInternal(errors.New("JWT claims not found in context"))
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	var req dto_internal.UpsertGoalRequestDTO
+	if err := c.Bind(&req); err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	if err := h.goalUsecase.Update(c.Request().Context(), claims.UserID, id, &req); err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func (h *GoalHandler) DeleteGoal(c echo.Context) error {
+	claims, ok := c.Get("user").(*auth.Claims)
+	if !ok || claims == nil {
+		return apierror.ErrUnauthorized.WithInternal(errors.New("JWT claims not found in context"))
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	if err := h.goalUsecase.Delete(c.Request().Context(), claims.UserID, id); err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/internal/app/handler/api_internal/master_data_handler.go
+++ b/internal/app/handler/api_internal/master_data_handler.go
@@ -63,6 +63,16 @@ func (h *MasterDataHandler) GetMasterData(c echo.Context) error {
 	}
 	sortMasterItemsByID(accountTypes)
 
+	// AchievementTypes をID順にソートして配列化
+	achievementTypes := make([]*dto.MasterItemDTO, 0, len(h.masterCache.AchievementTypes))
+	for _, item := range h.masterCache.AchievementTypes {
+		achievementTypes = append(achievementTypes, &dto.MasterItemDTO{
+			ID:   item.ID,
+			Name: item.Name,
+		})
+	}
+	sortMasterItemsByID(achievementTypes)
+
 	// Versions をID順にソートして配列化
 	versions := make([]*dto.VersionDTO, 0, len(h.masterCache.Versions))
 	for _, item := range h.masterCache.Versions {
@@ -89,11 +99,12 @@ func (h *MasterDataHandler) GetMasterData(c echo.Context) error {
 	}
 
 	response := &dto.MasterDataResponse{
-		Genres:       genres,
-		Difficulties: difficulties,
-		AccountTypes: accountTypes,
-		Versions:     versions,
-		RatingBands:  ratingBands,
+		Genres:           genres,
+		Difficulties:     difficulties,
+		AccountTypes:     accountTypes,
+		AchievementTypes: achievementTypes,
+		Versions:         versions,
+		RatingBands:      ratingBands,
 	}
 
 	return c.JSON(http.StatusOK, response)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -58,6 +58,7 @@ type Handlers struct {
 	Me         *api_internal.MeHandler
 	MasterData *api_internal.MasterDataHandler
 	Session    *api_internal.SessionHandler
+	Goal       *api_internal.GoalHandler
 	// 外部API v1 用ハンドラ
 	V1Song      *api_v1.V1SongHandler
 	V1Worldsend *api_v1.V1WorldsendHandler
@@ -118,6 +119,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	worldsendChartRepo := infra.NewWorldsendChartRepository(db)
 	chartStatsRepo := infra.NewChartStatsRepository(staticDB)
 	sessionRepo := infra.NewSessionRepository(db)
+	goalRepo := infra.NewGoalRepository(db)
 	apiTokenRepo := infra.NewAPITokenRepository(db)
 	recoveryCodeRepo := infra.NewRecoveryCodeRepository(db)
 	songRepo := infra.NewSongRepository(db)
@@ -139,6 +141,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	chartStatsUsecase := usecase.NewChartStatsUsecase(songRepo, worldsendChartRepo, chartStatsRepo, masterCache, chartStatsMasterProvider, db, staticDB)
 	worldsendUsecase := usecase.NewWorldsendUsecase(worldsendChartRepo, tm, db)
 	sessionUsecase := usecase.NewSessionUsecase(sessionRepo, db)
+	goalUsecase := usecase.NewGoalService(db, tm, goalRepo, masterCache.GoalMasters())
 
 	// DI - Handlers
 	sameSite := parseSameSite(cfg.Auth.CookieSameSite)
@@ -152,6 +155,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 		Me:         api_internal.NewMeHandler(playerDataUsecase),
 		MasterData: api_internal.NewMasterDataHandler(masterCache, staticMasterCache),
 		Session:    api_internal.NewSessionHandler(sessionUsecase),
+		Goal:       api_internal.NewGoalHandler(goalUsecase),
 		// 外部API v1 用ハンドラ
 		V1Song:      api_v1.NewV1SongHandler(songUsecase, chartStatsUsecase, masterCache, staticMasterCache),
 		V1Worldsend: api_v1.NewV1WorldsendHandler(worldsendUsecase, masterCache),
@@ -233,6 +237,10 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authUsecase usecase.AuthUs
 		// セッション管理
 		meGroup.GET("/sessions", handlers.Session.GetSessionCount)
 		meGroup.DELETE("/sessions", handlers.Session.LogoutOtherSessions)
+		meGroup.GET("/goals", handlers.Goal.ListGoals)
+		meGroup.POST("/goals", handlers.Goal.CreateGoal)
+		meGroup.PUT("/goals/:id", handlers.Goal.UpdateGoal)
+		meGroup.DELETE("/goals/:id", handlers.Goal.DeleteGoal)
 	}
 
 	// api.chunisupport.net/internal/users

--- a/internal/domain/entity/goal.go
+++ b/internal/domain/entity/goal.go
@@ -1,0 +1,15 @@
+package entity
+
+import "time"
+
+// Goal はユーザーの目標を表す集約です。
+type Goal struct {
+	ID                int
+	UserID            int
+	Title             string
+	AchievementTypeID int
+	AchievementParams map[string]any
+	Attributes        map[string]any
+	Invert            bool
+	CreatedAt         time.Time
+}

--- a/internal/domain/masterdata/masterdata.go
+++ b/internal/domain/masterdata/masterdata.go
@@ -44,3 +44,13 @@ type SongMasters struct {
 	GenreNamesByID map[int]string
 	Difficulties   map[string]Item
 }
+
+// GoalMasters は目標機能で必要になるマスタ集合です。
+type GoalMasters struct {
+	AchievementTypesByCode map[string]Item
+	AchievementTypesByID   map[int]string
+	GenresByID             map[int]Item
+	VersionsByID           map[int]Version
+	ClearLampsByName       map[string]Item
+	ComboLampsByName       map[string]Item
+}

--- a/internal/domain/repository/goal_repository.go
+++ b/internal/domain/repository/goal_repository.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+)
+
+// GoalRepository は目標データへのアクセスを抽象化するインターフェースです。
+type GoalRepository interface {
+	FindByUserID(ctx context.Context, exec Executor, userID int) ([]*entity.Goal, error)
+	FindByIDAndUserID(ctx context.Context, exec Executor, id int, userID int) (*entity.Goal, error)
+	Create(ctx context.Context, exec Executor, goal *entity.Goal) error
+	Update(ctx context.Context, exec Executor, goal *entity.Goal) error
+	Delete(ctx context.Context, exec Executor, id int, userID int) error
+	CountByUserID(ctx context.Context, exec Executor, userID int) (int, error)
+	LockUser(ctx context.Context, exec Executor, userID int) error
+}

--- a/internal/dto/api_internal/goal_dto.go
+++ b/internal/dto/api_internal/goal_dto.go
@@ -1,0 +1,50 @@
+package api_internal
+
+import (
+	"time"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+)
+
+// GoalDTO は目標レスポンスです。
+type GoalDTO struct {
+	ID                int            `json:"id"`
+	Title             string         `json:"title"`
+	AchievementType   string         `json:"achievement_type"`
+	AchievementParams map[string]any `json:"achievement_params"`
+	Attributes        map[string]any `json:"attributes"`
+	Invert            bool           `json:"invert"`
+	CreatedAt         string         `json:"created_at"`
+}
+
+type UpsertGoalRequestDTO struct {
+	Title             string         `json:"title"`
+	AchievementType   string         `json:"achievement_type"`
+	AchievementParams map[string]any `json:"achievement_params"`
+	Attributes        map[string]any `json:"attributes"`
+	Invert            bool           `json:"invert"`
+}
+
+type GoalListResponseDTO struct {
+	Goals []*GoalDTO `json:"goals"`
+}
+
+func ToGoalDTO(goal *entity.Goal, achievementTypesByID map[int]string) *GoalDTO {
+	return &GoalDTO{
+		ID:                goal.ID,
+		Title:             goal.Title,
+		AchievementType:   achievementTypesByID[goal.AchievementTypeID],
+		AchievementParams: goal.AchievementParams,
+		Attributes:        goal.Attributes,
+		Invert:            goal.Invert,
+		CreatedAt:         goal.CreatedAt.Format(time.RFC3339),
+	}
+}
+
+func ToGoalDTOs(goals []*entity.Goal, achievementTypesByID map[int]string) []*GoalDTO {
+	result := make([]*GoalDTO, 0, len(goals))
+	for _, goal := range goals {
+		result = append(result, ToGoalDTO(goal, achievementTypesByID))
+	}
+	return result
+}

--- a/internal/dto/master_data_dto.go
+++ b/internal/dto/master_data_dto.go
@@ -15,11 +15,12 @@ type VersionDTO struct {
 
 // MasterDataResponse はマスタデータ取得APIのレスポンスを表します。
 type MasterDataResponse struct {
-	Genres       []*MasterItemDTO `json:"genres"`
-	Difficulties []*MasterItemDTO `json:"difficulties"`
-	AccountTypes []*MasterItemDTO `json:"account_types"`
-	Versions     []*VersionDTO    `json:"versions"`
-	RatingBands  []*RatingBandDTO `json:"rating_bands"`
+	Genres           []*MasterItemDTO `json:"genres"`
+	Difficulties     []*MasterItemDTO `json:"difficulties"`
+	AccountTypes     []*MasterItemDTO `json:"account_types"`
+	AchievementTypes []*MasterItemDTO `json:"achievement_types"`
+	Versions         []*VersionDTO    `json:"versions"`
+	RatingBands      []*RatingBandDTO `json:"rating_bands"`
 }
 
 // RatingBandDTO はレーティング帯マスタのDTOです。

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -13,6 +13,9 @@ const (
 	BulkSelectChunkSize  = 1000 // IN句のプレースホルダ上限を避けるための分割数
 	DefaultUserListLimit = 100
 	DefaultSongListLimit = 100
+	GoalLimitPerUser     = 100
+	ChartConstMin        = 1.0
+	ChartConstMax        = 15.9
 
 	// レートリミット設定: 外部API v1
 	APIRateLimitRequests      = 150              // 一般ユーザーのリクエスト制限（15分間）
@@ -63,3 +66,31 @@ const (
 // プレイヤーデータ登録時に、このリストに含まれるバージョンのみ受け付ける
 // NOTE: ユーザーが設定ファイルで変更できるようにする必要があれば、example.setting.jsonに追加してください
 var SupportedAppVersions = []string{"0.0.2"}
+
+// HardLampAbbrevToName はAPI略称からクリアランプマスタ名への変換テーブルです。
+var HardLampAbbrevToName = map[string]string{
+	"HRD": "HARD",
+	"BRV": "BRAVE",
+	"ABS": "ABSOLUTE",
+	"CTS": "CATASTROPHY",
+}
+
+// HardLampNameToAbbrev はクリアランプマスタ名からAPI略称への変換テーブルです。
+var HardLampNameToAbbrev = map[string]string{
+	"HARD":        "HRD",
+	"BRAVE":       "BRV",
+	"ABSOLUTE":    "ABS",
+	"CATASTROPHY": "CTS",
+}
+
+// ComboLampAbbrevToName はAPI略称からコンボランプマスタ名への変換テーブルです。
+var ComboLampAbbrevToName = map[string]string{
+	"FC": "FULL COMBO",
+	"AJ": "ALL JUSTICE",
+}
+
+// ComboLampNameToAbbrev はコンボランプマスタ名からAPI略称への変換テーブルです。
+var ComboLampNameToAbbrev = map[string]string{
+	"FULL COMBO":  "FC",
+	"ALL JUSTICE": "AJ",
+}

--- a/internal/infra/masterdata/cache.go
+++ b/internal/infra/masterdata/cache.go
@@ -12,23 +12,29 @@ import (
 
 // Cache は起動時にプリロードされるマスタのセットです。
 type Cache struct {
-	ClassEmblems        map[string]Item
-	ClassEmblemBases    map[string]Item
-	ClearLamps          map[string]Item
-	ClearLampNamesByID  map[int]string
-	ComboLamps          map[string]Item
-	ComboLampNamesByID  map[int]string
-	FullChains          map[string]Item
-	FullChainNamesByID  map[int]string
-	Slots               map[string]Item
-	SlotNamesByID       map[int]string
-	HonorTypes          map[string]Item
-	Difficulties        map[string]Item
-	DifficultyNamesByID map[int]string
-	Genres              map[string]Item
-	GenreNamesByID      map[int]string
-	AccountTypes        map[string]Item
-	Versions            map[string]Version
+	ClassEmblems         map[string]Item
+	ClassEmblemBases     map[string]Item
+	ClearLamps           map[string]Item
+	ClearLampNamesByID   map[int]string
+	ComboLamps           map[string]Item
+	ComboLampNamesByID   map[int]string
+	FullChains           map[string]Item
+	FullChainNamesByID   map[int]string
+	Slots                map[string]Item
+	SlotNamesByID        map[int]string
+	HonorTypes           map[string]Item
+	Difficulties         map[string]Item
+	DifficultyNamesByID  map[int]string
+	Genres               map[string]Item
+	GenreNamesByID       map[int]string
+	AccountTypes         map[string]Item
+	Versions             map[string]Version
+	AchievementTypes     map[string]Item
+	AchievementTypesByID map[int]string
+	GenresByID           map[int]Item
+	VersionsByID         map[int]Version
+	ClearLampsByName     map[string]Item
+	ComboLampsByName     map[string]Item
 }
 
 // Preload は固定値が INSERT されているマスタを読み込み、キャッシュを構築します。
@@ -113,24 +119,55 @@ func Preload(ctx context.Context, db *sqlx.DB) (*Cache, error) {
 		return nil, fmt.Errorf("failed to preload versions: %w", err)
 	}
 
+	achievementTypes, err := loadSimpleMasters(ctx, db, "SELECT id, code FROM achievement_types", false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to preload achievement_types: %w", err)
+	}
+	achievementTypesByID := make(map[int]string, len(achievementTypes))
+	for _, item := range achievementTypes {
+		achievementTypesByID[item.ID] = item.Name
+	}
+	genresByID := make(map[int]Item, len(genres))
+	for _, item := range genres {
+		genresByID[item.ID] = item
+	}
+	versionsByID := make(map[int]Version, len(versions))
+	for _, version := range versions {
+		versionsByID[int(version.ID)] = version
+	}
+	clearLampsByName := make(map[string]Item, len(clearLamps))
+	for _, item := range clearLamps {
+		clearLampsByName[strings.ToUpper(item.Name)] = item
+	}
+	comboLampsByName := make(map[string]Item, len(comboLamps))
+	for _, item := range comboLamps {
+		comboLampsByName[strings.ToUpper(item.Name)] = item
+	}
+
 	return &Cache{
-		ClassEmblems:        classEmblems,
-		ClassEmblemBases:    classEmblemBases,
-		ClearLamps:          clearLamps,
-		ClearLampNamesByID:  clearLampNamesByID,
-		ComboLamps:          comboLamps,
-		ComboLampNamesByID:  comboLampNamesByID,
-		FullChains:          fullChains,
-		FullChainNamesByID:  fullChainNamesByID,
-		Slots:               slots,
-		SlotNamesByID:       slotNamesByID,
-		HonorTypes:          honorTypes,
-		Difficulties:        difficulties,
-		DifficultyNamesByID: difficultyNamesByID,
-		Genres:              genres,
-		GenreNamesByID:      genreNamesByID,
-		AccountTypes:        accountTypes,
-		Versions:            versions,
+		ClassEmblems:         classEmblems,
+		ClassEmblemBases:     classEmblemBases,
+		ClearLamps:           clearLamps,
+		ClearLampNamesByID:   clearLampNamesByID,
+		ComboLamps:           comboLamps,
+		ComboLampNamesByID:   comboLampNamesByID,
+		FullChains:           fullChains,
+		FullChainNamesByID:   fullChainNamesByID,
+		Slots:                slots,
+		SlotNamesByID:        slotNamesByID,
+		HonorTypes:           honorTypes,
+		Difficulties:         difficulties,
+		DifficultyNamesByID:  difficultyNamesByID,
+		Genres:               genres,
+		GenreNamesByID:       genreNamesByID,
+		AccountTypes:         accountTypes,
+		Versions:             versions,
+		AchievementTypes:     achievementTypes,
+		AchievementTypesByID: achievementTypesByID,
+		GenresByID:           genresByID,
+		VersionsByID:         versionsByID,
+		ClearLampsByName:     clearLampsByName,
+		ComboLampsByName:     comboLampsByName,
 	}, nil
 }
 
@@ -222,6 +259,29 @@ func (c *Cache) SongMasters() *domainmasterdata.SongMasters {
 		GenreNamesByID: maps.Clone(c.GenreNamesByID),
 		Genres:         maps.Clone(c.Genres),
 		Difficulties:   maps.Clone(c.Difficulties),
+	}
+}
+
+// GoalMasters は目標機能で必要なマスタ集合を返します。
+func (c *Cache) GoalMasters() *domainmasterdata.GoalMasters {
+	if c == nil {
+		return nil
+	}
+	versionsByID := make(map[int]domainmasterdata.Version, len(c.VersionsByID))
+	for id, version := range c.VersionsByID {
+		versionsByID[id] = domainmasterdata.Version{
+			ID:         version.ID,
+			Name:       version.Name,
+			ReleasedAt: version.ReleasedAt,
+		}
+	}
+	return &domainmasterdata.GoalMasters{
+		AchievementTypesByCode: maps.Clone(c.AchievementTypes),
+		AchievementTypesByID:   maps.Clone(c.AchievementTypesByID),
+		GenresByID:             maps.Clone(c.GenresByID),
+		VersionsByID:           versionsByID,
+		ClearLampsByName:       maps.Clone(c.ClearLampsByName),
+		ComboLampsByName:       maps.Clone(c.ComboLampsByName),
 	}
 }
 

--- a/internal/infra/models/goal_model.go
+++ b/internal/infra/models/goal_model.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+)
+
+// GoalModel はデータベース用のGoalモデルです。
+type GoalModel struct {
+	ID                int             `db:"id"`
+	UserID            int             `db:"user_id"`
+	Title             string          `db:"title"`
+	AchievementTypeID int             `db:"achievement_type_id"`
+	AchievementParams json.RawMessage `db:"achievement_params"`
+	Attributes        json.RawMessage `db:"attributes"`
+	Invert            bool            `db:"invert"`
+	CreatedAt         time.Time       `db:"created_at"`
+}
+
+func (m *GoalModel) ToEntity() (*entity.Goal, error) {
+	params := map[string]any{}
+	if len(m.AchievementParams) > 0 {
+		if err := json.Unmarshal(m.AchievementParams, &params); err != nil {
+			return nil, err
+		}
+	}
+	attrs := map[string]any{}
+	if len(m.Attributes) > 0 {
+		if err := json.Unmarshal(m.Attributes, &attrs); err != nil {
+			return nil, err
+		}
+	}
+	return &entity.Goal{
+		ID:                m.ID,
+		UserID:            m.UserID,
+		Title:             m.Title,
+		AchievementTypeID: m.AchievementTypeID,
+		AchievementParams: params,
+		Attributes:        attrs,
+		Invert:            m.Invert,
+		CreatedAt:         m.CreatedAt,
+	}, nil
+}
+
+func FromGoalEntity(e *entity.Goal) (*GoalModel, error) {
+	paramsBytes, err := json.Marshal(e.AchievementParams)
+	if err != nil {
+		return nil, err
+	}
+	attrsBytes, err := json.Marshal(e.Attributes)
+	if err != nil {
+		return nil, err
+	}
+	return &GoalModel{
+		ID:                e.ID,
+		UserID:            e.UserID,
+		Title:             e.Title,
+		AchievementTypeID: e.AchievementTypeID,
+		AchievementParams: paramsBytes,
+		Attributes:        attrsBytes,
+		Invert:            e.Invert,
+		CreatedAt:         e.CreatedAt,
+	}, nil
+}

--- a/internal/infra/repository/goal_repository_impl.go
+++ b/internal/infra/repository/goal_repository_impl.go
@@ -1,0 +1,118 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/infra/models"
+	"github.com/jmoiron/sqlx"
+)
+
+type goalRepository struct {
+	db *sqlx.DB
+}
+
+// NewGoalRepository は新しいGoalRepositoryを生成します。
+func NewGoalRepository(db *sqlx.DB) repository.GoalRepository {
+	return &goalRepository{db: db}
+}
+
+func (r *goalRepository) FindByUserID(ctx context.Context, exec repository.Executor, userID int) ([]*entity.Goal, error) {
+	var rows []models.GoalModel
+	query := `SELECT id, user_id, title, achievement_type_id, achievement_params, attributes, invert, created_at FROM goals WHERE user_id = ? ORDER BY created_at ASC, id ASC`
+	if err := exec.SelectContext(ctx, &rows, query, userID); err != nil {
+		return nil, err
+	}
+	goals := make([]*entity.Goal, 0, len(rows))
+	for i := range rows {
+		goal, err := rows[i].ToEntity()
+		if err != nil {
+			return nil, err
+		}
+		goals = append(goals, goal)
+	}
+	return goals, nil
+}
+
+func (r *goalRepository) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id int, userID int) (*entity.Goal, error) {
+	var row models.GoalModel
+	query := `SELECT id, user_id, title, achievement_type_id, achievement_params, attributes, invert, created_at FROM goals WHERE id = ? AND user_id = ?`
+	if err := exec.GetContext(ctx, &row, query, id, userID); err != nil {
+		return nil, err
+	}
+	return row.ToEntity()
+}
+
+func (r *goalRepository) Create(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	model, err := models.FromGoalEntity(goal)
+	if err != nil {
+		return err
+	}
+	query := `INSERT INTO goals (user_id, title, achievement_type_id, achievement_params, attributes, invert) VALUES (?, ?, ?, ?, ?, ?)`
+	result, err := exec.ExecContext(ctx, query, model.UserID, model.Title, model.AchievementTypeID, model.AchievementParams, model.Attributes, model.Invert)
+	if err != nil {
+		return err
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return err
+	}
+	goal.ID = int(id)
+	return nil
+}
+
+func (r *goalRepository) Update(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	model, err := models.FromGoalEntity(goal)
+	if err != nil {
+		return err
+	}
+	query := `UPDATE goals SET title = ?, achievement_type_id = ?, achievement_params = ?, attributes = ?, invert = ? WHERE id = ? AND user_id = ?`
+	result, err := exec.ExecContext(ctx, query, model.Title, model.AchievementTypeID, model.AchievementParams, model.Attributes, model.Invert, model.ID, model.UserID)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (r *goalRepository) Delete(ctx context.Context, exec repository.Executor, id int, userID int) error {
+	query := `DELETE FROM goals WHERE id = ? AND user_id = ?`
+	result, err := exec.ExecContext(ctx, query, id, userID)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (r *goalRepository) CountByUserID(ctx context.Context, exec repository.Executor, userID int) (int, error) {
+	var count int
+	query := `SELECT COUNT(*) FROM goals WHERE user_id = ?`
+	if err := exec.GetContext(ctx, &count, query, userID); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (r *goalRepository) LockUser(ctx context.Context, exec repository.Executor, userID int) error {
+	var id int
+	query := `SELECT id FROM users WHERE id = ? FOR UPDATE`
+	if err := exec.GetContext(ctx, &id, query, userID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/usecase/errors.go
+++ b/internal/usecase/errors.go
@@ -36,5 +36,9 @@ var (
 	ErrAdminRequired = errors.New("admin permission required") // ADMIN権限が必要
 
 	// アプリバージョン関連エラー
-	ErrAppVersionUnsupported = errors.New("unsupported app version") // 対応していないアプリバージョン
+	ErrAppVersionUnsupported  = errors.New("unsupported app version") // 対応していないアプリバージョン
+	ErrGoalNotFound           = errors.New("goal not found")
+	ErrGoalLimitExceeded      = errors.New("goal limit exceeded")
+	ErrInvalidAchievementType = errors.New("invalid achievement type")
+	ErrInvalidGoalRequest     = errors.New("invalid goal request")
 )

--- a/internal/usecase/goal_usecase.go
+++ b/internal/usecase/goal_usecase.go
@@ -1,0 +1,279 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math"
+	"strings"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
+	"github.com/chunisupport/chunisupport-api/internal/info"
+)
+
+// GoalUsecase は目標機能のユースケースです。
+type GoalUsecase interface {
+	List(ctx context.Context, userID int) ([]*api_internal.GoalDTO, error)
+	Create(ctx context.Context, userID int, req *api_internal.UpsertGoalRequestDTO) (*api_internal.GoalDTO, error)
+	Update(ctx context.Context, userID int, id int, req *api_internal.UpsertGoalRequestDTO) error
+	Delete(ctx context.Context, userID int, id int) error
+}
+
+type goalService struct {
+	db      repository.Executor
+	tm      TransactionManager
+	repo    repository.GoalRepository
+	masters *domainmasterdata.GoalMasters
+}
+
+func NewGoalService(db repository.Executor, tm TransactionManager, repo repository.GoalRepository, masters *domainmasterdata.GoalMasters) GoalUsecase {
+	return &goalService{db: db, tm: tm, repo: repo, masters: masters}
+}
+
+func (s *goalService) List(ctx context.Context, userID int) ([]*api_internal.GoalDTO, error) {
+	goals, err := s.repo.FindByUserID(ctx, s.db, userID)
+	if err != nil {
+		return nil, err
+	}
+	return api_internal.ToGoalDTOs(goals, s.masters.AchievementTypesByID), nil
+}
+
+func (s *goalService) Create(ctx context.Context, userID int, req *api_internal.UpsertGoalRequestDTO) (*api_internal.GoalDTO, error) {
+	var created *api_internal.GoalDTO
+	err := s.tm.Transactional(ctx, func(tx repository.Executor) error {
+		if err := s.repo.LockUser(ctx, tx, userID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrUserNotFound
+			}
+			return err
+		}
+		count, err := s.repo.CountByUserID(ctx, tx, userID)
+		if err != nil {
+			return err
+		}
+		if count >= info.GoalLimitPerUser {
+			return ErrGoalLimitExceeded
+		}
+		goal, err := s.buildGoal(userID, req)
+		if err != nil {
+			return err
+		}
+		if err := s.repo.Create(ctx, tx, goal); err != nil {
+			return err
+		}
+		stored, err := s.repo.FindByIDAndUserID(ctx, tx, goal.ID, userID)
+		if err != nil {
+			return err
+		}
+		created = api_internal.ToGoalDTO(stored, s.masters.AchievementTypesByID)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+func (s *goalService) Update(ctx context.Context, userID int, id int, req *api_internal.UpsertGoalRequestDTO) error {
+	goal, err := s.buildGoal(userID, req)
+	if err != nil {
+		return err
+	}
+	goal.ID = id
+	if err := s.repo.Update(ctx, s.db, goal); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrGoalNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *goalService) Delete(ctx context.Context, userID int, id int) error {
+	if err := s.repo.Delete(ctx, s.db, id, userID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrGoalNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *goalService) buildGoal(userID int, req *api_internal.UpsertGoalRequestDTO) (*entity.Goal, error) {
+	title := strings.TrimSpace(req.Title)
+	if title == "" || len([]rune(title)) > 30 {
+		return nil, ErrInvalidGoalRequest
+	}
+	ach, ok := s.masters.AchievementTypesByCode[req.AchievementType]
+	if !ok {
+		return nil, ErrInvalidAchievementType
+	}
+	if err := s.validateAttributes(req.Attributes); err != nil {
+		return nil, err
+	}
+	if err := s.validateAchievement(req.AchievementType, req.AchievementParams, req.Attributes); err != nil {
+		return nil, err
+	}
+	return &entity.Goal{
+		UserID:            userID,
+		Title:             title,
+		AchievementTypeID: ach.ID,
+		AchievementParams: req.AchievementParams,
+		Attributes:        req.Attributes,
+		Invert:            req.Invert,
+	}, nil
+}
+
+func (s *goalService) validateAttributes(attrs map[string]any) error {
+	if attrs == nil {
+		return nil
+	}
+	if diffValue, ok := attrs["diff"]; ok {
+		diff, ok := toInt(diffValue)
+		if !ok || diff < 1 || diff > 5 {
+			return ErrInvalidGoalRequest
+		}
+	}
+	if genreValue, ok := attrs["genre"]; ok {
+		genreID, ok := toInt(genreValue)
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		if _, exists := s.masters.GenresByID[genreID]; !exists {
+			return ErrInvalidGoalRequest
+		}
+	}
+	if versionValue, ok := attrs["ver"]; ok {
+		versionID, ok := toInt(versionValue)
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		if _, exists := s.masters.VersionsByID[versionID]; !exists {
+			return ErrInvalidGoalRequest
+		}
+	}
+	if constValue, ok := attrs["const"]; ok {
+		obj, ok := constValue.(map[string]any)
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		minValue, ok := toFloat(obj["min"])
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		maxValue, ok := toFloat(obj["max"])
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		if minValue < info.ChartConstMin || maxValue > info.ChartConstMax || minValue > maxValue {
+			return ErrInvalidGoalRequest
+		}
+	}
+	return nil
+}
+
+func (s *goalService) validateAchievement(kind string, params map[string]any, attrs map[string]any) error {
+	if params == nil {
+		return ErrInvalidGoalRequest
+	}
+	switch kind {
+	case "rank_count", "score_count":
+		score, ok := toInt(params["score"])
+		if !ok || score < 0 || score > 1010000 {
+			return ErrInvalidGoalRequest
+		}
+		count, ok := toInt(params["count"])
+		if !ok || count < 1 {
+			return ErrInvalidGoalRequest
+		}
+	case "avg_score":
+		score, ok := toInt(params["score"])
+		if !ok || score < 0 || score > 1010000 {
+			return ErrInvalidGoalRequest
+		}
+	case "hardlamp_count":
+		lamp, ok := params["lamp"].(string)
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		name, ok := info.HardLampAbbrevToName[lamp]
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		if _, ok := s.masters.ClearLampsByName[name]; !ok {
+			return ErrInvalidGoalRequest
+		}
+		count, ok := toInt(params["count"])
+		if !ok || count < 1 {
+			return ErrInvalidGoalRequest
+		}
+	case "combolamp_count":
+		lamp, ok := params["lamp"].(string)
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		name, ok := info.ComboLampAbbrevToName[lamp]
+		if !ok {
+			return ErrInvalidGoalRequest
+		}
+		if _, ok := s.masters.ComboLampsByName[name]; !ok {
+			return ErrInvalidGoalRequest
+		}
+		count, ok := toInt(params["count"])
+		if !ok || count < 1 {
+			return ErrInvalidGoalRequest
+		}
+	case "total_score":
+		total, ok := toInt(params["total"])
+		if !ok || total < 0 {
+			return ErrInvalidGoalRequest
+		}
+	case "overpower_value":
+		total, ok := toFloat(params["total"])
+		if !ok || total < 0 || roundDigits(total, 3) != total {
+			return ErrInvalidGoalRequest
+		}
+	case "overpower_percent":
+		total, ok := toFloat(params["total"])
+		if !ok || total < 0 || total > 100 || roundDigits(total, 2) != total {
+			return ErrInvalidGoalRequest
+		}
+	default:
+		return ErrInvalidAchievementType
+	}
+	_ = attrs
+	return nil
+}
+
+func toInt(v any) (int, bool) {
+	switch t := v.(type) {
+	case int:
+		return t, true
+	case float64:
+		if math.Trunc(t) != t {
+			return 0, false
+		}
+		return int(t), true
+	default:
+		return 0, false
+	}
+}
+
+func toFloat(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case int:
+		return float64(t), true
+	default:
+		return 0, false
+	}
+}
+
+func roundDigits(v float64, digits int) float64 {
+	pow := math.Pow10(digits)
+	return math.Round(v*pow) / pow
+}

--- a/internal/usecase/goal_usecase_test.go
+++ b/internal/usecase/goal_usecase_test.go
@@ -1,0 +1,93 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
+)
+
+type mockGoalRepo struct {
+	goals []*entity.Goal
+}
+
+func (m *mockGoalRepo) FindByUserID(ctx context.Context, exec repository.Executor, userID int) ([]*entity.Goal, error) {
+	return m.goals, nil
+}
+func (m *mockGoalRepo) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id int, userID int) (*entity.Goal, error) {
+	for _, goal := range m.goals {
+		if goal.ID == id && goal.UserID == userID {
+			return goal, nil
+		}
+	}
+	return nil, nil
+}
+func (m *mockGoalRepo) Create(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	goal.ID = len(m.goals) + 1
+	goal.CreatedAt = time.Now()
+	m.goals = append(m.goals, goal)
+	return nil
+}
+func (m *mockGoalRepo) Update(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	return nil
+}
+func (m *mockGoalRepo) Delete(ctx context.Context, exec repository.Executor, id int, userID int) error {
+	return nil
+}
+func (m *mockGoalRepo) CountByUserID(ctx context.Context, exec repository.Executor, userID int) (int, error) {
+	return len(m.goals), nil
+}
+func (m *mockGoalRepo) LockUser(ctx context.Context, exec repository.Executor, userID int) error {
+	return nil
+}
+
+type passthroughTM struct{ exec repository.Executor }
+
+func (m *passthroughTM) Transactional(ctx context.Context, f func(tx repository.Executor) error) error {
+	return f(m.exec)
+}
+
+func newGoalMasters() *domainmasterdata.GoalMasters {
+	return &domainmasterdata.GoalMasters{
+		AchievementTypesByCode: map[string]domainmasterdata.Item{"score_count": {ID: 2, Name: "score_count"}},
+		AchievementTypesByID:   map[int]string{2: "score_count"},
+		GenresByID:             map[int]domainmasterdata.Item{1: {ID: 1, Name: "POPS"}},
+		VersionsByID:           map[int]domainmasterdata.Version{1: {ID: 1, Name: "LUMINOUS"}},
+		ClearLampsByName:       map[string]domainmasterdata.Item{"HARD": {ID: 1, Name: "HARD"}},
+		ComboLampsByName:       map[string]domainmasterdata.Item{"FULL COMBO": {ID: 1, Name: "FULL COMBO"}},
+	}
+}
+
+func TestGoalCreate(t *testing.T) {
+	repo := &mockGoalRepo{}
+	uc := NewGoalService(nil, &passthroughTM{}, repo, newGoalMasters())
+	goal, err := uc.Create(context.Background(), 1, &dto_internal.UpsertGoalRequestDTO{
+		Title:             "目標",
+		AchievementType:   "score_count",
+		AchievementParams: map[string]any{"score": 1000000, "count": 1},
+		Attributes:        map[string]any{"diff": 4},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if goal.ID == 0 {
+		t.Fatalf("created goal id should not be zero")
+	}
+}
+
+func TestGoalCreateInvalidAchievementType(t *testing.T) {
+	repo := &mockGoalRepo{}
+	uc := NewGoalService(nil, &passthroughTM{}, repo, newGoalMasters())
+	_, err := uc.Create(context.Background(), 1, &dto_internal.UpsertGoalRequestDTO{
+		Title:             "目標",
+		AchievementType:   "invalid",
+		AchievementParams: map[string]any{"score": 1000000, "count": 1},
+	})
+	if err == nil {
+		t.Fatalf("Create() should return error")
+	}
+}

--- a/migration/mysql/000005_add_goals.down.sql
+++ b/migration/mysql/000005_add_goals.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS goals;
+DROP TABLE IF EXISTS achievement_types;

--- a/migration/mysql/000005_add_goals.up.sql
+++ b/migration/mysql/000005_add_goals.up.sql
@@ -1,0 +1,31 @@
+CREATE TABLE achievement_types (
+  id   TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  code VARCHAR(30)  NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_achievement_types_code (code)
+);
+
+INSERT INTO achievement_types (code) VALUES
+  ('rank_count'),
+  ('score_count'),
+  ('avg_score'),
+  ('hardlamp_count'),
+  ('combolamp_count'),
+  ('total_score'),
+  ('overpower_value'),
+  ('overpower_percent');
+
+CREATE TABLE goals (
+  id                   INT UNSIGNED     NOT NULL AUTO_INCREMENT,
+  user_id              INT UNSIGNED     NOT NULL,
+  title                VARCHAR(30)      NOT NULL,
+  achievement_type_id  TINYINT UNSIGNED NOT NULL,
+  achievement_params   JSON             NOT NULL,
+  attributes           JSON             NOT NULL,
+  invert               BOOLEAN          NOT NULL DEFAULT FALSE,
+  created_at           DATETIME         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_goals_user_id (user_id),
+  CONSTRAINT fk_goals_user_id             FOREIGN KEY (user_id)             REFERENCES users             (id) ON DELETE CASCADE,
+  CONSTRAINT fk_goals_achievement_type_id FOREIGN KEY (achievement_type_id) REFERENCES achievement_types (id) ON DELETE RESTRICT
+);


### PR DESCRIPTION
### Motivation
- `internal/info/info.go` の `MigrationDir` が `migration/mysql/` を参照しているため、SQLite向けの `000005_add_goals` マイグレーションが不要であり混乱を避けるため削除しました。

### Description
- `migration/sqlite/000005_add_goals.up.sql` と `migration/sqlite/000005_add_goals.down.sql` を削除しました。

### Testing
- `gofmt -w internal/usecase/goal_usecase.go internal/app/router.go` を実行しコード整形を行ったうえで、`go test ./...` を実行して全テストが成功することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997cfdf0744832d81f0d0acc6fcc466)