### PR TITLE
feat: 目標機能の新規実装（MySQLマイグレーション含む）

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1991,7 +1991,7 @@ interface SkippedRecord {
 
 ### POST `/internal/me/goals`
 
-目標を作成します。`achievement_type` と `achievement_params` の組み合わせはサーバー側で検証します。
+目標を作成します。`achievement_type` と `achievement_params` の組み合わせはサーバー側で検証します。`overpower_percent` の `achievement_params.total` は割合ではなく実数値（0以上・小数3桁まで）として扱います。
 
 ### PUT `/internal/me/goals/:id`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -101,6 +101,10 @@
 | `/internal/me/player-data` | DELETE | Cookie | プレイヤー連携を解除し、プレイヤー関連レコードを削除。 |
 | `/internal/me/sessions` | GET | Cookie | 有効なセッション数を取得。 |
 | `/internal/me/sessions` | DELETE | Cookie | 現在のセッション以外をすべてログアウト。 |
+| `/internal/me/goals` | GET | Cookie | 目標一覧を取得。 |
+| `/internal/me/goals` | POST | Cookie | 目標を作成。 |
+| `/internal/me/goals/:id` | PUT | Cookie | 目標を更新。 |
+| `/internal/me/goals/:id` | DELETE | Cookie | 目標を削除。 |
 | `/internal/users/` | GET | Cookie (ADMIN+) | 全ユーザー一覧取得（プライベート・削除済み・プレイヤー未紐付けを含む）。 |
 | `/internal/users/:username` | GET | Cookie (任意) | プロファイルとレコードを一括取得。 |
 | `/internal/users/:username` | DELETE | Cookie (ADMIN+) | ユーザーの論理削除。 |
@@ -1280,6 +1284,9 @@ curl -X POST \
 ## `/internal/master` グループ
 
 ### GET `/internal/master`
+
+レスポンスに `achievement_types` が追加されます。
+
 - **認証**: Cookie 必須
 - **概要**: フロントエンド向けにマスタデータ（ジャンル、難易度、アカウント種別、バージョン）を返却します。
 - **レスポンス**: 200 OK
@@ -1976,3 +1983,20 @@ interface SkippedRecord {
 - `.env` の `JWT_SECRET` と `PW_PEPPER` は32文字以上の強度を推奨します。
 - CORSの許可オリジンやCookie属性は環境ごとに設定ファイルで管理します。
 - ユーザーを論理削除するとログインは失敗し、既存セッションも無効化されます。
+
+
+### GET `/internal/me/goals`
+
+`{ "goals": Goal[] }` を返します。
+
+### POST `/internal/me/goals`
+
+目標を作成します。`achievement_type` と `achievement_params` の組み合わせはサーバー側で検証します。
+
+### PUT `/internal/me/goals/:id`
+
+指定IDの目標を更新します。
+
+### DELETE `/internal/me/goals/:id`
+
+指定IDの目標を削除します。

--- a/internal/app/apierror/api_error.go
+++ b/internal/app/apierror/api_error.go
@@ -103,6 +103,10 @@ var (
 	ErrPasswordTooLong       = New(CodePasswordTooLong, http.StatusBadRequest)
 	ErrInvalidPassword       = New(CodeInvalidPassword, http.StatusBadRequest)       // パスワード無効（詳細隠蔽）
 	ErrAppVersionUnsupported = New(CodeAppVersionUnsupported, http.StatusBadRequest) // 対応していないアプリバージョン
+
+	ErrGoalNotFound      = New(CodeGoalNotFound, http.StatusNotFound)
+	ErrGoalLimitExceeded = New(CodeGoalLimitExceeded, http.StatusBadRequest)
+	ErrInvalidGoalInput  = New(CodeInvalidGoalInput, http.StatusBadRequest)
 )
 
 // ErrorResponse はエラーレスポンスの構造体です

--- a/internal/app/apierror/codes.go
+++ b/internal/app/apierror/codes.go
@@ -54,4 +54,9 @@ const (
 	CodePasswordTooLong       = "password_too_long"
 	CodeInvalidPassword       = "invalid_password"        // パスワードが無効（詳細を隠蔽）
 	CodeAppVersionUnsupported = "app_version_unsupported" // 対応していないアプリバージョン
+
+	// 目標関連エラー
+	CodeGoalNotFound      = "goal_not_found"
+	CodeGoalLimitExceeded = "goal_limit_exceeded"
+	CodeInvalidGoalInput  = "invalid_goal_input"
 )

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -73,6 +73,12 @@ func FromUsecaseError(err error) *APIError {
 	// アプリバージョンバリデーションエラー
 	case errors.Is(err, usecase.ErrAppVersionUnsupported):
 		return ErrAppVersionUnsupported.WithInternal(err)
+	case errors.Is(err, usecase.ErrGoalNotFound):
+		return ErrGoalNotFound.WithInternal(err)
+	case errors.Is(err, usecase.ErrGoalLimitExceeded):
+		return ErrGoalLimitExceeded.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidGoalInput), errors.Is(err, usecase.ErrInvalidGoalTitle), errors.Is(err, usecase.ErrInvalidAchievementType), errors.Is(err, usecase.ErrInvalidAchievementParam), errors.Is(err, usecase.ErrInvalidGoalAttributes):
+		return ErrInvalidGoalInput.WithInternal(err)
 	}
 
 	// PlayerDataValidationError

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -44,6 +44,8 @@ func FromUsecaseError(err error) *APIError {
 		return ErrOperationFailed.WithInternal(err) // 409 → 400 で詳細を隠蔽
 	case errors.Is(err, usecase.ErrOperationFailed):
 		return ErrOperationFailed.WithInternal(err)
+	case errors.Is(err, usecase.ErrInternalError):
+		return ErrInternalError.WithInternal(err)
 	case errors.Is(err, usecase.ErrAdminRequired):
 		return ErrForbidden.WithInternal(err)
 	case errors.Is(err, usecase.ErrInvalidAPIToken):

--- a/internal/app/handler/api_internal/goal_handler.go
+++ b/internal/app/handler/api_internal/goal_handler.go
@@ -23,9 +23,9 @@ func NewGoalHandler(goalUsecase usecase.GoalUsecase) *GoalHandler {
 }
 
 func (h *GoalHandler) List(c echo.Context) error {
-	user, ok := c.Get("userEntity").(*entity.User)
-	if !ok || user == nil {
-		return apierror.ErrUnauthorized
+	user, err := getUser(c)
+	if err != nil {
+		return err
 	}
 	goals, err := h.goalUsecase.List(c.Request().Context(), user.ID)
 	if err != nil {
@@ -39,9 +39,9 @@ func (h *GoalHandler) List(c echo.Context) error {
 }
 
 func (h *GoalHandler) Create(c echo.Context) error {
-	user, ok := c.Get("userEntity").(*entity.User)
-	if !ok || user == nil {
-		return apierror.ErrUnauthorized
+	user, err := getUser(c)
+	if err != nil {
+		return err
 	}
 	var req internaldto.GoalRequest
 	if err := c.Bind(&req); err != nil {
@@ -62,9 +62,9 @@ func (h *GoalHandler) Create(c echo.Context) error {
 }
 
 func (h *GoalHandler) Update(c echo.Context) error {
-	user, ok := c.Get("userEntity").(*entity.User)
-	if !ok || user == nil {
-		return apierror.ErrUnauthorized
+	user, err := getUser(c)
+	if err != nil {
+		return err
 	}
 	id64, err := strconv.ParseUint(c.Param("id"), 10, 32)
 	if err != nil {
@@ -89,9 +89,9 @@ func (h *GoalHandler) Update(c echo.Context) error {
 }
 
 func (h *GoalHandler) Delete(c echo.Context) error {
-	user, ok := c.Get("userEntity").(*entity.User)
-	if !ok || user == nil {
-		return apierror.ErrUnauthorized
+	user, err := getUser(c)
+	if err != nil {
+		return err
 	}
 	id64, err := strconv.ParseUint(c.Param("id"), 10, 32)
 	if err != nil {
@@ -116,6 +116,14 @@ func toGoalInput(req *internaldto.GoalRequest) (*usecase.GoalInput, error) {
 		}
 	}
 	return &usecase.GoalInput{Title: req.Title, AchievementType: req.AchievementType, AchievementParams: params, Attributes: attrs, Invert: req.Invert}, nil
+}
+
+func getUser(c echo.Context) (*entity.User, error) {
+	user, ok := c.Get("userEntity").(*entity.User)
+	if !ok || user == nil {
+		return nil, apierror.ErrUnauthorized
+	}
+	return user, nil
 }
 
 func toGoalResponse(goal *usecase.GoalOutput) *internaldto.GoalResponse {

--- a/internal/app/handler/api_internal/goal_handler.go
+++ b/internal/app/handler/api_internal/goal_handler.go
@@ -66,7 +66,7 @@ func (h *GoalHandler) Update(c echo.Context) error {
 	if !ok || user == nil {
 		return apierror.ErrUnauthorized
 	}
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	id64, err := strconv.ParseUint(c.Param("id"), 10, 32)
 	if err != nil {
 		return apierror.ErrBadRequest.WithInternal(err)
 	}
@@ -81,7 +81,7 @@ func (h *GoalHandler) Update(c echo.Context) error {
 	if err != nil {
 		return apierror.ErrValidationFailed.WithInternal(err)
 	}
-	goal, err := h.goalUsecase.Update(c.Request().Context(), user.ID, id, in)
+	goal, err := h.goalUsecase.Update(c.Request().Context(), user.ID, uint32(id64), in)
 	if err != nil {
 		return apierror.FromUsecaseError(err)
 	}
@@ -93,11 +93,11 @@ func (h *GoalHandler) Delete(c echo.Context) error {
 	if !ok || user == nil {
 		return apierror.ErrUnauthorized
 	}
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	id64, err := strconv.ParseUint(c.Param("id"), 10, 32)
 	if err != nil {
 		return apierror.ErrBadRequest.WithInternal(err)
 	}
-	if err := h.goalUsecase.Delete(c.Request().Context(), user.ID, id); err != nil {
+	if err := h.goalUsecase.Delete(c.Request().Context(), user.ID, uint32(id64)); err != nil {
 		return apierror.FromUsecaseError(err)
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/app/handler/api_internal/goal_handler.go
+++ b/internal/app/handler/api_internal/goal_handler.go
@@ -1,0 +1,131 @@
+package api_internal
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	internaldto "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
+	"github.com/chunisupport/chunisupport-api/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+// GoalHandler は目標APIを扱います。
+type GoalHandler struct {
+	goalUsecase usecase.GoalUsecase
+}
+
+// NewGoalHandler は GoalHandler を生成します。
+func NewGoalHandler(goalUsecase usecase.GoalUsecase) *GoalHandler {
+	return &GoalHandler{goalUsecase: goalUsecase}
+}
+
+func (h *GoalHandler) List(c echo.Context) error {
+	user, ok := c.Get("userEntity").(*entity.User)
+	if !ok || user == nil {
+		return apierror.ErrUnauthorized
+	}
+	goals, err := h.goalUsecase.List(c.Request().Context(), user.ID)
+	if err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	items := make([]*internaldto.GoalResponse, 0, len(goals))
+	for _, g := range goals {
+		items = append(items, toGoalResponse(g))
+	}
+	return c.JSON(http.StatusOK, &internaldto.GoalsResponse{Goals: items})
+}
+
+func (h *GoalHandler) Create(c echo.Context) error {
+	user, ok := c.Get("userEntity").(*entity.User)
+	if !ok || user == nil {
+		return apierror.ErrUnauthorized
+	}
+	var req internaldto.GoalRequest
+	if err := c.Bind(&req); err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	if err := c.Validate(&req); err != nil {
+		return err
+	}
+	in, err := toGoalInput(&req)
+	if err != nil {
+		return apierror.ErrValidationFailed.WithInternal(err)
+	}
+	goal, err := h.goalUsecase.Create(c.Request().Context(), user.ID, in)
+	if err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	return c.JSON(http.StatusCreated, toGoalResponse(goal))
+}
+
+func (h *GoalHandler) Update(c echo.Context) error {
+	user, ok := c.Get("userEntity").(*entity.User)
+	if !ok || user == nil {
+		return apierror.ErrUnauthorized
+	}
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	var req internaldto.GoalRequest
+	if err := c.Bind(&req); err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	if err := c.Validate(&req); err != nil {
+		return err
+	}
+	in, err := toGoalInput(&req)
+	if err != nil {
+		return apierror.ErrValidationFailed.WithInternal(err)
+	}
+	goal, err := h.goalUsecase.Update(c.Request().Context(), user.ID, id, in)
+	if err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	return c.JSON(http.StatusOK, toGoalResponse(goal))
+}
+
+func (h *GoalHandler) Delete(c echo.Context) error {
+	user, ok := c.Get("userEntity").(*entity.User)
+	if !ok || user == nil {
+		return apierror.ErrUnauthorized
+	}
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	if err := h.goalUsecase.Delete(c.Request().Context(), user.ID, id); err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func toGoalInput(req *internaldto.GoalRequest) (*usecase.GoalInput, error) {
+	params, err := json.Marshal(req.AchievementParams)
+	if err != nil {
+		return nil, err
+	}
+	attrs := []byte("{}")
+	if req.Attributes != nil {
+		attrs, err = json.Marshal(req.Attributes)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &usecase.GoalInput{Title: req.Title, AchievementType: req.AchievementType, AchievementParams: params, Attributes: attrs, Invert: req.Invert}, nil
+}
+
+func toGoalResponse(goal *usecase.GoalOutput) *internaldto.GoalResponse {
+	return &internaldto.GoalResponse{
+		ID:                goal.ID,
+		Title:             goal.Title,
+		AchievementType:   goal.AchievementType,
+		AchievementParams: goal.AchievementParams,
+		Attributes:        goal.Attributes,
+		Invert:            goal.Invert,
+		CreatedAt:         goal.CreatedAt,
+	}
+}

--- a/internal/app/handler/api_internal/master_data_handler.go
+++ b/internal/app/handler/api_internal/master_data_handler.go
@@ -88,12 +88,19 @@ func (h *MasterDataHandler) GetMasterData(c echo.Context) error {
 		})
 	}
 
+	achievementTypes := make([]*dto.MasterItemDTO, 0, len(h.masterCache.AchievementTypes))
+	for _, item := range h.masterCache.AchievementTypes {
+		achievementTypes = append(achievementTypes, &dto.MasterItemDTO{ID: item.ID, Name: item.Name})
+	}
+	sortMasterItemsByID(achievementTypes)
+
 	response := &dto.MasterDataResponse{
-		Genres:       genres,
-		Difficulties: difficulties,
-		AccountTypes: accountTypes,
-		Versions:     versions,
-		RatingBands:  ratingBands,
+		Genres:           genres,
+		Difficulties:     difficulties,
+		AccountTypes:     accountTypes,
+		Versions:         versions,
+		RatingBands:      ratingBands,
+		AchievementTypes: achievementTypes,
 	}
 
 	return c.JSON(http.StatusOK, response)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -58,6 +58,7 @@ type Handlers struct {
 	Me         *api_internal.MeHandler
 	MasterData *api_internal.MasterDataHandler
 	Session    *api_internal.SessionHandler
+	Goal       *api_internal.GoalHandler
 	// 外部API v1 用ハンドラ
 	V1Song      *api_v1.V1SongHandler
 	V1Worldsend *api_v1.V1WorldsendHandler
@@ -121,6 +122,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	apiTokenRepo := infra.NewAPITokenRepository(db)
 	recoveryCodeRepo := infra.NewRecoveryCodeRepository(db)
 	songRepo := infra.NewSongRepository(db)
+	goalRepo := infra.NewGoalRepository(db)
 	honorRepo := infra.NewHonorRepository(db)
 	tm := transaction.NewTransactionManager(db)
 	authUsecase := usecase.NewAuthService(db, tm, userRepo, sessionRepo, recoveryCodeRepo, playerRecordRepo, cfg.JWTSecret, cfg.Auth.JWTExpirationHour, cfg.Auth.SessionExpirationHour, cfg.PwPepper, masterCache)
@@ -139,6 +141,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	chartStatsUsecase := usecase.NewChartStatsUsecase(songRepo, worldsendChartRepo, chartStatsRepo, masterCache, chartStatsMasterProvider, db, staticDB)
 	worldsendUsecase := usecase.NewWorldsendUsecase(worldsendChartRepo, tm, db)
 	sessionUsecase := usecase.NewSessionUsecase(sessionRepo, db)
+	goalUsecase := usecase.NewGoalUsecase(db, tm, goalRepo, masterCache)
 
 	// DI - Handlers
 	sameSite := parseSameSite(cfg.Auth.CookieSameSite)
@@ -152,6 +155,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 		Me:         api_internal.NewMeHandler(playerDataUsecase),
 		MasterData: api_internal.NewMasterDataHandler(masterCache, staticMasterCache),
 		Session:    api_internal.NewSessionHandler(sessionUsecase),
+		Goal:       api_internal.NewGoalHandler(goalUsecase),
 		// 外部API v1 用ハンドラ
 		V1Song:      api_v1.NewV1SongHandler(songUsecase, chartStatsUsecase, masterCache, staticMasterCache),
 		V1Worldsend: api_v1.NewV1WorldsendHandler(worldsendUsecase, masterCache),
@@ -233,6 +237,10 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authUsecase usecase.AuthUs
 		// セッション管理
 		meGroup.GET("/sessions", handlers.Session.GetSessionCount)
 		meGroup.DELETE("/sessions", handlers.Session.LogoutOtherSessions)
+		meGroup.GET("/goals", handlers.Goal.List)
+		meGroup.POST("/goals", handlers.Goal.Create)
+		meGroup.PUT("/goals/:id", handlers.Goal.Update)
+		meGroup.DELETE("/goals/:id", handlers.Goal.Delete)
 	}
 
 	// api.chunisupport.net/internal/users

--- a/internal/domain/entity/goal.go
+++ b/internal/domain/entity/goal.go
@@ -1,0 +1,16 @@
+package entity
+
+import "time"
+
+// Goal はユーザーが設定する目標を表します。
+type Goal struct {
+	ID                int64
+	UserID            int
+	Title             string
+	AchievementTypeID int
+	AchievementType   string
+	AchievementParams []byte
+	Attributes        []byte
+	Invert            bool
+	CreatedAt         time.Time
+}

--- a/internal/domain/entity/goal.go
+++ b/internal/domain/entity/goal.go
@@ -4,7 +4,7 @@ import "time"
 
 // Goal はユーザーが設定する目標を表します。
 type Goal struct {
-	ID                int64
+	ID                uint32
 	UserID            int
 	Title             string
 	AchievementTypeID int

--- a/internal/domain/masterdata/masterdata.go
+++ b/internal/domain/masterdata/masterdata.go
@@ -49,6 +49,7 @@ type SongMasters struct {
 type GoalMasters struct {
 	AchievementTypesByCode map[string]Item
 	AchievementTypesByID   map[int]string
+	DifficultyNamesByID    map[int]string
 	GenreNamesByID         map[int]string
 	VersionsByID           map[int]Version
 	ClearLampNamesByID     map[int]string

--- a/internal/domain/masterdata/masterdata.go
+++ b/internal/domain/masterdata/masterdata.go
@@ -44,3 +44,13 @@ type SongMasters struct {
 	GenreNamesByID map[int]string
 	Difficulties   map[string]Item
 }
+
+// GoalMasters は目標機能で必要になるマスタ集合です。
+type GoalMasters struct {
+	AchievementTypesByCode map[string]Item
+	AchievementTypesByID   map[int]string
+	GenreNamesByID         map[int]string
+	VersionsByID           map[int]Version
+	ClearLampNamesByID     map[int]string
+	ComboLampNamesByID     map[int]string
+}

--- a/internal/domain/repository/goal_repository.go
+++ b/internal/domain/repository/goal_repository.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+)
+
+// GoalRepository は目標の永続化を扱います。
+type GoalRepository interface {
+	ListByUserID(ctx context.Context, exec Executor, userID int) ([]*entity.Goal, error)
+	FindByIDAndUserID(ctx context.Context, exec Executor, id int64, userID int) (*entity.Goal, error)
+	Create(ctx context.Context, exec Executor, goal *entity.Goal) error
+	Update(ctx context.Context, exec Executor, goal *entity.Goal) error
+	DeleteByIDAndUserID(ctx context.Context, exec Executor, id int64, userID int) error
+	CountByUserID(ctx context.Context, exec Executor, userID int) (int, error)
+	LockUserByID(ctx context.Context, exec Executor, userID int) error
+}

--- a/internal/domain/repository/goal_repository.go
+++ b/internal/domain/repository/goal_repository.go
@@ -9,10 +9,10 @@ import (
 // GoalRepository は目標の永続化を扱います。
 type GoalRepository interface {
 	ListByUserID(ctx context.Context, exec Executor, userID int) ([]*entity.Goal, error)
-	FindByIDAndUserID(ctx context.Context, exec Executor, id int64, userID int) (*entity.Goal, error)
+	FindByIDAndUserID(ctx context.Context, exec Executor, id uint32, userID int) (*entity.Goal, error)
 	Create(ctx context.Context, exec Executor, goal *entity.Goal) error
 	Update(ctx context.Context, exec Executor, goal *entity.Goal) error
-	DeleteByIDAndUserID(ctx context.Context, exec Executor, id int64, userID int) error
+	DeleteByIDAndUserID(ctx context.Context, exec Executor, id uint32, userID int) error
 	CountByUserID(ctx context.Context, exec Executor, userID int) (int, error)
 	LockUserByID(ctx context.Context, exec Executor, userID int) error
 }

--- a/internal/domain/repository/master_data_provider.go
+++ b/internal/domain/repository/master_data_provider.go
@@ -28,3 +28,8 @@ type AccountTypeMasterProvider interface {
 type ChartStatsMasterProvider interface {
 	RatingBands() []*entity.RatingBand
 }
+
+// GoalMasterProvider は目標機能で必要なマスタデータを提供します。
+type GoalMasterProvider interface {
+	GoalMasters() *masterdata.GoalMasters
+}

--- a/internal/dto/api_internal/goal_dto.go
+++ b/internal/dto/api_internal/goal_dto.go
@@ -11,7 +11,7 @@ type GoalRequest struct {
 
 // GoalResponse は目標レスポンスです。
 type GoalResponse struct {
-	ID                int64          `json:"id"`
+	ID                uint32         `json:"id"`
 	Title             string         `json:"title"`
 	AchievementType   string         `json:"achievement_type"`
 	AchievementParams map[string]any `json:"achievement_params"`

--- a/internal/dto/api_internal/goal_dto.go
+++ b/internal/dto/api_internal/goal_dto.go
@@ -1,0 +1,26 @@
+package api_internal
+
+// GoalRequest は目標作成・更新リクエストです。
+type GoalRequest struct {
+	Title             string         `json:"title" validate:"required"`
+	AchievementType   string         `json:"achievement_type" validate:"required"`
+	AchievementParams map[string]any `json:"achievement_params" validate:"required"`
+	Attributes        map[string]any `json:"attributes"`
+	Invert            bool           `json:"invert"`
+}
+
+// GoalResponse は目標レスポンスです。
+type GoalResponse struct {
+	ID                int64          `json:"id"`
+	Title             string         `json:"title"`
+	AchievementType   string         `json:"achievement_type"`
+	AchievementParams map[string]any `json:"achievement_params"`
+	Attributes        map[string]any `json:"attributes"`
+	Invert            bool           `json:"invert"`
+	CreatedAt         string         `json:"created_at"`
+}
+
+// GoalsResponse は目標一覧レスポンスです。
+type GoalsResponse struct {
+	Goals []*GoalResponse `json:"goals"`
+}

--- a/internal/dto/master_data_dto.go
+++ b/internal/dto/master_data_dto.go
@@ -15,11 +15,12 @@ type VersionDTO struct {
 
 // MasterDataResponse はマスタデータ取得APIのレスポンスを表します。
 type MasterDataResponse struct {
-	Genres       []*MasterItemDTO `json:"genres"`
-	Difficulties []*MasterItemDTO `json:"difficulties"`
-	AccountTypes []*MasterItemDTO `json:"account_types"`
-	Versions     []*VersionDTO    `json:"versions"`
-	RatingBands  []*RatingBandDTO `json:"rating_bands"`
+	Genres           []*MasterItemDTO `json:"genres"`
+	Difficulties     []*MasterItemDTO `json:"difficulties"`
+	AccountTypes     []*MasterItemDTO `json:"account_types"`
+	Versions         []*VersionDTO    `json:"versions"`
+	RatingBands      []*RatingBandDTO `json:"rating_bands"`
+	AchievementTypes []*MasterItemDTO `json:"achievement_types"`
 }
 
 // RatingBandDTO はレーティング帯マスタのDTOです。

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -13,6 +13,9 @@ const (
 	BulkSelectChunkSize  = 1000 // IN句のプレースホルダ上限を避けるための分割数
 	DefaultUserListLimit = 100
 	DefaultSongListLimit = 100
+	GoalMaxPerUser       = 100
+	ChartConstMin        = 1.0
+	ChartConstMax        = 15.9
 
 	// レートリミット設定: 外部API v1
 	APIRateLimitRequests      = 150              // 一般ユーザーのリクエスト制限（15分間）
@@ -63,3 +66,31 @@ const (
 // プレイヤーデータ登録時に、このリストに含まれるバージョンのみ受け付ける
 // NOTE: ユーザーが設定ファイルで変更できるようにする必要があれば、example.setting.jsonに追加してください
 var SupportedAppVersions = []string{"0.0.2"}
+
+// HardLampAbbrevToName はAPI略称→マスタ名（clear_lamp_types.name）への変換テーブルです。
+var HardLampAbbrevToName = map[string]string{
+	"HRD": "HARD",
+	"BRV": "BRAVE",
+	"ABS": "ABSOLUTE",
+	"CTS": "CATASTROPHY",
+}
+
+// HardLampNameToAbbrev はマスタ名→API略称への逆引き変換テーブルです。
+var HardLampNameToAbbrev = map[string]string{
+	"HARD":        "HRD",
+	"BRAVE":       "BRV",
+	"ABSOLUTE":    "ABS",
+	"CATASTROPHY": "CTS",
+}
+
+// ComboLampAbbrevToName はAPI略称→マスタ名（combo_lamp_types.name）への変換テーブルです。
+var ComboLampAbbrevToName = map[string]string{
+	"FC": "FULL COMBO",
+	"AJ": "ALL JUSTICE",
+}
+
+// ComboLampNameToAbbrev はマスタ名→API略称への逆引き変換テーブルです。
+var ComboLampNameToAbbrev = map[string]string{
+	"FULL COMBO":  "FC",
+	"ALL JUSTICE": "AJ",
+}

--- a/internal/infra/masterdata/cache.go
+++ b/internal/infra/masterdata/cache.go
@@ -305,6 +305,7 @@ func (c *Cache) GoalMasters() *domainmasterdata.GoalMasters {
 	return &domainmasterdata.GoalMasters{
 		AchievementTypesByCode: maps.Clone(c.AchievementTypes),
 		AchievementTypesByID:   maps.Clone(c.AchievementTypesByID),
+		DifficultyNamesByID:    maps.Clone(c.DifficultyNamesByID),
 		GenreNamesByID:         maps.Clone(c.GenreNamesByID),
 		VersionsByID:           versionsByID,
 		ClearLampNamesByID:     maps.Clone(c.ClearLampNamesByID),

--- a/internal/infra/masterdata/cache.go
+++ b/internal/infra/masterdata/cache.go
@@ -12,23 +12,26 @@ import (
 
 // Cache は起動時にプリロードされるマスタのセットです。
 type Cache struct {
-	ClassEmblems        map[string]Item
-	ClassEmblemBases    map[string]Item
-	ClearLamps          map[string]Item
-	ClearLampNamesByID  map[int]string
-	ComboLamps          map[string]Item
-	ComboLampNamesByID  map[int]string
-	FullChains          map[string]Item
-	FullChainNamesByID  map[int]string
-	Slots               map[string]Item
-	SlotNamesByID       map[int]string
-	HonorTypes          map[string]Item
-	Difficulties        map[string]Item
-	DifficultyNamesByID map[int]string
-	Genres              map[string]Item
-	GenreNamesByID      map[int]string
-	AccountTypes        map[string]Item
-	Versions            map[string]Version
+	ClassEmblems         map[string]Item
+	ClassEmblemBases     map[string]Item
+	ClearLamps           map[string]Item
+	ClearLampNamesByID   map[int]string
+	ComboLamps           map[string]Item
+	ComboLampNamesByID   map[int]string
+	FullChains           map[string]Item
+	FullChainNamesByID   map[int]string
+	Slots                map[string]Item
+	SlotNamesByID        map[int]string
+	HonorTypes           map[string]Item
+	Difficulties         map[string]Item
+	DifficultyNamesByID  map[int]string
+	Genres               map[string]Item
+	GenreNamesByID       map[int]string
+	AccountTypes         map[string]Item
+	Versions             map[string]Version
+	VersionsByID         map[int]Version
+	AchievementTypes     map[string]Item
+	AchievementTypesByID map[int]string
 }
 
 // Preload は固定値が INSERT されているマスタを読み込み、キャッシュを構築します。
@@ -113,24 +116,41 @@ func Preload(ctx context.Context, db *sqlx.DB) (*Cache, error) {
 		return nil, fmt.Errorf("failed to preload versions: %w", err)
 	}
 
+	versionsByID := make(map[int]Version, len(versions))
+	for _, item := range versions {
+		versionsByID[int(item.ID)] = item
+	}
+
+	achievementTypes, err := loadSimpleMasters(ctx, db, "SELECT id, code FROM achievement_types", false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to preload achievement_types: %w", err)
+	}
+	achievementTypesByID := make(map[int]string, len(achievementTypes))
+	for _, item := range achievementTypes {
+		achievementTypesByID[item.ID] = item.Name
+	}
+
 	return &Cache{
-		ClassEmblems:        classEmblems,
-		ClassEmblemBases:    classEmblemBases,
-		ClearLamps:          clearLamps,
-		ClearLampNamesByID:  clearLampNamesByID,
-		ComboLamps:          comboLamps,
-		ComboLampNamesByID:  comboLampNamesByID,
-		FullChains:          fullChains,
-		FullChainNamesByID:  fullChainNamesByID,
-		Slots:               slots,
-		SlotNamesByID:       slotNamesByID,
-		HonorTypes:          honorTypes,
-		Difficulties:        difficulties,
-		DifficultyNamesByID: difficultyNamesByID,
-		Genres:              genres,
-		GenreNamesByID:      genreNamesByID,
-		AccountTypes:        accountTypes,
-		Versions:            versions,
+		ClassEmblems:         classEmblems,
+		ClassEmblemBases:     classEmblemBases,
+		ClearLamps:           clearLamps,
+		ClearLampNamesByID:   clearLampNamesByID,
+		ComboLamps:           comboLamps,
+		ComboLampNamesByID:   comboLampNamesByID,
+		FullChains:           fullChains,
+		FullChainNamesByID:   fullChainNamesByID,
+		Slots:                slots,
+		SlotNamesByID:        slotNamesByID,
+		HonorTypes:           honorTypes,
+		Difficulties:         difficulties,
+		DifficultyNamesByID:  difficultyNamesByID,
+		Genres:               genres,
+		GenreNamesByID:       genreNamesByID,
+		AccountTypes:         accountTypes,
+		Versions:             versions,
+		VersionsByID:         versionsByID,
+		AchievementTypes:     achievementTypes,
+		AchievementTypesByID: achievementTypesByID,
 	}, nil
 }
 
@@ -265,4 +285,29 @@ func (c *Cache) GetAccountTypeNameByID(id int) string {
 		}
 	}
 	return "UNKNOWN"
+}
+
+// GoalMasters は目標機能で必要なマスタ集合を返します。
+func (c *Cache) GoalMasters() *domainmasterdata.GoalMasters {
+	if c == nil {
+		return nil
+	}
+
+	versionsByID := make(map[int]domainmasterdata.Version, len(c.VersionsByID))
+	for k, v := range c.VersionsByID {
+		versionsByID[k] = domainmasterdata.Version{
+			ID:         v.ID,
+			Name:       v.Name,
+			ReleasedAt: v.ReleasedAt,
+		}
+	}
+
+	return &domainmasterdata.GoalMasters{
+		AchievementTypesByCode: maps.Clone(c.AchievementTypes),
+		AchievementTypesByID:   maps.Clone(c.AchievementTypesByID),
+		GenreNamesByID:         maps.Clone(c.GenreNamesByID),
+		VersionsByID:           versionsByID,
+		ClearLampNamesByID:     maps.Clone(c.ClearLampNamesByID),
+		ComboLampNamesByID:     maps.Clone(c.ComboLampNamesByID),
+	}
 }

--- a/internal/infra/models/goal_model.go
+++ b/internal/infra/models/goal_model.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"time"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+)
+
+// GoalModel はデータベース用のGoalモデルです。
+type GoalModel struct {
+	ID                int64     `db:"id"`
+	UserID            int       `db:"user_id"`
+	Title             string    `db:"title"`
+	AchievementTypeID int       `db:"achievement_type_id"`
+	AchievementParams []byte    `db:"achievement_params"`
+	Attributes        []byte    `db:"attributes"`
+	Invert            bool      `db:"invert"`
+	CreatedAt         time.Time `db:"created_at"`
+}
+
+func (m *GoalModel) ToEntity() *entity.Goal {
+	return &entity.Goal{
+		ID:                m.ID,
+		UserID:            m.UserID,
+		Title:             m.Title,
+		AchievementTypeID: m.AchievementTypeID,
+		AchievementParams: m.AchievementParams,
+		Attributes:        m.Attributes,
+		Invert:            m.Invert,
+		CreatedAt:         m.CreatedAt,
+	}
+}
+
+func FromGoalEntity(e *entity.Goal) *GoalModel {
+	return &GoalModel{
+		ID:                e.ID,
+		UserID:            e.UserID,
+		Title:             e.Title,
+		AchievementTypeID: e.AchievementTypeID,
+		AchievementParams: e.AchievementParams,
+		Attributes:        e.Attributes,
+		Invert:            e.Invert,
+		CreatedAt:         e.CreatedAt,
+	}
+}

--- a/internal/infra/models/goal_model.go
+++ b/internal/infra/models/goal_model.go
@@ -8,7 +8,7 @@ import (
 
 // GoalModel はデータベース用のGoalモデルです。
 type GoalModel struct {
-	ID                int64     `db:"id"`
+	ID                uint32    `db:"id"`
 	UserID            int       `db:"user_id"`
 	Title             string    `db:"title"`
 	AchievementTypeID int       `db:"achievement_type_id"`

--- a/internal/infra/repository/goal_repository_impl.go
+++ b/internal/infra/repository/goal_repository_impl.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"math"
 
@@ -67,8 +68,18 @@ func (r *goalRepository) Update(ctx context.Context, exec repository.Executor, g
 
 func (r *goalRepository) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) error {
 	query := `DELETE FROM goals WHERE id = ? AND user_id = ?`
-	_, err := exec.ExecContext(ctx, query, id, userID)
-	return err
+	res, err := exec.ExecContext(ctx, query, id, userID)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func (r *goalRepository) CountByUserID(ctx context.Context, exec repository.Executor, userID int) (int, error) {

--- a/internal/infra/repository/goal_repository_impl.go
+++ b/internal/infra/repository/goal_repository_impl.go
@@ -62,8 +62,18 @@ func (r *goalRepository) Create(ctx context.Context, exec repository.Executor, g
 
 func (r *goalRepository) Update(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
 	query := `UPDATE goals SET title = ?, achievement_type_id = ?, achievement_params = ?, attributes = ?, invert = ? WHERE id = ? AND user_id = ?`
-	_, err := exec.ExecContext(ctx, query, goal.Title, goal.AchievementTypeID, goal.AchievementParams, goal.Attributes, goal.Invert, goal.ID, goal.UserID)
-	return err
+	res, err := exec.ExecContext(ctx, query, goal.Title, goal.AchievementTypeID, goal.AchievementParams, goal.Attributes, goal.Invert, goal.ID, goal.UserID)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func (r *goalRepository) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) error {

--- a/internal/infra/repository/goal_repository_impl.go
+++ b/internal/infra/repository/goal_repository_impl.go
@@ -1,0 +1,80 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/infra/models"
+	"github.com/jmoiron/sqlx"
+)
+
+type goalRepository struct {
+	db *sqlx.DB
+}
+
+// NewGoalRepository は新しいGoalRepositoryを生成します。
+func NewGoalRepository(db *sqlx.DB) repository.GoalRepository {
+	return &goalRepository{db: db}
+}
+
+func (r *goalRepository) ListByUserID(ctx context.Context, exec repository.Executor, userID int) ([]*entity.Goal, error) {
+	var goalModels []*models.GoalModel
+	query := `SELECT id, user_id, title, achievement_type_id, achievement_params, attributes, invert, created_at FROM goals WHERE user_id = ? ORDER BY created_at ASC, id ASC`
+	if err := exec.SelectContext(ctx, &goalModels, query, userID); err != nil {
+		return nil, err
+	}
+	goals := make([]*entity.Goal, 0, len(goalModels))
+	for _, m := range goalModels {
+		goals = append(goals, m.ToEntity())
+	}
+	return goals, nil
+}
+
+func (r *goalRepository) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id int64, userID int) (*entity.Goal, error) {
+	var m models.GoalModel
+	query := `SELECT id, user_id, title, achievement_type_id, achievement_params, attributes, invert, created_at FROM goals WHERE id = ? AND user_id = ?`
+	if err := exec.GetContext(ctx, &m, query, id, userID); err != nil {
+		return nil, err
+	}
+	return m.ToEntity(), nil
+}
+
+func (r *goalRepository) Create(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	query := `INSERT INTO goals (user_id, title, achievement_type_id, achievement_params, attributes, invert) VALUES (?, ?, ?, ?, ?, ?)`
+	res, err := exec.ExecContext(ctx, query, goal.UserID, goal.Title, goal.AchievementTypeID, goal.AchievementParams, goal.Attributes, goal.Invert)
+	if err != nil {
+		return err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return err
+	}
+	goal.ID = id
+	return nil
+}
+
+func (r *goalRepository) Update(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	query := `UPDATE goals SET title = ?, achievement_type_id = ?, achievement_params = ?, attributes = ?, invert = ? WHERE id = ? AND user_id = ?`
+	_, err := exec.ExecContext(ctx, query, goal.Title, goal.AchievementTypeID, goal.AchievementParams, goal.Attributes, goal.Invert, goal.ID, goal.UserID)
+	return err
+}
+
+func (r *goalRepository) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id int64, userID int) error {
+	query := `DELETE FROM goals WHERE id = ? AND user_id = ?`
+	_, err := exec.ExecContext(ctx, query, id, userID)
+	return err
+}
+
+func (r *goalRepository) CountByUserID(ctx context.Context, exec repository.Executor, userID int) (int, error) {
+	var count int
+	if err := exec.GetContext(ctx, &count, `SELECT COUNT(*) FROM goals WHERE user_id = ?`, userID); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (r *goalRepository) LockUserByID(ctx context.Context, exec repository.Executor, userID int) error {
+	var id int
+	return exec.GetContext(ctx, &id, `SELECT id FROM users WHERE id = ? FOR UPDATE`, userID)
+}

--- a/internal/infra/repository/goal_repository_impl.go
+++ b/internal/infra/repository/goal_repository_impl.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"fmt"
+	"math"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
@@ -31,7 +33,7 @@ func (r *goalRepository) ListByUserID(ctx context.Context, exec repository.Execu
 	return goals, nil
 }
 
-func (r *goalRepository) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id int64, userID int) (*entity.Goal, error) {
+func (r *goalRepository) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) (*entity.Goal, error) {
 	var m models.GoalModel
 	query := `SELECT id, user_id, title, achievement_type_id, achievement_params, attributes, invert, created_at FROM goals WHERE id = ? AND user_id = ?`
 	if err := exec.GetContext(ctx, &m, query, id, userID); err != nil {
@@ -50,7 +52,10 @@ func (r *goalRepository) Create(ctx context.Context, exec repository.Executor, g
 	if err != nil {
 		return err
 	}
-	goal.ID = id
+	if id < 0 || id > math.MaxUint32 {
+		return fmt.Errorf("goals.id out of range: %d", id)
+	}
+	goal.ID = uint32(id)
 	return nil
 }
 
@@ -60,7 +65,7 @@ func (r *goalRepository) Update(ctx context.Context, exec repository.Executor, g
 	return err
 }
 
-func (r *goalRepository) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id int64, userID int) error {
+func (r *goalRepository) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) error {
 	query := `DELETE FROM goals WHERE id = ? AND user_id = ?`
 	_, err := exec.ExecContext(ctx, query, id, userID)
 	return err

--- a/internal/usecase/errors.go
+++ b/internal/usecase/errors.go
@@ -14,6 +14,7 @@ var (
 	ErrIncorrectPassword          = errors.New("current password is incorrect")  // パスワード不一致
 	ErrInvalidPassword            = errors.New("invalid password")               // パスワード無効（詳細隠蔽）
 	ErrOperationFailed            = errors.New("operation failed")               // 操作失敗（詳細隠蔽）
+	ErrInternalError              = errors.New("internal error")                 // サーバ内部エラー（詳細隠蔽）
 	ErrInvalidRecoveryCredentials = errors.New("invalid recovery credentials")   // リカバリー失敗（詳細隠蔽）
 	ErrUserAlreadyDeleted         = errors.New("user already deleted")           // 内部用
 	ErrUserNotDeleted             = errors.New("user not deleted")               // 内部用

--- a/internal/usecase/goal_usecase.go
+++ b/internal/usecase/goal_usecase.go
@@ -1,0 +1,31 @@
+package usecase
+
+import "context"
+
+// GoalUsecase は目標機能のユースケースです。
+type GoalUsecase interface {
+	List(ctx context.Context, userID int) ([]*GoalOutput, error)
+	Create(ctx context.Context, userID int, input *GoalInput) (*GoalOutput, error)
+	Update(ctx context.Context, userID int, id int64, input *GoalInput) (*GoalOutput, error)
+	Delete(ctx context.Context, userID int, id int64) error
+}
+
+// GoalInput は目標の作成・更新入力です。
+type GoalInput struct {
+	Title             string
+	AchievementType   string
+	AchievementParams []byte
+	Attributes        []byte
+	Invert            bool
+}
+
+// GoalOutput は目標API向けの出力です。
+type GoalOutput struct {
+	ID                int64
+	Title             string
+	AchievementType   string
+	AchievementParams map[string]any
+	Attributes        map[string]any
+	Invert            bool
+	CreatedAt         string
+}

--- a/internal/usecase/goal_usecase.go
+++ b/internal/usecase/goal_usecase.go
@@ -6,8 +6,8 @@ import "context"
 type GoalUsecase interface {
 	List(ctx context.Context, userID int) ([]*GoalOutput, error)
 	Create(ctx context.Context, userID int, input *GoalInput) (*GoalOutput, error)
-	Update(ctx context.Context, userID int, id int64, input *GoalInput) (*GoalOutput, error)
-	Delete(ctx context.Context, userID int, id int64) error
+	Update(ctx context.Context, userID int, id uint32, input *GoalInput) (*GoalOutput, error)
+	Delete(ctx context.Context, userID int, id uint32) error
 }
 
 // GoalInput は目標の作成・更新入力です。
@@ -21,7 +21,7 @@ type GoalInput struct {
 
 // GoalOutput は目標API向けの出力です。
 type GoalOutput struct {
-	ID                int64
+	ID                uint32
 	Title             string
 	AchievementType   string
 	AchievementParams map[string]any

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -172,7 +172,10 @@ func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]by
 	}
 	if v, ok := attrs["diff"]; ok {
 		var diff int
-		if err := json.Unmarshal(v, &diff); err != nil || diff < 1 || diff > 5 {
+		if err := json.Unmarshal(v, &diff); err != nil {
+			return nil, ErrInvalidGoalAttributes
+		}
+		if _, exists := masters.DifficultyNamesByID[diff]; !exists {
 			return nil, ErrInvalidGoalAttributes
 		}
 	}

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -1,0 +1,300 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/info"
+)
+
+var (
+	ErrGoalLimitExceeded       = errors.New("goal limit exceeded")
+	ErrGoalNotFound            = errors.New("goal not found")
+	ErrInvalidGoalInput        = errors.New("invalid goal input")
+	ErrInvalidGoalTitle        = errors.New("invalid goal title")
+	ErrInvalidAchievementType  = errors.New("invalid achievement type")
+	ErrInvalidAchievementParam = errors.New("invalid achievement params")
+	ErrInvalidGoalAttributes   = errors.New("invalid goal attributes")
+)
+
+type goalUsecase struct {
+	db             repository.Executor
+	tm             TransactionManager
+	goalRepo       repository.GoalRepository
+	masterProvider repository.GoalMasterProvider
+}
+
+func NewGoalUsecase(db repository.Executor, tm TransactionManager, goalRepo repository.GoalRepository, masterProvider repository.GoalMasterProvider) GoalUsecase {
+	return &goalUsecase{db: db, tm: tm, goalRepo: goalRepo, masterProvider: masterProvider}
+}
+
+func (u *goalUsecase) List(ctx context.Context, userID int) ([]*GoalOutput, error) {
+	goals, err := u.goalRepo.ListByUserID(ctx, u.db, userID)
+	if err != nil {
+		return nil, err
+	}
+	return u.toOutputs(goals)
+}
+
+func (u *goalUsecase) Create(ctx context.Context, userID int, input *GoalInput) (*GoalOutput, error) {
+	validated, err := u.validateInput(input)
+	if err != nil {
+		return nil, err
+	}
+
+	var created *entity.Goal
+	err = u.tm.Transactional(ctx, func(tx repository.Executor) error {
+		if err := u.goalRepo.LockUserByID(ctx, tx, userID); err != nil {
+			return err
+		}
+		count, err := u.goalRepo.CountByUserID(ctx, tx, userID)
+		if err != nil {
+			return err
+		}
+		if count >= info.GoalMaxPerUser {
+			return ErrGoalLimitExceeded
+		}
+		goal := &entity.Goal{
+			UserID:            userID,
+			Title:             validated.Title,
+			AchievementTypeID: validated.AchievementTypeID,
+			AchievementParams: validated.AchievementParams,
+			Attributes:        validated.Attributes,
+			Invert:            validated.Invert,
+		}
+		if err := u.goalRepo.Create(ctx, tx, goal); err != nil {
+			return err
+		}
+		created, err = u.goalRepo.FindByIDAndUserID(ctx, tx, goal.ID, userID)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	outs, err := u.toOutputs([]*entity.Goal{created})
+	if err != nil {
+		return nil, err
+	}
+	return outs[0], nil
+}
+
+func (u *goalUsecase) Update(ctx context.Context, userID int, id int64, input *GoalInput) (*GoalOutput, error) {
+	validated, err := u.validateInput(input)
+	if err != nil {
+		return nil, err
+	}
+	goal, err := u.goalRepo.FindByIDAndUserID(ctx, u.db, id, userID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrGoalNotFound
+		}
+		return nil, err
+	}
+	goal.Title = validated.Title
+	goal.AchievementTypeID = validated.AchievementTypeID
+	goal.AchievementParams = validated.AchievementParams
+	goal.Attributes = validated.Attributes
+	goal.Invert = validated.Invert
+	if err := u.goalRepo.Update(ctx, u.db, goal); err != nil {
+		return nil, err
+	}
+	outs, err := u.toOutputs([]*entity.Goal{goal})
+	if err != nil {
+		return nil, err
+	}
+	return outs[0], nil
+}
+
+func (u *goalUsecase) Delete(ctx context.Context, userID int, id int64) error {
+	if _, err := u.goalRepo.FindByIDAndUserID(ctx, u.db, id, userID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrGoalNotFound
+		}
+		return err
+	}
+	return u.goalRepo.DeleteByIDAndUserID(ctx, u.db, id, userID)
+}
+
+type validatedGoalInput struct {
+	Title             string
+	AchievementTypeID int
+	AchievementParams []byte
+	Attributes        []byte
+	Invert            bool
+}
+
+func (u *goalUsecase) validateInput(input *GoalInput) (*validatedGoalInput, error) {
+	if input == nil {
+		return nil, ErrInvalidGoalInput
+	}
+	title := strings.TrimSpace(input.Title)
+	if title == "" || len([]rune(title)) > 30 {
+		return nil, ErrInvalidGoalTitle
+	}
+	masters := u.masterProvider.GoalMasters()
+	if masters == nil {
+		return nil, ErrOperationFailed
+	}
+	item, ok := masters.AchievementTypesByCode[input.AchievementType]
+	if !ok {
+		return nil, ErrInvalidAchievementType
+	}
+	attrsRaw, err := validateAttributes(input.Attributes, masters)
+	if err != nil {
+		return nil, err
+	}
+	paramsRaw, err := validateAchievementParams(input.AchievementType, input.AchievementParams)
+	if err != nil {
+		return nil, err
+	}
+	return &validatedGoalInput{Title: title, AchievementTypeID: item.ID, AchievementParams: paramsRaw, Attributes: attrsRaw, Invert: input.Invert}, nil
+}
+
+func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]byte, error) {
+	var attrs map[string]json.RawMessage
+	if len(raw) == 0 {
+		return []byte("{}"), nil
+	}
+	if err := json.Unmarshal(raw, &attrs); err != nil {
+		return nil, ErrInvalidGoalAttributes
+	}
+	allowed := map[string]bool{"diff": true, "const": true, "genre": true, "ver": true}
+	for k := range attrs {
+		if !allowed[k] {
+			return nil, ErrInvalidGoalAttributes
+		}
+	}
+	if v, ok := attrs["diff"]; ok {
+		var diff int
+		if err := json.Unmarshal(v, &diff); err != nil || diff < 1 || diff > 5 {
+			return nil, ErrInvalidGoalAttributes
+		}
+	}
+	if v, ok := attrs["const"]; ok {
+		var c struct {
+			Min float64 `json:"min"`
+			Max float64 `json:"max"`
+		}
+		if err := json.Unmarshal(v, &c); err != nil || c.Min < info.ChartConstMin || c.Max > info.ChartConstMax || c.Min > c.Max {
+			return nil, ErrInvalidGoalAttributes
+		}
+	}
+	if v, ok := attrs["genre"]; ok {
+		var id int
+		if err := json.Unmarshal(v, &id); err != nil {
+			return nil, ErrInvalidGoalAttributes
+		}
+		if _, exists := masters.GenreNamesByID[id]; !exists {
+			return nil, ErrInvalidGoalAttributes
+		}
+	}
+	if v, ok := attrs["ver"]; ok {
+		var id int
+		if err := json.Unmarshal(v, &id); err != nil {
+			return nil, ErrInvalidGoalAttributes
+		}
+		if _, exists := masters.VersionsByID[id]; !exists {
+			return nil, ErrInvalidGoalAttributes
+		}
+	}
+	canon, err := json.Marshal(attrs)
+	if err != nil {
+		return nil, ErrInvalidGoalAttributes
+	}
+	return canon, nil
+}
+
+func validateAchievementParams(achievementType string, raw []byte) ([]byte, error) {
+	if len(raw) == 0 {
+		return nil, ErrInvalidAchievementParam
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, ErrInvalidAchievementParam
+	}
+	scoreCountTypes := map[string]bool{"rank_count": true, "score_count": true}
+	switch {
+	case scoreCountTypes[achievementType]:
+		if len(m) != 2 {
+			return nil, ErrInvalidAchievementParam
+		}
+		var score, count int
+		if err := json.Unmarshal(m["score"], &score); err != nil || score < 0 || score > 1010000 {
+			return nil, ErrInvalidAchievementParam
+		}
+		if err := json.Unmarshal(m["count"], &count); err != nil || count < 1 {
+			return nil, ErrInvalidAchievementParam
+		}
+	case achievementType == "avg_score":
+		var score int
+		if len(m) != 1 || json.Unmarshal(m["score"], &score) != nil || score < 0 || score > 1010000 {
+			return nil, ErrInvalidAchievementParam
+		}
+	case achievementType == "hardlamp_count" || achievementType == "combolamp_count":
+		var lamp string
+		var count int
+		if len(m) != 2 || json.Unmarshal(m["lamp"], &lamp) != nil || json.Unmarshal(m["count"], &count) != nil || count < 1 {
+			return nil, ErrInvalidAchievementParam
+		}
+		if achievementType == "hardlamp_count" {
+			if _, ok := info.HardLampAbbrevToName[lamp]; !ok {
+				return nil, ErrInvalidAchievementParam
+			}
+		} else if _, ok := info.ComboLampAbbrevToName[lamp]; !ok {
+			return nil, ErrInvalidAchievementParam
+		}
+	case achievementType == "total_score":
+		var total int64
+		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 {
+			return nil, ErrInvalidAchievementParam
+		}
+	case achievementType == "overpower_value":
+		var total float64
+		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || !isScale(total, 3) {
+			return nil, ErrInvalidAchievementParam
+		}
+	case achievementType == "overpower_percent":
+		var total float64
+		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || total > 100 || !isScale(total, 2) {
+			return nil, ErrInvalidAchievementParam
+		}
+	default:
+		return nil, ErrInvalidAchievementType
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, ErrInvalidAchievementParam
+	}
+	return b, nil
+}
+
+func isScale(v float64, scale int) bool {
+	f := math.Pow10(scale)
+	return math.Abs(v*f-math.Round(v*f)) < 1e-9
+}
+
+func (u *goalUsecase) toOutputs(goals []*entity.Goal) ([]*GoalOutput, error) {
+	masters := u.masterProvider.GoalMasters()
+	outs := make([]*GoalOutput, 0, len(goals))
+	for _, g := range goals {
+		typeCode := masters.AchievementTypesByID[g.AchievementTypeID]
+		var p map[string]any
+		if err := json.Unmarshal(g.AchievementParams, &p); err != nil {
+			return nil, fmt.Errorf("failed to decode achievement params: %w", err)
+		}
+		var a map[string]any
+		if err := json.Unmarshal(g.Attributes, &a); err != nil {
+			return nil, fmt.Errorf("failed to decode attributes: %w", err)
+		}
+		outs = append(outs, &GoalOutput{ID: g.ID, Title: g.Title, AchievementType: typeCode, AchievementParams: p, Attributes: a, Invert: g.Invert, CreatedAt: g.CreatedAt.Format("2006-01-02T15:04:05Z07:00")})
+	}
+	return outs, nil
+}

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -184,12 +184,33 @@ func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]by
 	}
 	if v, ok := attrs["const"]; ok {
 		var c struct {
-			Min float64 `json:"min"`
-			Max float64 `json:"max"`
+			Min *float64 `json:"min"`
+			Max *float64 `json:"max"`
 		}
-		if err := json.Unmarshal(v, &c); err != nil || c.Min < info.ChartConstMin || c.Max > info.ChartConstMax || c.Min > c.Max {
+		if err := json.Unmarshal(v, &c); err != nil {
 			return nil, ErrInvalidGoalAttributes
 		}
+
+		minConst := info.ChartConstMin
+		maxConst := info.ChartConstMax
+		if c.Min != nil {
+			minConst = *c.Min
+		}
+		if c.Max != nil {
+			maxConst = *c.Max
+		}
+		if minConst < info.ChartConstMin || maxConst > info.ChartConstMax || minConst > maxConst {
+			return nil, ErrInvalidGoalAttributes
+		}
+
+		normalizedConst, err := json.Marshal(struct {
+			Min float64 `json:"min"`
+			Max float64 `json:"max"`
+		}{Min: minConst, Max: maxConst})
+		if err != nil {
+			return nil, ErrInvalidGoalAttributes
+		}
+		attrs["const"] = normalizedConst
 	}
 	if v, ok := attrs["genre"]; ok {
 		var id int

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -114,13 +114,11 @@ func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *
 }
 
 func (u *goalUsecase) Delete(ctx context.Context, userID int, id uint32) error {
-	if _, err := u.goalRepo.FindByIDAndUserID(ctx, u.db, id, userID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return ErrGoalNotFound
-		}
-		return err
+	err := u.goalRepo.DeleteByIDAndUserID(ctx, u.db, id, userID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrGoalNotFound
 	}
-	return u.goalRepo.DeleteByIDAndUserID(ctx, u.db, id, userID)
+	return err
 }
 
 type validatedGoalInput struct {

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -104,6 +104,9 @@ func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *
 	goal.Attributes = validated.Attributes
 	goal.Invert = validated.Invert
 	if err := u.goalRepo.Update(ctx, u.db, goal); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrGoalNotFound
+		}
 		return nil, err
 	}
 	outs, err := u.toOutputs([]*entity.Goal{goal})

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -142,7 +142,7 @@ func (u *goalUsecase) validateInput(input *GoalInput) (*validatedGoalInput, erro
 	}
 	masters := u.masterProvider.GoalMasters()
 	if masters == nil {
-		return nil, ErrOperationFailed
+		return nil, ErrInternalError
 	}
 	item, ok := masters.AchievementTypesByCode[input.AchievementType]
 	if !ok {

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -86,7 +86,7 @@ func (u *goalUsecase) Create(ctx context.Context, userID int, input *GoalInput) 
 	return outs[0], nil
 }
 
-func (u *goalUsecase) Update(ctx context.Context, userID int, id int64, input *GoalInput) (*GoalOutput, error) {
+func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *GoalInput) (*GoalOutput, error) {
 	validated, err := u.validateInput(input)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func (u *goalUsecase) Update(ctx context.Context, userID int, id int64, input *G
 	return outs[0], nil
 }
 
-func (u *goalUsecase) Delete(ctx context.Context, userID int, id int64) error {
+func (u *goalUsecase) Delete(ctx context.Context, userID int, id uint32) error {
 	if _, err := u.goalRepo.FindByIDAndUserID(ctx, u.db, id, userID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrGoalNotFound

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"strings"
 
@@ -311,6 +312,9 @@ func (u *goalUsecase) toOutputs(goals []*entity.Goal) ([]*GoalOutput, error) {
 	outs := make([]*GoalOutput, 0, len(goals))
 	for _, g := range goals {
 		typeCode := masters.AchievementTypesByID[g.AchievementTypeID]
+		if typeCode == "" {
+			slog.Warn("achievement type code not found in master cache", "goal_id", g.ID, "achievement_type_id", g.AchievementTypeID)
+		}
 		var p map[string]any
 		if err := json.Unmarshal(g.AchievementParams, &p); err != nil {
 			return nil, fmt.Errorf("failed to decode achievement params: %w", err)

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -289,7 +289,7 @@ func validateAchievementParams(achievementType string, raw []byte) ([]byte, erro
 		}
 	case achievementType == "overpower_percent":
 		var total float64
-		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || total > 100 || !isScale(total, 2) {
+		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || !isScale(total, 3) {
 			return nil, ErrInvalidAchievementParam
 		}
 	default:

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -147,3 +147,29 @@ func TestGoalUsecase_CreateInvalidDifficultyAttribute(t *testing.T) {
 	})
 	assert.True(t, errors.Is(err, ErrInvalidGoalAttributes))
 }
+
+func TestGoalUsecase_CreateConstAttributeWithOmittedMinUsesDefault(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	out, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "score_count",
+		AchievementParams: []byte(`{"score":1000000,"count":1}`),
+		Attributes:        []byte(`{"const":{"max":15.9}}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"const": map[string]any{"min": float64(1), "max": float64(15.9)}}, out.Attributes)
+}
+
+func TestGoalUsecase_CreateConstAttributeWithOmittedMaxUsesDefault(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	out, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "score_count",
+		AchievementParams: []byte(`{"score":1000000,"count":1}`),
+		Attributes:        []byte(`{"const":{"min":1.2}}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"const": map[string]any{"min": float64(1.2), "max": float64(15.9)}}, out.Attributes)
+}

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -1,0 +1,84 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubGoalRepo struct {
+	count int
+	goal  *entity.Goal
+}
+
+func (s *stubGoalRepo) ListByUserID(ctx context.Context, exec repository.Executor, userID int) ([]*entity.Goal, error) {
+	return []*entity.Goal{s.goal}, nil
+}
+func (s *stubGoalRepo) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id int64, userID int) (*entity.Goal, error) {
+	if s.goal == nil || s.goal.ID != id {
+		return nil, sql.ErrNoRows
+	}
+	return s.goal, nil
+}
+func (s *stubGoalRepo) Create(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	goal.ID = 1
+	goal.CreatedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s.goal = goal
+	return nil
+}
+func (s *stubGoalRepo) Update(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	s.goal = goal
+	return nil
+}
+func (s *stubGoalRepo) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id int64, userID int) error {
+	s.goal = nil
+	return nil
+}
+func (s *stubGoalRepo) CountByUserID(ctx context.Context, exec repository.Executor, userID int) (int, error) {
+	return s.count, nil
+}
+func (s *stubGoalRepo) LockUserByID(ctx context.Context, exec repository.Executor, userID int) error {
+	return nil
+}
+
+type stubTM struct{}
+
+func (s *stubTM) Transactional(ctx context.Context, f func(tx repository.Executor) error) error {
+	return f(nil)
+}
+
+type stubGoalMasterProvider struct{}
+
+func (s *stubGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
+	return &domainmasterdata.GoalMasters{
+		AchievementTypesByCode: map[string]domainmasterdata.Item{"score_count": {ID: 2, Name: "score_count"}},
+		AchievementTypesByID:   map[int]string{2: "score_count"},
+		GenreNamesByID:         map[int]string{1: "POPS & ANIME"},
+		VersionsByID:           map[int]domainmasterdata.Version{20: {ID: 20, Name: "VERSE"}},
+	}
+}
+
+func TestGoalUsecase_Create(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	in := &GoalInput{Title: "  test  ", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{"diff":4,"genre":1,"ver":20}`)}
+	out, err := u.Create(context.Background(), 1, in)
+	require.NoError(t, err)
+	assert.Equal(t, "test", out.Title)
+	assert.Equal(t, "score_count", out.AchievementType)
+}
+
+func TestGoalUsecase_CreateLimitExceeded(t *testing.T) {
+	repo := &stubGoalRepo{count: 100}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{}`)})
+	assert.True(t, errors.Is(err, ErrGoalLimitExceeded))
+}

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -15,8 +15,9 @@ import (
 )
 
 type stubGoalRepo struct {
-	count int
-	goal  *entity.Goal
+	count     int
+	goal      *entity.Goal
+	updateErr error
 }
 
 func (s *stubGoalRepo) ListByUserID(ctx context.Context, exec repository.Executor, userID int) ([]*entity.Goal, error) {
@@ -35,6 +36,9 @@ func (s *stubGoalRepo) Create(ctx context.Context, exec repository.Executor, goa
 	return nil
 }
 func (s *stubGoalRepo) Update(ctx context.Context, exec repository.Executor, goal *entity.Goal) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
 	s.goal = goal
 	return nil
 }
@@ -99,6 +103,18 @@ func TestGoalUsecase_DeleteNotFound(t *testing.T) {
 	repo := &stubGoalRepo{}
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	err := u.Delete(context.Background(), 1, 999)
+	assert.True(t, errors.Is(err, ErrGoalNotFound))
+}
+
+func TestGoalUsecase_UpdateNotFoundOnSave(t *testing.T) {
+	repo := &stubGoalRepo{goal: &entity.Goal{ID: 1, UserID: 1}, updateErr: sql.ErrNoRows}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Update(context.Background(), 1, 1, &GoalInput{
+		Title:             "updated",
+		AchievementType:   "score_count",
+		AchievementParams: []byte(`{"score":1000000,"count":1}`),
+		Attributes:        []byte(`{"diff":4,"genre":1,"ver":20}`),
+	})
 	assert.True(t, errors.Is(err, ErrGoalNotFound))
 }
 

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -64,6 +64,12 @@ func (s *stubTM) Transactional(ctx context.Context, f func(tx repository.Executo
 
 type stubGoalMasterProvider struct{}
 
+type stubNilGoalMasterProvider struct{}
+
+func (s *stubNilGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
+	return nil
+}
+
 func (s *stubGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
 	return &domainmasterdata.GoalMasters{
 		AchievementTypesByCode: map[string]domainmasterdata.Item{"score_count": {ID: 2, Name: "score_count"}},
@@ -116,6 +122,18 @@ func TestGoalUsecase_UpdateNotFoundOnSave(t *testing.T) {
 		Attributes:        []byte(`{"diff":4,"genre":1,"ver":20}`),
 	})
 	assert.True(t, errors.Is(err, ErrGoalNotFound))
+}
+
+func TestGoalUsecase_CreateMasterDataUnavailable(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubNilGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "score_count",
+		AchievementParams: []byte(`{"score":1000000,"count":1}`),
+		Attributes:        []byte(`{}`),
+	})
+	assert.True(t, errors.Is(err, ErrInternalError))
 }
 
 func TestGoalUsecase_CreateInvalidDifficultyAttribute(t *testing.T) {

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -39,6 +39,9 @@ func (s *stubGoalRepo) Update(ctx context.Context, exec repository.Executor, goa
 	return nil
 }
 func (s *stubGoalRepo) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) error {
+	if s.goal == nil || s.goal.ID != id {
+		return sql.ErrNoRows
+	}
 	s.goal = nil
 	return nil
 }
@@ -81,4 +84,19 @@ func TestGoalUsecase_CreateLimitExceeded(t *testing.T) {
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{}`)})
 	assert.True(t, errors.Is(err, ErrGoalLimitExceeded))
+}
+
+func TestGoalUsecase_Delete(t *testing.T) {
+	repo := &stubGoalRepo{goal: &entity.Goal{ID: 1, UserID: 1}}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	err := u.Delete(context.Background(), 1, 1)
+	require.NoError(t, err)
+	assert.Nil(t, repo.goal)
+}
+
+func TestGoalUsecase_DeleteNotFound(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	err := u.Delete(context.Background(), 1, 999)
+	assert.True(t, errors.Is(err, ErrGoalNotFound))
 }

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -72,8 +72,8 @@ func (s *stubNilGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters 
 
 func (s *stubGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
 	return &domainmasterdata.GoalMasters{
-		AchievementTypesByCode: map[string]domainmasterdata.Item{"score_count": {ID: 2, Name: "score_count"}},
-		AchievementTypesByID:   map[int]string{2: "score_count"},
+		AchievementTypesByCode: map[string]domainmasterdata.Item{"score_count": {ID: 2, Name: "score_count"}, "overpower_percent": {ID: 8, Name: "overpower_percent"}},
+		AchievementTypesByID:   map[int]string{2: "score_count", 8: "overpower_percent"},
 		DifficultyNamesByID:    map[int]string{4: "MASTER"},
 		GenreNamesByID:         map[int]string{1: "POPS & ANIME"},
 		VersionsByID:           map[int]domainmasterdata.Version{20: {ID: 20, Name: "VERSE"}},
@@ -172,4 +172,28 @@ func TestGoalUsecase_CreateConstAttributeWithOmittedMaxUsesDefault(t *testing.T)
 	})
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{"const": map[string]any{"min": float64(1.2), "max": float64(15.9)}}, out.Attributes)
+}
+
+func TestGoalUsecase_CreateOverpowerPercentAcceptsRealValue(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "overpower_percent",
+		AchievementParams: []byte(`{"total":123.456}`),
+		Attributes:        []byte(`{}`),
+	})
+	require.NoError(t, err)
+}
+
+func TestGoalUsecase_CreateOverpowerPercentRejectsMoreThan3Decimals(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "overpower_percent",
+		AchievementParams: []byte(`{"total":12.3456}`),
+		Attributes:        []byte(`{}`),
+	})
+	assert.True(t, errors.Is(err, ErrInvalidAchievementParam))
 }

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -22,7 +22,7 @@ type stubGoalRepo struct {
 func (s *stubGoalRepo) ListByUserID(ctx context.Context, exec repository.Executor, userID int) ([]*entity.Goal, error) {
 	return []*entity.Goal{s.goal}, nil
 }
-func (s *stubGoalRepo) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id int64, userID int) (*entity.Goal, error) {
+func (s *stubGoalRepo) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) (*entity.Goal, error) {
 	if s.goal == nil || s.goal.ID != id {
 		return nil, sql.ErrNoRows
 	}
@@ -38,7 +38,7 @@ func (s *stubGoalRepo) Update(ctx context.Context, exec repository.Executor, goa
 	s.goal = goal
 	return nil
 }
-func (s *stubGoalRepo) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id int64, userID int) error {
+func (s *stubGoalRepo) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) error {
 	s.goal = nil
 	return nil
 }

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -64,6 +64,7 @@ func (s *stubGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
 	return &domainmasterdata.GoalMasters{
 		AchievementTypesByCode: map[string]domainmasterdata.Item{"score_count": {ID: 2, Name: "score_count"}},
 		AchievementTypesByID:   map[int]string{2: "score_count"},
+		DifficultyNamesByID:    map[int]string{4: "MASTER"},
 		GenreNamesByID:         map[int]string{1: "POPS & ANIME"},
 		VersionsByID:           map[int]domainmasterdata.Version{20: {ID: 20, Name: "VERSE"}},
 	}
@@ -99,4 +100,16 @@ func TestGoalUsecase_DeleteNotFound(t *testing.T) {
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	err := u.Delete(context.Background(), 1, 999)
 	assert.True(t, errors.Is(err, ErrGoalNotFound))
+}
+
+func TestGoalUsecase_CreateInvalidDifficultyAttribute(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "score_count",
+		AchievementParams: []byte(`{"score":1000000,"count":1}`),
+		Attributes:        []byte(`{"diff":5,"genre":1,"ver":20}`),
+	})
+	assert.True(t, errors.Is(err, ErrInvalidGoalAttributes))
 }

--- a/migration/mysql/000005_add_goals.down.sql
+++ b/migration/mysql/000005_add_goals.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS goals;
+DROP TABLE IF EXISTS achievement_types;

--- a/migration/mysql/000005_add_goals.up.sql
+++ b/migration/mysql/000005_add_goals.up.sql
@@ -1,0 +1,31 @@
+CREATE TABLE achievement_types (
+  id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  code VARCHAR(30) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_achievement_types_code (code)
+);
+
+INSERT INTO achievement_types (code) VALUES
+  ('rank_count'),
+  ('score_count'),
+  ('avg_score'),
+  ('hardlamp_count'),
+  ('combolamp_count'),
+  ('total_score'),
+  ('overpower_value'),
+  ('overpower_percent');
+
+CREATE TABLE goals (
+  id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  user_id INT UNSIGNED NOT NULL,
+  title VARCHAR(30) NOT NULL,
+  achievement_type_id TINYINT UNSIGNED NOT NULL,
+  achievement_params JSON NOT NULL,
+  attributes JSON NOT NULL,
+  invert BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_goals_user_id (user_id),
+  CONSTRAINT fk_goals_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+  CONSTRAINT fk_goals_achievement_type_id FOREIGN KEY (achievement_type_id) REFERENCES achievement_types (id) ON DELETE RESTRICT
+);

--- a/migration/mysql/000005_add_goals.up.sql
+++ b/migration/mysql/000005_add_goals.up.sql
@@ -17,7 +17,7 @@ INSERT INTO achievement_types (code) VALUES
 
 CREATE TABLE goals (
   id INT UNSIGNED NOT NULL AUTO_INCREMENT,
-  user_id INT UNSIGNED NOT NULL,
+  user_id INT NOT NULL,
   title VARCHAR(30) NOT NULL,
   achievement_type_id TINYINT UNSIGNED NOT NULL,
   achievement_params JSON NOT NULL,


### PR DESCRIPTION
### Motivation
- `_report/goal_achievement_design.md` に基づき、ユーザー毎の目標（Goal）を永続化して操作できるAPIを追加するため。 
- MySQL上に `achievement_types` / `goals` テーブルを作成して、成果種別をDBマスタで管理し安全に拡張可能にするため。 
- UI側で必要な判定用パラメータ（`achievement_params` / `attributes`）をサーバで厳密に検証し、運用時の不整合を低減するため。 

### Description
- データベース: `migration/mysql/000005_add_goals.up.sql` / `.down.sql` を追加し、`achievement_types` と `goals` テーブル（FK含む）を定義して初期データを投入しました。 
- ドメイン/リポジトリ: `entity.Goal` と `repository.GoalRepository` を追加し、`internal/infra/models/goal_model.go` と `internal/infra/repository/goal_repository_impl.go` で永続化を実装しました。 
- ユースケース: `usecase.GoalUsecase`（一覧/作成/更新/削除）を実装し、`achievement_type`・`achievement_params`・`attributes` のバリデーションを行い、100件上限はトランザクション内で `SELECT id FROM users WHERE id = ? FOR UPDATE` による行ロック＋カウントで担保しています（`NewGoalUsecase` / `Create` 等）。 
- ハンドラ/API/ルーター: `/internal/me/goals` 配下に `GET`/`POST`/`PUT /:id`/`DELETE /:id` を追加し、`internal/app/handler/api_internal/goal_handler.go` と `internal/app/router.go` にDIとルーティングを組み込みました。 
- マスタキャッシュとAPI: マスタキャッシュに `achievement_types` を追加して起動時プリロードし、`GET /internal/master` のレスポンスに `achievement_types` を含めるようにしました（`internal/infra/masterdata/cache.go` / `internal/app/handler/api_internal/master_data_handler.go`）。 
- エラー管理とドキュメント: 目標関連のエラーコードと `FromUsecaseError` マッピングを追加し、`docs/API.md` を更新して新エンドポイントを追記しました。 

### Testing
- 自動化テストは `gofmt` を実行した上で `go test ./...` を実行し、全パッケージのテストが成功しました（`go test ./...` 成功）。 
- ユースケース単体のテスト `internal/usecase/goal_usecase_impl_test.go` を追加し、作成成功ケースと上限超過ケースを実行して成功を確認しました。 
- 変更後に `gofmt -w` を実行してコード整形を行い、その状態で再度 `go test ./...` を実行して問題ないことを確認しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d68ebf74832d95351ff1ee995041)