### PR TITLE
update: goal機能のバリデーションとエラー分類を強化

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1993,9 +1993,31 @@ interface SkippedRecord {
 
 目標を作成します。`achievement_type` と `achievement_params` の組み合わせはサーバー側で検証します。`overpower_percent` の `achievement_params.total` は割合（0以上100以下・小数3桁まで）として扱います。
 
+- `title`: 前後の空白はtrimされます。trim後は1〜30文字で、改行を含む制御文字およびゼロ幅文字は許可されません。
+- `attributes`: 未知キーは不許可です（`diff` / `const` / `genre` / `ver` のみ許可）。
+- `attributes.const`: `min` / `max` は小数1桁までを許可します。
+
+主なエラーコード:
+
+- `invalid_goal_input`
+- `invalid_goal_title`
+- `invalid_goal_achievement_type`
+- `invalid_goal_achievement_params`
+- `invalid_goal_attributes`
+- `goal_limit_exceeded`
+
 ### PUT `/internal/me/goals/:id`
 
 指定IDの目標を更新します。
+
+主なエラーコード:
+
+- `goal_not_found`
+- `invalid_goal_input`
+- `invalid_goal_title`
+- `invalid_goal_achievement_type`
+- `invalid_goal_achievement_params`
+- `invalid_goal_attributes`
 
 ### DELETE `/internal/me/goals/:id`
 

--- a/internal/app/apierror/api_error.go
+++ b/internal/app/apierror/api_error.go
@@ -107,6 +107,10 @@ var (
 	ErrGoalNotFound      = New(CodeGoalNotFound, http.StatusNotFound)
 	ErrGoalLimitExceeded = New(CodeGoalLimitExceeded, http.StatusBadRequest)
 	ErrInvalidGoalInput  = New(CodeInvalidGoalInput, http.StatusBadRequest)
+	ErrInvalidGoalTitle  = New(CodeInvalidGoalTitle, http.StatusBadRequest)
+	ErrInvalidGoalType   = New(CodeInvalidGoalType, http.StatusBadRequest)
+	ErrInvalidGoalParam  = New(CodeInvalidGoalParam, http.StatusBadRequest)
+	ErrInvalidGoalAttr   = New(CodeInvalidGoalAttr, http.StatusBadRequest)
 )
 
 // ErrorResponse はエラーレスポンスの構造体です

--- a/internal/app/apierror/codes.go
+++ b/internal/app/apierror/codes.go
@@ -59,4 +59,8 @@ const (
 	CodeGoalNotFound      = "goal_not_found"
 	CodeGoalLimitExceeded = "goal_limit_exceeded"
 	CodeInvalidGoalInput  = "invalid_goal_input"
+	CodeInvalidGoalTitle  = "invalid_goal_title"
+	CodeInvalidGoalType   = "invalid_goal_achievement_type"
+	CodeInvalidGoalParam  = "invalid_goal_achievement_params"
+	CodeInvalidGoalAttr   = "invalid_goal_attributes"
 )

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -79,8 +79,16 @@ func FromUsecaseError(err error) *APIError {
 		return ErrGoalNotFound.WithInternal(err)
 	case errors.Is(err, usecase.ErrGoalLimitExceeded):
 		return ErrGoalLimitExceeded.WithInternal(err)
-	case errors.Is(err, usecase.ErrInvalidGoalInput), errors.Is(err, usecase.ErrInvalidGoalTitle), errors.Is(err, usecase.ErrInvalidAchievementType), errors.Is(err, usecase.ErrInvalidAchievementParam), errors.Is(err, usecase.ErrInvalidGoalAttributes):
+	case errors.Is(err, usecase.ErrInvalidGoalInput):
 		return ErrInvalidGoalInput.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidGoalTitle):
+		return ErrInvalidGoalTitle.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidAchievementType):
+		return ErrInvalidGoalType.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidAchievementParam):
+		return ErrInvalidGoalParam.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidGoalAttributes):
+		return ErrInvalidGoalAttr.WithInternal(err)
 	}
 
 	// PlayerDataValidationError

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -141,7 +141,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	chartStatsUsecase := usecase.NewChartStatsUsecase(songRepo, worldsendChartRepo, chartStatsRepo, masterCache, chartStatsMasterProvider, db, staticDB)
 	worldsendUsecase := usecase.NewWorldsendUsecase(worldsendChartRepo, tm, db)
 	sessionUsecase := usecase.NewSessionUsecase(sessionRepo, db)
-	goalUsecase := usecase.NewGoalUsecase(db, tm, goalRepo, masterCache)
+	goalUsecase := usecase.NewGoalUsecase(db, tm, goalRepo, songRepo, masterCache)
 
 	// DI - Handlers
 	sameSite := parseSameSite(cfg.Auth.CookieSameSite)

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -8,11 +8,15 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"slices"
 	"strings"
+	"time"
+	"unicode"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/domain/service"
 	"github.com/chunisupport/chunisupport-api/internal/info"
 )
 
@@ -30,11 +34,12 @@ type goalUsecase struct {
 	db             repository.Executor
 	tm             TransactionManager
 	goalRepo       repository.GoalRepository
+	songRepo       repository.SongRepository
 	masterProvider repository.GoalMasterProvider
 }
 
-func NewGoalUsecase(db repository.Executor, tm TransactionManager, goalRepo repository.GoalRepository, masterProvider repository.GoalMasterProvider) GoalUsecase {
-	return &goalUsecase{db: db, tm: tm, goalRepo: goalRepo, masterProvider: masterProvider}
+func NewGoalUsecase(db repository.Executor, tm TransactionManager, goalRepo repository.GoalRepository, songRepo repository.SongRepository, masterProvider repository.GoalMasterProvider) GoalUsecase {
+	return &goalUsecase{db: db, tm: tm, goalRepo: goalRepo, songRepo: songRepo, masterProvider: masterProvider}
 }
 
 func (u *goalUsecase) List(ctx context.Context, userID int) ([]*GoalOutput, error) {
@@ -46,7 +51,7 @@ func (u *goalUsecase) List(ctx context.Context, userID int) ([]*GoalOutput, erro
 }
 
 func (u *goalUsecase) Create(ctx context.Context, userID int, input *GoalInput) (*GoalOutput, error) {
-	validated, err := u.validateInput(input)
+	validated, err := u.validateInput(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +93,7 @@ func (u *goalUsecase) Create(ctx context.Context, userID int, input *GoalInput) 
 }
 
 func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *GoalInput) (*GoalOutput, error) {
-	validated, err := u.validateInput(input)
+	validated, err := u.validateInput(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +122,15 @@ func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *
 	return outs[0], nil
 }
 
+type validatedGoalAttributes struct {
+	Diff     *int
+	Genre    *int
+	Version  *int
+	ConstMin float64
+	ConstMax float64
+	HasConst bool
+}
+
 func (u *goalUsecase) Delete(ctx context.Context, userID int, id uint32) error {
 	err := u.goalRepo.DeleteByIDAndUserID(ctx, u.db, id, userID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -133,12 +147,12 @@ type validatedGoalInput struct {
 	Invert            bool
 }
 
-func (u *goalUsecase) validateInput(input *GoalInput) (*validatedGoalInput, error) {
+func (u *goalUsecase) validateInput(ctx context.Context, input *GoalInput) (*validatedGoalInput, error) {
 	if input == nil {
 		return nil, ErrInvalidGoalInput
 	}
 	title := strings.TrimSpace(input.Title)
-	if title == "" || len([]rune(title)) > 30 {
+	if title == "" || len([]rune(title)) > 30 || hasInvalidGoalTitleRune(title) {
 		return nil, ErrInvalidGoalTitle
 	}
 	masters := u.masterProvider.GoalMasters()
@@ -149,7 +163,7 @@ func (u *goalUsecase) validateInput(input *GoalInput) (*validatedGoalInput, erro
 	if !ok {
 		return nil, ErrInvalidAchievementType
 	}
-	attrsRaw, err := validateAttributes(input.Attributes, masters)
+	attrsRaw, attrs, err := validateAttributes(input.Attributes, masters)
 	if err != nil {
 		return nil, err
 	}
@@ -157,31 +171,36 @@ func (u *goalUsecase) validateInput(input *GoalInput) (*validatedGoalInput, erro
 	if err != nil {
 		return nil, err
 	}
+	if err := u.validateDynamicUpperBounds(ctx, input.AchievementType, paramsRaw, attrs, masters); err != nil {
+		return nil, err
+	}
 	return &validatedGoalInput{Title: title, AchievementTypeID: item.ID, AchievementParams: paramsRaw, Attributes: attrsRaw, Invert: input.Invert}, nil
 }
 
-func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]byte, error) {
+func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]byte, *validatedGoalAttributes, error) {
 	var attrs map[string]json.RawMessage
+	validated := &validatedGoalAttributes{}
 	if len(raw) == 0 {
-		return []byte("{}"), nil
+		return []byte("{}"), validated, nil
 	}
 	if err := json.Unmarshal(raw, &attrs); err != nil {
-		return nil, ErrInvalidGoalAttributes
+		return nil, nil, ErrInvalidGoalAttributes
 	}
 	allowed := map[string]bool{"diff": true, "const": true, "genre": true, "ver": true}
 	for k := range attrs {
 		if !allowed[k] {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 	}
 	if v, ok := attrs["diff"]; ok {
 		var diff int
 		if err := json.Unmarshal(v, &diff); err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 		if _, exists := masters.DifficultyNamesByID[diff]; !exists {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
+		validated.Diff = &diff
 	}
 	if v, ok := attrs["const"]; ok {
 		var c struct {
@@ -189,19 +208,25 @@ func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]by
 			Max *float64 `json:"max"`
 		}
 		if err := json.Unmarshal(v, &c); err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 
 		minConst := info.ChartConstMin
 		maxConst := info.ChartConstMax
 		if c.Min != nil {
+			if !isScale(*c.Min, 1) {
+				return nil, nil, ErrInvalidGoalAttributes
+			}
 			minConst = *c.Min
 		}
 		if c.Max != nil {
+			if !isScale(*c.Max, 1) {
+				return nil, nil, ErrInvalidGoalAttributes
+			}
 			maxConst = *c.Max
 		}
 		if minConst < info.ChartConstMin || maxConst > info.ChartConstMax || minConst > maxConst {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 
 		normalizedConst, err := json.Marshal(struct {
@@ -209,33 +234,38 @@ func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]by
 			Max float64 `json:"max"`
 		}{Min: minConst, Max: maxConst})
 		if err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 		attrs["const"] = normalizedConst
+		validated.ConstMin = minConst
+		validated.ConstMax = maxConst
+		validated.HasConst = true
 	}
 	if v, ok := attrs["genre"]; ok {
 		var id int
 		if err := json.Unmarshal(v, &id); err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 		if _, exists := masters.GenreNamesByID[id]; !exists {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
+		validated.Genre = &id
 	}
 	if v, ok := attrs["ver"]; ok {
 		var id int
 		if err := json.Unmarshal(v, &id); err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 		if _, exists := masters.VersionsByID[id]; !exists {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
+		validated.Version = &id
 	}
 	canon, err := json.Marshal(attrs)
 	if err != nil {
-		return nil, ErrInvalidGoalAttributes
+		return nil, nil, ErrInvalidGoalAttributes
 	}
-	return canon, nil
+	return canon, validated, nil
 }
 
 func validateAchievementParams(achievementType string, raw []byte) ([]byte, error) {
@@ -289,7 +319,7 @@ func validateAchievementParams(achievementType string, raw []byte) ([]byte, erro
 		}
 	case achievementType == "overpower_percent":
 		var total float64
-		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || !isScale(total, 3) {
+		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || total > 100 || !isScale(total, 3) {
 			return nil, ErrInvalidAchievementParam
 		}
 	default:
@@ -302,6 +332,159 @@ func validateAchievementParams(achievementType string, raw []byte) ([]byte, erro
 	return b, nil
 }
 
+func (u *goalUsecase) validateDynamicUpperBounds(ctx context.Context, achievementType string, paramsRaw []byte, attrs *validatedGoalAttributes, masters *domainmasterdata.GoalMasters) error {
+	if u.songRepo == nil {
+		return ErrInternalError
+	}
+	targets, err := u.collectTargetCharts(ctx, attrs, masters)
+	if err != nil {
+		return err
+	}
+	maxCount := len(targets)
+	maxTotalScore := int64(maxCount) * 1010000
+	maxOPValue := calcMaxOverpowerValue(targets)
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(paramsRaw, &m); err != nil {
+		return ErrInvalidAchievementParam
+	}
+
+	switch achievementType {
+	case "score_count", "rank_count", "hardlamp_count", "combolamp_count":
+		var count int
+		if err := json.Unmarshal(m["count"], &count); err != nil {
+			return ErrInvalidAchievementParam
+		}
+		if count > maxCount {
+			return ErrInvalidAchievementParam
+		}
+	case "total_score":
+		var total int64
+		if err := json.Unmarshal(m["total"], &total); err != nil {
+			return ErrInvalidAchievementParam
+		}
+		if total > maxTotalScore {
+			return ErrInvalidAchievementParam
+		}
+	case "overpower_value":
+		var total float64
+		if err := json.Unmarshal(m["total"], &total); err != nil {
+			return ErrInvalidAchievementParam
+		}
+		if total > maxOPValue {
+			return ErrInvalidAchievementParam
+		}
+	}
+
+	return nil
+}
+
+func (u *goalUsecase) collectTargetCharts(ctx context.Context, attrs *validatedGoalAttributes, masters *domainmasterdata.GoalMasters) ([]*entity.Chart, error) {
+	songs, err := u.songRepo.FindAllExcludingWorldsend(ctx, u.db, false)
+	if err != nil {
+		return nil, ErrInternalError
+	}
+	targets := make([]*entity.Chart, 0)
+	for _, song := range songs {
+		if !matchGoalSong(song, attrs, masters) {
+			continue
+		}
+		if attrs.Diff != nil {
+			for _, chart := range song.Charts {
+				if chart.DifficultyID == *attrs.Diff {
+					targets = append(targets, chart)
+				}
+			}
+			continue
+		}
+		if attrs.HasConst {
+			for _, chart := range song.Charts {
+				constValue := float64(chart.Const)
+				if constValue >= attrs.ConstMin && constValue <= attrs.ConstMax {
+					targets = append(targets, chart)
+				}
+			}
+			continue
+		}
+		maxChart := maxConstChart(song.Charts)
+		if maxChart != nil {
+			targets = append(targets, maxChart)
+		}
+	}
+	return targets, nil
+}
+
+func matchGoalSong(song *entity.Song, attrs *validatedGoalAttributes, masters *domainmasterdata.GoalMasters) bool {
+	if attrs.Genre != nil {
+		if song.GenreID == nil || *song.GenreID != *attrs.Genre {
+			return false
+		}
+	}
+	if attrs.Version != nil {
+		versionID, ok := versionIDByReleasedAt(song.ReleasedAt, masters.VersionsByID)
+		if !ok || versionID != *attrs.Version {
+			return false
+		}
+	}
+	return true
+}
+
+func versionIDByReleasedAt(releasedAt *time.Time, versionsByID map[int]domainmasterdata.Version) (int, bool) {
+	if releasedAt == nil {
+		return 0, false
+	}
+	versions := make([]domainmasterdata.Version, 0, len(versionsByID))
+	for _, v := range versionsByID {
+		versions = append(versions, v)
+	}
+	slices.SortFunc(versions, func(a, b domainmasterdata.Version) int {
+		return a.ReleasedAt.Compare(b.ReleasedAt)
+	})
+	latestID := 0
+	found := false
+	for _, v := range versions {
+		if !releasedAt.Before(v.ReleasedAt) {
+			latestID = int(v.ID)
+			found = true
+		}
+	}
+	return latestID, found
+}
+
+func maxConstChart(charts []*entity.Chart) *entity.Chart {
+	if len(charts) == 0 {
+		return nil
+	}
+	maxChart := charts[0]
+	for _, chart := range charts[1:] {
+		if float64(chart.Const) > float64(maxChart.Const) {
+			maxChart = chart
+		}
+	}
+	return maxChart
+}
+
+func calcMaxOverpowerValue(charts []*entity.Chart) float64 {
+	total := 0.0
+	for _, chart := range charts {
+		total += service.CalcSongMaxOP(float64(chart.Const))
+	}
+	return total
+}
+
+func hasInvalidGoalTitleRune(title string) bool {
+	for _, r := range title {
+		if unicode.IsControl(r) {
+			return true
+		}
+		switch r {
+		case '\u200B', '\u200C', '\u200D', '\uFEFF':
+			return true
+		}
+	}
+	return false
+}
+
 func isScale(v float64, scale int) bool {
 	f := math.Pow10(scale)
 	return math.Abs(v*f-math.Round(v*f)) < 1e-9
@@ -309,11 +492,15 @@ func isScale(v float64, scale int) bool {
 
 func (u *goalUsecase) toOutputs(goals []*entity.Goal) ([]*GoalOutput, error) {
 	masters := u.masterProvider.GoalMasters()
+	if masters == nil {
+		return nil, ErrInternalError
+	}
 	outs := make([]*GoalOutput, 0, len(goals))
 	for _, g := range goals {
 		typeCode := masters.AchievementTypesByID[g.AchievementTypeID]
 		if typeCode == "" {
-			slog.Warn("achievement type code not found in master cache", "goal_id", g.ID, "achievement_type_id", g.AchievementTypeID)
+			slog.Error("achievement type code not found in master cache", "goal_id", g.ID, "achievement_type_id", g.AchievementTypeID)
+			return nil, ErrInternalError
 		}
 		var p map[string]any
 		if err := json.Unmarshal(g.AchievementParams, &p); err != nil {

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/chartconstant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -56,6 +57,29 @@ func (s *stubGoalRepo) LockUserByID(ctx context.Context, exec repository.Executo
 	return nil
 }
 
+type stubSongRepo struct {
+	songs []*entity.Song
+}
+
+func (s *stubSongRepo) FindAllExcludingWorldsend(ctx context.Context, exec repository.Executor, includeDeleted bool) ([]*entity.Song, error) {
+	return s.songs, nil
+}
+func (s *stubSongRepo) FindByDisplayID(ctx context.Context, exec repository.Executor, displayID string) (*entity.Song, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSongRepo) FindByDisplayIDs(ctx context.Context, exec repository.Executor, displayIDs []string) ([]*entity.Song, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *stubSongRepo) DeleteSong(ctx context.Context, exec repository.Executor, displayID string) error {
+	return errors.New("not implemented")
+}
+func (s *stubSongRepo) RestoreSong(ctx context.Context, exec repository.Executor, displayID string) error {
+	return errors.New("not implemented")
+}
+func (s *stubSongRepo) UpdateSongs(ctx context.Context, exec repository.Executor, songs []*entity.Song) error {
+	return errors.New("not implemented")
+}
+
 type stubTM struct{}
 
 func (s *stubTM) Transactional(ctx context.Context, f func(tx repository.Executor) error) error {
@@ -63,26 +87,37 @@ func (s *stubTM) Transactional(ctx context.Context, f func(tx repository.Executo
 }
 
 type stubGoalMasterProvider struct{}
-
 type stubNilGoalMasterProvider struct{}
 
-func (s *stubNilGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
-	return nil
-}
+func (s *stubNilGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters { return nil }
 
 func (s *stubGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
+	releasedAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	return &domainmasterdata.GoalMasters{
-		AchievementTypesByCode: map[string]domainmasterdata.Item{"score_count": {ID: 2, Name: "score_count"}, "overpower_percent": {ID: 8, Name: "overpower_percent"}},
-		AchievementTypesByID:   map[int]string{2: "score_count", 8: "overpower_percent"},
-		DifficultyNamesByID:    map[int]string{4: "MASTER"},
-		GenreNamesByID:         map[int]string{1: "POPS & ANIME"},
-		VersionsByID:           map[int]domainmasterdata.Version{20: {ID: 20, Name: "VERSE"}},
+		AchievementTypesByCode: map[string]domainmasterdata.Item{
+			"score_count": {ID: 2, Name: "score_count"}, "overpower_percent": {ID: 8, Name: "overpower_percent"},
+		},
+		AchievementTypesByID: map[int]string{2: "score_count", 8: "overpower_percent"},
+		DifficultyNamesByID:  map[int]string{4: "MASTER"},
+		GenreNamesByID:       map[int]string{1: "POPS & ANIME"},
+		VersionsByID:         map[int]domainmasterdata.Version{20: {ID: 20, Name: "VERSE", ReleasedAt: releasedAt}},
 	}
+}
+
+func sampleSongs() []*entity.Song {
+	genreID := 1
+	releasedAt := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	constValue, _ := chartconstant.NewChartConstant(14.0)
+	return []*entity.Song{{ID: 1, GenreID: &genreID, ReleasedAt: &releasedAt, Charts: []*entity.Chart{{ID: 10, DifficultyID: 4, Const: constValue}}}}
+}
+
+func newGoalUsecaseForTest(repo *stubGoalRepo) GoalUsecase {
+	return NewGoalUsecase(nil, &stubTM{}, repo, &stubSongRepo{songs: sampleSongs()}, &stubGoalMasterProvider{})
 }
 
 func TestGoalUsecase_Create(t *testing.T) {
 	repo := &stubGoalRepo{}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	u := newGoalUsecaseForTest(repo)
 	in := &GoalInput{Title: "  test  ", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{"diff":4,"genre":1,"ver":20}`)}
 	out, err := u.Create(context.Background(), 1, in)
 	require.NoError(t, err)
@@ -92,14 +127,14 @@ func TestGoalUsecase_Create(t *testing.T) {
 
 func TestGoalUsecase_CreateLimitExceeded(t *testing.T) {
 	repo := &stubGoalRepo{count: 100}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	u := newGoalUsecaseForTest(repo)
 	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{}`)})
 	assert.True(t, errors.Is(err, ErrGoalLimitExceeded))
 }
 
 func TestGoalUsecase_Delete(t *testing.T) {
 	repo := &stubGoalRepo{goal: &entity.Goal{ID: 1, UserID: 1}}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	u := newGoalUsecaseForTest(repo)
 	err := u.Delete(context.Background(), 1, 1)
 	require.NoError(t, err)
 	assert.Nil(t, repo.goal)
@@ -107,93 +142,100 @@ func TestGoalUsecase_Delete(t *testing.T) {
 
 func TestGoalUsecase_DeleteNotFound(t *testing.T) {
 	repo := &stubGoalRepo{}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	u := newGoalUsecaseForTest(repo)
 	err := u.Delete(context.Background(), 1, 999)
 	assert.True(t, errors.Is(err, ErrGoalNotFound))
 }
 
 func TestGoalUsecase_UpdateNotFoundOnSave(t *testing.T) {
 	repo := &stubGoalRepo{goal: &entity.Goal{ID: 1, UserID: 1}, updateErr: sql.ErrNoRows}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
-	_, err := u.Update(context.Background(), 1, 1, &GoalInput{
-		Title:             "updated",
-		AchievementType:   "score_count",
-		AchievementParams: []byte(`{"score":1000000,"count":1}`),
-		Attributes:        []byte(`{"diff":4,"genre":1,"ver":20}`),
-	})
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Update(context.Background(), 1, 1, &GoalInput{Title: "updated", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{"diff":4,"genre":1,"ver":20}`)})
 	assert.True(t, errors.Is(err, ErrGoalNotFound))
 }
 
 func TestGoalUsecase_CreateMasterDataUnavailable(t *testing.T) {
 	repo := &stubGoalRepo{}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubNilGoalMasterProvider{})
-	_, err := u.Create(context.Background(), 1, &GoalInput{
-		Title:             "test",
-		AchievementType:   "score_count",
-		AchievementParams: []byte(`{"score":1000000,"count":1}`),
-		Attributes:        []byte(`{}`),
-	})
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubSongRepo{songs: sampleSongs()}, &stubNilGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{}`)})
 	assert.True(t, errors.Is(err, ErrInternalError))
 }
 
 func TestGoalUsecase_CreateInvalidDifficultyAttribute(t *testing.T) {
 	repo := &stubGoalRepo{}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
-	_, err := u.Create(context.Background(), 1, &GoalInput{
-		Title:             "test",
-		AchievementType:   "score_count",
-		AchievementParams: []byte(`{"score":1000000,"count":1}`),
-		Attributes:        []byte(`{"diff":5,"genre":1,"ver":20}`),
-	})
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{"diff":5,"genre":1,"ver":20}`)})
 	assert.True(t, errors.Is(err, ErrInvalidGoalAttributes))
 }
 
 func TestGoalUsecase_CreateConstAttributeWithOmittedMinUsesDefault(t *testing.T) {
 	repo := &stubGoalRepo{}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
-	out, err := u.Create(context.Background(), 1, &GoalInput{
-		Title:             "test",
-		AchievementType:   "score_count",
-		AchievementParams: []byte(`{"score":1000000,"count":1}`),
-		Attributes:        []byte(`{"const":{"max":15.9}}`),
-	})
+	u := newGoalUsecaseForTest(repo)
+	out, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{"const":{"max":15.9}}`)})
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{"const": map[string]any{"min": float64(1), "max": float64(15.9)}}, out.Attributes)
 }
 
 func TestGoalUsecase_CreateConstAttributeWithOmittedMaxUsesDefault(t *testing.T) {
 	repo := &stubGoalRepo{}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
-	out, err := u.Create(context.Background(), 1, &GoalInput{
-		Title:             "test",
-		AchievementType:   "score_count",
-		AchievementParams: []byte(`{"score":1000000,"count":1}`),
-		Attributes:        []byte(`{"const":{"min":1.2}}`),
-	})
+	u := newGoalUsecaseForTest(repo)
+	out, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{"const":{"min":1.2}}`)})
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{"const": map[string]any{"min": float64(1.2), "max": float64(15.9)}}, out.Attributes)
 }
 
 func TestGoalUsecase_CreateOverpowerPercentAcceptsRealValue(t *testing.T) {
 	repo := &stubGoalRepo{}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
-	_, err := u.Create(context.Background(), 1, &GoalInput{
-		Title:             "test",
-		AchievementType:   "overpower_percent",
-		AchievementParams: []byte(`{"total":123.456}`),
-		Attributes:        []byte(`{}`),
-	})
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "overpower_percent", AchievementParams: []byte(`{"total":99.999}`), Attributes: []byte(`{}`)})
 	require.NoError(t, err)
+}
+
+func TestGoalUsecase_CreateOverpowerPercentRejectsOver100(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "overpower_percent", AchievementParams: []byte(`{"total":100.001}`), Attributes: []byte(`{}`)})
+	assert.True(t, errors.Is(err, ErrInvalidAchievementParam))
 }
 
 func TestGoalUsecase_CreateOverpowerPercentRejectsMoreThan3Decimals(t *testing.T) {
 	repo := &stubGoalRepo{}
-	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
-	_, err := u.Create(context.Background(), 1, &GoalInput{
-		Title:             "test",
-		AchievementType:   "overpower_percent",
-		AchievementParams: []byte(`{"total":12.3456}`),
-		Attributes:        []byte(`{}`),
-	})
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "overpower_percent", AchievementParams: []byte(`{"total":12.3456}`), Attributes: []byte(`{}`)})
 	assert.True(t, errors.Is(err, ErrInvalidAchievementParam))
+}
+
+func TestGoalUsecase_CreateRejectsTitleWithLineBreak(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test\nabc", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{}`)})
+	assert.True(t, errors.Is(err, ErrInvalidGoalTitle))
+}
+
+func TestGoalUsecase_CreateRejectsConstAttributeWithTwoDecimals(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{"const":{"min":12.34,"max":15.9}}`)})
+	assert.True(t, errors.Is(err, ErrInvalidGoalAttributes))
+}
+
+func TestGoalUsecase_CreateRejectsCountOverDynamicMax(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":2}`), Attributes: []byte(`{}`)})
+	assert.True(t, errors.Is(err, ErrInvalidAchievementParam))
+}
+
+func TestGoalUsecase_CreateAcceptsCountAtDynamicMax(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.Create(context.Background(), 1, &GoalInput{Title: "test", AchievementType: "score_count", AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{}`)})
+	require.NoError(t, err)
+}
+
+func TestGoalUsecase_ListReturnsInternalErrorWhenAchievementTypeMasterMissing(t *testing.T) {
+	repo := &stubGoalRepo{goal: &entity.Goal{ID: 1, UserID: 1, AchievementTypeID: 99, AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{}`)}}
+	u := newGoalUsecaseForTest(repo)
+	_, err := u.List(context.Background(), 1)
+	assert.True(t, errors.Is(err, ErrInternalError))
 }


### PR DESCRIPTION
### Motivation
- 目標(Goal)作成/更新時の入力検証と運用上の安全性を高め、マスタ欠損や不正なパラメータを明確に扱うための改善を行う。
- 動的な上限（対象譜面数に依存する `count` / `total_score` / `overpower_value` 等）をサーバで検証して、不正な目標作成を防止する。

### Description
- 入力検証強化: `title` はtrim後1〜30文字かつ制御文字・ゼロ幅文字を禁止し、`attributes` は未知キー拒否、`attributes.const` の `min`/`max` は小数1桁まで許可するように検証を追加。
- 成果パラメータ強化: `overpower_percent` の `total` を 0..100（小数3桁）に制限し、既存の `achievement_type` ごとの構造検証を継承・拡張。
- 動的上限検証: `attributes` に基づいて対象譜面集合を算出し、`score_count` 系や `total_score` / `overpower_value` の値が対象集合の動的上限を超えないか検証するロジックを `usecase` に追加。これに伴い `GoalUsecase` が `SongRepository` を依存として受け取るよう DI を更新。 
- マスタ欠損の扱い: achievement type のマスタ解決に失敗した場合は継続ではなく `internal_error` として失敗するように変更（アプリ側で異常事態として扱う）。
- エラーコード細分化: `invalid_goal_title` / `invalid_goal_achievement_type` / `invalid_goal_achievement_params` / `invalid_goal_attributes` を追加し、Usecase→APIのマッピングを明確化。 
- ドキュメント: `docs/API.md` の `/internal/me/goals` 節へ検証ルールと主なエラーコードを追記。 
- テスト: `internal/usecase/goal_usecase_impl_test.go` を拡充し、上記ケース（`overpower_percent` 上限、タイトル改行禁止、const桁数、動的上限境界、マスタ欠損 の挙動）を追加。

### Testing
- 単体/統合テスト: `go test ./...` を実行し全パッケージで成功しました。 (内部の Goal 関連テスト含む) 
- 目標ユースケース単体: `go test ./internal/usecase -run Goal` を実行し成功しました。 
- 整形チェック: `gofmt -w` を対象ファイルに実行しコード整形を適用しました。 
- セルフレビュー: AGENTS.md に従い `gofmt` と `go test ./...` を含むセルフレビューを3回実施し、各サイクルでテストが成功することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699857930448832d81624060650eea05)