### PR TITLE
update: Goal機能の残課題対応（動的上限・割合仕様・エラー分類）

### DIFF
--- a/_report/goal_achievement_design.md
+++ b/_report/goal_achievement_design.md
@@ -339,7 +339,7 @@ CREATE TABLE goals (
 - 方針は **A: Goバリデーション中心 + 必要最小限のSchema併用**。
 - 境界（Handler/DTO）で形式チェック。
 - Usecaseで業務ルールチェック。
-  - `title` の形式チェック（trim()後で30文字以内かつ空文字不可）
+  - `title` の形式チェック（trim()後で30文字以内かつ空文字不可、制御文字は禁止）
   - `achievement_type` の有効性確認（起動時プリロード済みのキャッシュ `AchievementTypesByCode` で検索。存在しなければ `goal_invalid_achievement_type` (400)）
   - `achievement_type` の大文字小文字は完全一致のみ許可する（例: `score_count` は許可、`Score_Count` は不許可）
   - `achievement_type` と `params` の一致
@@ -548,6 +548,7 @@ Usecase でマスタIDを引く際は `AbbrevToName` テーブルを経由し、
 |---|---|---|
 | `goal_limit_exceeded` | 400 | 100件上限を超えて作成しようとした |
 | `goal_not_found` | 404 | 指定した goal が存在しない（他ユーザーの goal も含む）|
-| `goal_invalid_achievement_type` | 400 | `achievement_type` が不正な値または `params` との組み合わせが不一致 |
+| `goal_invalid_achievement_type` | 400 | `achievement_type` が不正な値 |
+| `goal_invalid_achievement_params` | 400 | `achievement_params` が不正な値または `achievement_type` との組み合わせが不一致 |
 | `goal_invalid_attributes` | 400 | `attributes` の値が不正（`diff` 範囲外・`const` 範囲外・`genre`/`ver` 未存在など） |
 | `goal_invalid_title` | 400 | `title` が空文字またはtrim後30文字超 |

--- a/_report/goal_remain.md
+++ b/_report/goal_remain.md
@@ -30,8 +30,10 @@
   - 「対象譜面数を超える count」を保存できる可能性がある。
 - 例: `total_score.total`
   - 「対象譜面数 × 1010000」を超える値を保存できる可能性がある。
-- 例: `overpower_value.total` / `overpower_percent.total`
+- 例: `overpower_value.total`
   - 対象譜面の理論値合計を超える値が保存できる可能性がある。
+- 例: `overpower_percent.total`
+  - 割合仕様（0〜100）を超える値が保存できる可能性がある。
 
 **対応方針**
 - Usecase層で `attributes` を解釈し対象譜面集合を確定。

--- a/docs/API.md
+++ b/docs/API.md
@@ -1993,6 +1993,15 @@ interface SkippedRecord {
 
 目標を作成します。`achievement_type` と `achievement_params` の組み合わせはサーバー側で検証します。`overpower_percent` の `achievement_params.total` は割合（0以上100以下・小数3桁まで）として扱います。
 
+`attributes` は `diff` / `const` / `genre` / `ver` のみ許可します。未知キーは不正入力です。`const.min` / `const.max` は小数1桁まで許可します。
+
+サーバー側では `attributes` で絞り込まれた対象譜面数をもとに上限を動的に検証します。
+
+- `rank_count` / `score_count` / `hardlamp_count` / `combolamp_count` の `count` は対象譜面数以下
+- `total_score.total` は `対象譜面数 × 1010000` 以下
+- `overpower_value.total` は対象譜面の理論値OverPower合計以下
+- `overpower_percent.total` は割合のため 0〜100 の固定上限
+
 ### PUT `/internal/me/goals/:id`
 
 指定IDの目標を更新します。
@@ -2000,3 +2009,14 @@ interface SkippedRecord {
 ### DELETE `/internal/me/goals/:id`
 
 指定IDの目標を削除します。
+
+### Goal API エラーコード
+
+| エラーコード | HTTP | 説明 |
+|---|---|---|
+| `goal_not_found` | 404 | 指定した goal が存在しない（他ユーザーの goal も含む） |
+| `goal_limit_exceeded` | 400 | 100件上限を超えて作成しようとした |
+| `goal_invalid_title` | 400 | `title` が空文字、trim後30文字超、または制御文字を含む |
+| `goal_invalid_achievement_type` | 400 | `achievement_type` が不正 |
+| `goal_invalid_achievement_params` | 400 | `achievement_params` の形式不正・範囲不正・動的上限超過 |
+| `goal_invalid_attributes` | 400 | `attributes` の形式不正・マスタ不整合・未許可キー |

--- a/internal/app/apierror/api_error.go
+++ b/internal/app/apierror/api_error.go
@@ -104,9 +104,13 @@ var (
 	ErrInvalidPassword       = New(CodeInvalidPassword, http.StatusBadRequest)       // パスワード無効（詳細隠蔽）
 	ErrAppVersionUnsupported = New(CodeAppVersionUnsupported, http.StatusBadRequest) // 対応していないアプリバージョン
 
-	ErrGoalNotFound      = New(CodeGoalNotFound, http.StatusNotFound)
-	ErrGoalLimitExceeded = New(CodeGoalLimitExceeded, http.StatusBadRequest)
-	ErrInvalidGoalInput  = New(CodeInvalidGoalInput, http.StatusBadRequest)
+	ErrGoalNotFound                 = New(CodeGoalNotFound, http.StatusNotFound)
+	ErrGoalLimitExceeded            = New(CodeGoalLimitExceeded, http.StatusBadRequest)
+	ErrGoalInvalidTitle             = New(CodeGoalInvalidTitle, http.StatusBadRequest)
+	ErrGoalInvalidAchievementType   = New(CodeGoalInvalidAchievementType, http.StatusBadRequest)
+	ErrGoalInvalidAchievementParams = New(CodeGoalInvalidAchievementParams, http.StatusBadRequest)
+	ErrGoalInvalidAttributes        = New(CodeGoalInvalidAttributes, http.StatusBadRequest)
+	ErrInvalidGoalInput             = New(CodeInvalidGoalInput, http.StatusBadRequest)
 )
 
 // ErrorResponse はエラーレスポンスの構造体です

--- a/internal/app/apierror/codes.go
+++ b/internal/app/apierror/codes.go
@@ -56,7 +56,11 @@ const (
 	CodeAppVersionUnsupported = "app_version_unsupported" // 対応していないアプリバージョン
 
 	// 目標関連エラー
-	CodeGoalNotFound      = "goal_not_found"
-	CodeGoalLimitExceeded = "goal_limit_exceeded"
-	CodeInvalidGoalInput  = "invalid_goal_input"
+	CodeGoalNotFound                 = "goal_not_found"
+	CodeGoalLimitExceeded            = "goal_limit_exceeded"
+	CodeGoalInvalidTitle             = "goal_invalid_title"
+	CodeGoalInvalidAchievementType   = "goal_invalid_achievement_type"
+	CodeGoalInvalidAchievementParams = "goal_invalid_achievement_params"
+	CodeGoalInvalidAttributes        = "goal_invalid_attributes"
+	CodeInvalidGoalInput             = "invalid_goal_input"
 )

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -79,8 +79,16 @@ func FromUsecaseError(err error) *APIError {
 		return ErrGoalNotFound.WithInternal(err)
 	case errors.Is(err, usecase.ErrGoalLimitExceeded):
 		return ErrGoalLimitExceeded.WithInternal(err)
-	case errors.Is(err, usecase.ErrInvalidGoalInput), errors.Is(err, usecase.ErrInvalidGoalTitle), errors.Is(err, usecase.ErrInvalidAchievementType), errors.Is(err, usecase.ErrInvalidAchievementParam), errors.Is(err, usecase.ErrInvalidGoalAttributes):
+	case errors.Is(err, usecase.ErrInvalidGoalInput):
 		return ErrInvalidGoalInput.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidGoalTitle):
+		return ErrGoalInvalidTitle.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidAchievementType):
+		return ErrGoalInvalidAchievementType.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidAchievementParam):
+		return ErrGoalInvalidAchievementParams.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidGoalAttributes):
+		return ErrGoalInvalidAttributes.WithInternal(err)
 	}
 
 	// PlayerDataValidationError

--- a/internal/domain/repository/goal_repository.go
+++ b/internal/domain/repository/goal_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 )
@@ -15,4 +16,21 @@ type GoalRepository interface {
 	DeleteByIDAndUserID(ctx context.Context, exec Executor, id uint32, userID int) error
 	CountByUserID(ctx context.Context, exec Executor, userID int) (int, error)
 	LockUserByID(ctx context.Context, exec Executor, userID int) error
+	GetTargetStats(ctx context.Context, exec Executor, filter GoalTargetFilter) (*GoalTargetStats, error)
+}
+
+// GoalTargetFilter は目標対象譜面の絞り込み条件です。
+type GoalTargetFilter struct {
+	DifficultyID          *int
+	GenreID               *int
+	VersionReleasedAt     *time.Time
+	VersionReleasedBefore *time.Time
+	ConstMin              *float64
+	ConstMax              *float64
+}
+
+// GoalTargetStats は絞り込み結果から得られる上限計算用統計です。
+type GoalTargetStats struct {
+	ChartCount        int
+	TotalOverpowerMax float64
 }

--- a/internal/domain/repository/goal_repository.go
+++ b/internal/domain/repository/goal_repository.go
@@ -31,6 +31,6 @@ type GoalTargetFilter struct {
 
 // GoalTargetStats は絞り込み結果から得られる上限計算用統計です。
 type GoalTargetStats struct {
-	ChartCount        int
-	TotalOverpowerMax float64
+	ChartCount      int
+	TotalChartConst float64
 }

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -17,6 +17,12 @@ const (
 	ChartConstMin        = 1.0
 	ChartConstMax        = 15.9
 
+	// Goal関連の理論値計算定数
+	TheoreticalScore            = 1010000
+	TheoreticalOverpowerBaseAdd = 2.0
+	TheoreticalOverpowerScale   = 5.0
+	TheoreticalOverpowerBonus   = 5.0
+
 	// レートリミット設定: 外部API v1
 	APIRateLimitRequests      = 150              // 一般ユーザーのリクエスト制限（15分間）
 	APIRateLimitAdminRequests = 150000           // ADMINユーザーのリクエスト制限（15分間）
@@ -93,4 +99,9 @@ var ComboLampAbbrevToName = map[string]string{
 var ComboLampNameToAbbrev = map[string]string{
 	"FULL COMBO":  "FC",
 	"ALL JUSTICE": "AJ",
+}
+
+// CalcTheoreticalOverpowerTotal は対象譜面群の理論値OVER POWER合計を計算します。
+func CalcTheoreticalOverpowerTotal(totalChartConst float64, chartCount int) float64 {
+	return (totalChartConst+float64(chartCount)*TheoreticalOverpowerBaseAdd)*TheoreticalOverpowerScale + float64(chartCount)*TheoreticalOverpowerBonus
 }

--- a/internal/infra/repository/goal_repository_impl.go
+++ b/internal/infra/repository/goal_repository_impl.go
@@ -138,18 +138,18 @@ func (r *goalRepository) GetTargetStats(ctx context.Context, exec repository.Exe
 	query := `
 		SELECT
 			COUNT(*) AS chart_count,
-			COALESCE(SUM((c.const + 2.0) * 5.0 + 5.0), 0) AS total_overpower_max
+			COALESCE(SUM(c.const), 0) AS total_chart_const
 		FROM charts c
 		INNER JOIN songs s ON s.id = c.song_id
 		WHERE ` + strings.Join(where, " AND ")
 
 	var row struct {
-		ChartCount        int     `db:"chart_count"`
-		TotalOverpowerMax float64 `db:"total_overpower_max"`
+		ChartCount      int     `db:"chart_count"`
+		TotalChartConst float64 `db:"total_chart_const"`
 	}
 	if err := exec.GetContext(ctx, &row, query, args...); err != nil {
 		return nil, err
 	}
 
-	return &repository.GoalTargetStats{ChartCount: row.ChartCount, TotalOverpowerMax: row.TotalOverpowerMax}, nil
+	return &repository.GoalTargetStats{ChartCount: row.ChartCount, TotalChartConst: row.TotalChartConst}, nil
 }

--- a/internal/infra/repository/goal_repository_impl.go
+++ b/internal/infra/repository/goal_repository_impl.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
@@ -103,4 +104,52 @@ func (r *goalRepository) CountByUserID(ctx context.Context, exec repository.Exec
 func (r *goalRepository) LockUserByID(ctx context.Context, exec repository.Executor, userID int) error {
 	var id int
 	return exec.GetContext(ctx, &id, `SELECT id FROM users WHERE id = ? FOR UPDATE`, userID)
+}
+
+func (r *goalRepository) GetTargetStats(ctx context.Context, exec repository.Executor, filter repository.GoalTargetFilter) (*repository.GoalTargetStats, error) {
+	where := []string{"s.is_deleted = 0"}
+	args := make([]any, 0, 5)
+
+	if filter.DifficultyID != nil {
+		where = append(where, "c.difficulty_id = ?")
+		args = append(args, *filter.DifficultyID)
+	}
+	if filter.GenreID != nil {
+		where = append(where, "s.genre_id = ?")
+		args = append(args, *filter.GenreID)
+	}
+	if filter.VersionReleasedAt != nil {
+		where = append(where, "s.released_at >= ?")
+		args = append(args, *filter.VersionReleasedAt)
+	}
+	if filter.VersionReleasedBefore != nil {
+		where = append(where, "s.released_at < ?")
+		args = append(args, *filter.VersionReleasedBefore)
+	}
+	if filter.ConstMin != nil {
+		where = append(where, "c.const >= ?")
+		args = append(args, *filter.ConstMin)
+	}
+	if filter.ConstMax != nil {
+		where = append(where, "c.const <= ?")
+		args = append(args, *filter.ConstMax)
+	}
+
+	query := `
+		SELECT
+			COUNT(*) AS chart_count,
+			COALESCE(SUM((c.const + 2.0) * 5.0 + 5.0), 0) AS total_overpower_max
+		FROM charts c
+		INNER JOIN songs s ON s.id = c.song_id
+		WHERE ` + strings.Join(where, " AND ")
+
+	var row struct {
+		ChartCount        int     `db:"chart_count"`
+		TotalOverpowerMax float64 `db:"total_overpower_max"`
+	}
+	if err := exec.GetContext(ctx, &row, query, args...); err != nil {
+		return nil, err
+	}
+
+	return &repository.GoalTargetStats{ChartCount: row.ChartCount, TotalOverpowerMax: row.TotalOverpowerMax}, nil
 }

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -297,7 +297,7 @@ func validateAchievementParams(achievementType string, raw []byte) ([]byte, *goa
 			return nil, nil, ErrInvalidAchievementParam
 		}
 		var score, count int
-		if err := json.Unmarshal(m["score"], &score); err != nil || score < 0 || score > 1010000 {
+		if err := json.Unmarshal(m["score"], &score); err != nil || score < 0 || score > info.TheoreticalScore {
 			return nil, nil, ErrInvalidAchievementParam
 		}
 		if err := json.Unmarshal(m["count"], &count); err != nil || count < 1 {
@@ -307,7 +307,7 @@ func validateAchievementParams(achievementType string, raw []byte) ([]byte, *goa
 		result.Count = &count
 	case achievementType == "avg_score":
 		var score int
-		if len(m) != 1 || json.Unmarshal(m["score"], &score) != nil || score < 0 || score > 1010000 {
+		if len(m) != 1 || json.Unmarshal(m["score"], &score) != nil || score < 0 || score > info.TheoreticalScore {
 			return nil, nil, ErrInvalidAchievementParam
 		}
 		result.Score = &score
@@ -380,16 +380,19 @@ func (u *goalUsecase) validateDynamicUpperBound(ctx context.Context, achievement
 		}
 	case "total_score":
 		if params.Total != nil {
-			maxTotal := float64(stats.ChartCount) * 1010000
+			maxTotal := float64(stats.ChartCount) * float64(info.TheoreticalScore)
 			if *params.Total > maxTotal {
 				slog.Info("goal validation failed", "reason", "total_score_over_dynamic_max", "input", *params.Total, "max", maxTotal)
 				return ErrInvalidAchievementParam
 			}
 		}
 	case "overpower_value":
-		if params.Total != nil && *params.Total > stats.TotalOverpowerMax {
-			slog.Info("goal validation failed", "reason", "overpower_value_over_dynamic_max", "input", *params.Total, "max", stats.TotalOverpowerMax)
-			return ErrInvalidAchievementParam
+		if params.Total != nil {
+			maxTotal := info.CalcTheoreticalOverpowerTotal(stats.TotalChartConst, stats.ChartCount)
+			if *params.Total > maxTotal {
+				slog.Info("goal validation failed", "reason", "overpower_value_over_dynamic_max", "input", *params.Total, "max", maxTotal)
+				return ErrInvalidAchievementParam
+			}
 		}
 	case "overpower_percent":
 		// 割合(0-100)で扱うため動的上限は不要

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math"
 	"strings"
+	"unicode"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
@@ -46,7 +47,7 @@ func (u *goalUsecase) List(ctx context.Context, userID int) ([]*GoalOutput, erro
 }
 
 func (u *goalUsecase) Create(ctx context.Context, userID int, input *GoalInput) (*GoalOutput, error) {
-	validated, err := u.validateInput(input)
+	validated, err := u.validateInput(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +89,7 @@ func (u *goalUsecase) Create(ctx context.Context, userID int, input *GoalInput) 
 }
 
 func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *GoalInput) (*GoalOutput, error) {
-	validated, err := u.validateInput(input)
+	validated, err := u.validateInput(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -133,12 +134,27 @@ type validatedGoalInput struct {
 	Invert            bool
 }
 
-func (u *goalUsecase) validateInput(input *GoalInput) (*validatedGoalInput, error) {
+type goalAttributeFilter struct {
+	DifficultyID          *int
+	ConstMin              *float64
+	ConstMax              *float64
+	GenreID               *int
+	VersionReleasedAt     *domainmasterdata.Version
+	VersionReleasedBefore *domainmasterdata.Version
+}
+
+type goalAchievementParam struct {
+	Score *int
+	Count *int
+	Total *float64
+}
+
+func (u *goalUsecase) validateInput(ctx context.Context, input *GoalInput) (*validatedGoalInput, error) {
 	if input == nil {
 		return nil, ErrInvalidGoalInput
 	}
 	title := strings.TrimSpace(input.Title)
-	if title == "" || len([]rune(title)) > 30 {
+	if title == "" || len([]rune(title)) > 30 || hasControlCharacter(title) {
 		return nil, ErrInvalidGoalTitle
 	}
 	masters := u.masterProvider.GoalMasters()
@@ -149,39 +165,47 @@ func (u *goalUsecase) validateInput(input *GoalInput) (*validatedGoalInput, erro
 	if !ok {
 		return nil, ErrInvalidAchievementType
 	}
-	attrsRaw, err := validateAttributes(input.Attributes, masters)
+	attrsRaw, attrsFilter, err := validateAttributes(input.Attributes, masters)
 	if err != nil {
 		return nil, err
 	}
-	paramsRaw, err := validateAchievementParams(input.AchievementType, input.AchievementParams)
+	paramsRaw, params, err := validateAchievementParams(input.AchievementType, input.AchievementParams)
 	if err != nil {
 		return nil, err
 	}
+
+	if err := u.validateDynamicUpperBound(ctx, input.AchievementType, attrsFilter, params); err != nil {
+		return nil, err
+	}
+
 	return &validatedGoalInput{Title: title, AchievementTypeID: item.ID, AchievementParams: paramsRaw, Attributes: attrsRaw, Invert: input.Invert}, nil
 }
 
-func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]byte, error) {
+func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]byte, *goalAttributeFilter, error) {
 	var attrs map[string]json.RawMessage
 	if len(raw) == 0 {
-		return []byte("{}"), nil
+		return []byte("{}"), &goalAttributeFilter{}, nil
 	}
 	if err := json.Unmarshal(raw, &attrs); err != nil {
-		return nil, ErrInvalidGoalAttributes
+		return nil, nil, ErrInvalidGoalAttributes
 	}
 	allowed := map[string]bool{"diff": true, "const": true, "genre": true, "ver": true}
 	for k := range attrs {
 		if !allowed[k] {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 	}
+
+	result := &goalAttributeFilter{}
 	if v, ok := attrs["diff"]; ok {
 		var diff int
 		if err := json.Unmarshal(v, &diff); err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 		if _, exists := masters.DifficultyNamesByID[diff]; !exists {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
+		result.DifficultyID = &diff
 	}
 	if v, ok := attrs["const"]; ok {
 		var c struct {
@@ -189,19 +213,25 @@ func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]by
 			Max *float64 `json:"max"`
 		}
 		if err := json.Unmarshal(v, &c); err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 
 		minConst := info.ChartConstMin
 		maxConst := info.ChartConstMax
 		if c.Min != nil {
+			if !isScale(*c.Min, 1) {
+				return nil, nil, ErrInvalidGoalAttributes
+			}
 			minConst = *c.Min
 		}
 		if c.Max != nil {
+			if !isScale(*c.Max, 1) {
+				return nil, nil, ErrInvalidGoalAttributes
+			}
 			maxConst = *c.Max
 		}
 		if minConst < info.ChartConstMin || maxConst > info.ChartConstMax || minConst > maxConst {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 
 		normalizedConst, err := json.Marshal(struct {
@@ -209,97 +239,163 @@ func validateAttributes(raw []byte, masters *domainmasterdata.GoalMasters) ([]by
 			Max float64 `json:"max"`
 		}{Min: minConst, Max: maxConst})
 		if err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 		attrs["const"] = normalizedConst
+		result.ConstMin = &minConst
+		result.ConstMax = &maxConst
 	}
 	if v, ok := attrs["genre"]; ok {
 		var id int
 		if err := json.Unmarshal(v, &id); err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
 		if _, exists := masters.GenreNamesByID[id]; !exists {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
+		result.GenreID = &id
 	}
 	if v, ok := attrs["ver"]; ok {
 		var id int
 		if err := json.Unmarshal(v, &id); err != nil {
-			return nil, ErrInvalidGoalAttributes
+			return nil, nil, ErrInvalidGoalAttributes
 		}
-		if _, exists := masters.VersionsByID[id]; !exists {
-			return nil, ErrInvalidGoalAttributes
+		version, exists := masters.VersionsByID[id]
+		if !exists {
+			return nil, nil, ErrInvalidGoalAttributes
+		}
+		result.VersionReleasedAt = &version
+		for _, candidate := range masters.VersionsByID {
+			if candidate.ReleasedAt.After(version.ReleasedAt) {
+				if result.VersionReleasedBefore == nil || candidate.ReleasedAt.Before(result.VersionReleasedBefore.ReleasedAt) {
+					v := candidate
+					result.VersionReleasedBefore = &v
+				}
+			}
 		}
 	}
 	canon, err := json.Marshal(attrs)
 	if err != nil {
-		return nil, ErrInvalidGoalAttributes
+		return nil, nil, ErrInvalidGoalAttributes
 	}
-	return canon, nil
+	return canon, result, nil
 }
 
-func validateAchievementParams(achievementType string, raw []byte) ([]byte, error) {
+func validateAchievementParams(achievementType string, raw []byte) ([]byte, *goalAchievementParam, error) {
 	if len(raw) == 0 {
-		return nil, ErrInvalidAchievementParam
+		return nil, nil, ErrInvalidAchievementParam
 	}
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &m); err != nil {
-		return nil, ErrInvalidAchievementParam
+		return nil, nil, ErrInvalidAchievementParam
 	}
+	result := &goalAchievementParam{}
 	scoreCountTypes := map[string]bool{"rank_count": true, "score_count": true}
 	switch {
 	case scoreCountTypes[achievementType]:
 		if len(m) != 2 {
-			return nil, ErrInvalidAchievementParam
+			return nil, nil, ErrInvalidAchievementParam
 		}
 		var score, count int
 		if err := json.Unmarshal(m["score"], &score); err != nil || score < 0 || score > 1010000 {
-			return nil, ErrInvalidAchievementParam
+			return nil, nil, ErrInvalidAchievementParam
 		}
 		if err := json.Unmarshal(m["count"], &count); err != nil || count < 1 {
-			return nil, ErrInvalidAchievementParam
+			return nil, nil, ErrInvalidAchievementParam
 		}
+		result.Score = &score
+		result.Count = &count
 	case achievementType == "avg_score":
 		var score int
 		if len(m) != 1 || json.Unmarshal(m["score"], &score) != nil || score < 0 || score > 1010000 {
-			return nil, ErrInvalidAchievementParam
+			return nil, nil, ErrInvalidAchievementParam
 		}
+		result.Score = &score
 	case achievementType == "hardlamp_count" || achievementType == "combolamp_count":
 		var lamp string
 		var count int
 		if len(m) != 2 || json.Unmarshal(m["lamp"], &lamp) != nil || json.Unmarshal(m["count"], &count) != nil || count < 1 {
-			return nil, ErrInvalidAchievementParam
+			return nil, nil, ErrInvalidAchievementParam
 		}
 		if achievementType == "hardlamp_count" {
 			if _, ok := info.HardLampAbbrevToName[lamp]; !ok {
-				return nil, ErrInvalidAchievementParam
+				return nil, nil, ErrInvalidAchievementParam
 			}
 		} else if _, ok := info.ComboLampAbbrevToName[lamp]; !ok {
-			return nil, ErrInvalidAchievementParam
+			return nil, nil, ErrInvalidAchievementParam
 		}
+		result.Count = &count
 	case achievementType == "total_score":
 		var total int64
 		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 {
-			return nil, ErrInvalidAchievementParam
+			return nil, nil, ErrInvalidAchievementParam
 		}
+		totalFloat := float64(total)
+		result.Total = &totalFloat
 	case achievementType == "overpower_value":
 		var total float64
 		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || !isScale(total, 3) {
-			return nil, ErrInvalidAchievementParam
+			return nil, nil, ErrInvalidAchievementParam
 		}
+		result.Total = &total
 	case achievementType == "overpower_percent":
 		var total float64
-		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || !isScale(total, 3) {
-			return nil, ErrInvalidAchievementParam
+		if len(m) != 1 || json.Unmarshal(m["total"], &total) != nil || total < 0 || total > 100 || !isScale(total, 3) {
+			return nil, nil, ErrInvalidAchievementParam
 		}
+		result.Total = &total
 	default:
-		return nil, ErrInvalidAchievementType
+		return nil, nil, ErrInvalidAchievementType
 	}
 	b, err := json.Marshal(m)
 	if err != nil {
-		return nil, ErrInvalidAchievementParam
+		return nil, nil, ErrInvalidAchievementParam
 	}
-	return b, nil
+	return b, result, nil
+}
+
+func (u *goalUsecase) validateDynamicUpperBound(ctx context.Context, achievementType string, attrs *goalAttributeFilter, params *goalAchievementParam) error {
+	filter := repository.GoalTargetFilter{
+		DifficultyID: attrs.DifficultyID,
+		GenreID:      attrs.GenreID,
+		ConstMin:     attrs.ConstMin,
+		ConstMax:     attrs.ConstMax,
+	}
+	if attrs.VersionReleasedAt != nil {
+		filter.VersionReleasedAt = &attrs.VersionReleasedAt.ReleasedAt
+	}
+	if attrs.VersionReleasedBefore != nil {
+		filter.VersionReleasedBefore = &attrs.VersionReleasedBefore.ReleasedAt
+	}
+	stats, err := u.goalRepo.GetTargetStats(ctx, u.db, filter)
+	if err != nil {
+		return err
+	}
+
+	switch achievementType {
+	case "rank_count", "score_count", "hardlamp_count", "combolamp_count":
+		if params.Count != nil && *params.Count > stats.ChartCount {
+			slog.Info("goal validation failed", "reason", "count_over_dynamic_max", "achievement_type", achievementType, "input", *params.Count, "max", stats.ChartCount)
+			return ErrInvalidAchievementParam
+		}
+	case "total_score":
+		if params.Total != nil {
+			maxTotal := float64(stats.ChartCount) * 1010000
+			if *params.Total > maxTotal {
+				slog.Info("goal validation failed", "reason", "total_score_over_dynamic_max", "input", *params.Total, "max", maxTotal)
+				return ErrInvalidAchievementParam
+			}
+		}
+	case "overpower_value":
+		if params.Total != nil && *params.Total > stats.TotalOverpowerMax {
+			slog.Info("goal validation failed", "reason", "overpower_value_over_dynamic_max", "input", *params.Total, "max", stats.TotalOverpowerMax)
+			return ErrInvalidAchievementParam
+		}
+	case "overpower_percent":
+		// 割合(0-100)で扱うため動的上限は不要
+	}
+
+	return nil
 }
 
 func isScale(v float64, scale int) bool {
@@ -307,13 +403,26 @@ func isScale(v float64, scale int) bool {
 	return math.Abs(v*f-math.Round(v*f)) < 1e-9
 }
 
+func hasControlCharacter(value string) bool {
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
 func (u *goalUsecase) toOutputs(goals []*entity.Goal) ([]*GoalOutput, error) {
 	masters := u.masterProvider.GoalMasters()
+	if masters == nil {
+		return nil, ErrInternalError
+	}
 	outs := make([]*GoalOutput, 0, len(goals))
 	for _, g := range goals {
 		typeCode := masters.AchievementTypesByID[g.AchievementTypeID]
 		if typeCode == "" {
-			slog.Warn("achievement type code not found in master cache", "goal_id", g.ID, "achievement_type_id", g.AchievementTypeID)
+			slog.Error("achievement type code not found in master cache", "goal_id", g.ID, "achievement_type_id", g.AchievementTypeID)
+			return nil, ErrInternalError
 		}
 		var p map[string]any
 		if err := json.Unmarshal(g.AchievementParams, &p); err != nil {

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -58,7 +58,7 @@ func (s *stubGoalRepo) LockUserByID(ctx context.Context, exec repository.Executo
 }
 func (s *stubGoalRepo) GetTargetStats(ctx context.Context, exec repository.Executor, filter repository.GoalTargetFilter) (*repository.GoalTargetStats, error) {
 	if s.stats == nil {
-		return &repository.GoalTargetStats{ChartCount: 1000, TotalOverpowerMax: 90000}, nil
+		return &repository.GoalTargetStats{ChartCount: 1000, TotalChartConst: 17000}, nil
 	}
 	return s.stats, nil
 }
@@ -231,7 +231,7 @@ func TestGoalUsecase_CreateRejectsUnknownAttributeKey(t *testing.T) {
 }
 
 func TestGoalUsecase_CreateRejectsCountOverDynamicUpperBound(t *testing.T) {
-	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalOverpowerMax: 100}}
+	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalChartConst: 20.0}}
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	_, err := u.Create(context.Background(), 1, &GoalInput{
 		Title:             "test",
@@ -243,7 +243,7 @@ func TestGoalUsecase_CreateRejectsCountOverDynamicUpperBound(t *testing.T) {
 }
 
 func TestGoalUsecase_CreateRejectsTotalScoreOverDynamicUpperBound(t *testing.T) {
-	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalOverpowerMax: 100}}
+	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalChartConst: 20.0}}
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	_, err := u.Create(context.Background(), 1, &GoalInput{
 		Title:             "test",
@@ -255,7 +255,7 @@ func TestGoalUsecase_CreateRejectsTotalScoreOverDynamicUpperBound(t *testing.T) 
 }
 
 func TestGoalUsecase_CreateRejectsOverpowerValueOverDynamicUpperBound(t *testing.T) {
-	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalOverpowerMax: 99.9}}
+	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalChartConst: 10.0}}
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	_, err := u.Create(context.Background(), 1, &GoalInput{
 		Title:             "test",

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -18,6 +18,7 @@ type stubGoalRepo struct {
 	count     int
 	goal      *entity.Goal
 	updateErr error
+	stats     *repository.GoalTargetStats
 }
 
 func (s *stubGoalRepo) ListByUserID(ctx context.Context, exec repository.Executor, userID int) ([]*entity.Goal, error) {
@@ -55,6 +56,12 @@ func (s *stubGoalRepo) CountByUserID(ctx context.Context, exec repository.Execut
 func (s *stubGoalRepo) LockUserByID(ctx context.Context, exec repository.Executor, userID int) error {
 	return nil
 }
+func (s *stubGoalRepo) GetTargetStats(ctx context.Context, exec repository.Executor, filter repository.GoalTargetFilter) (*repository.GoalTargetStats, error) {
+	if s.stats == nil {
+		return &repository.GoalTargetStats{ChartCount: 1000, TotalOverpowerMax: 90000}, nil
+	}
+	return s.stats, nil
+}
 
 type stubTM struct{}
 
@@ -64,6 +71,8 @@ func (s *stubTM) Transactional(ctx context.Context, f func(tx repository.Executo
 
 type stubGoalMasterProvider struct{}
 
+type stubMissingTypeMasterProvider struct{}
+
 type stubNilGoalMasterProvider struct{}
 
 func (s *stubNilGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
@@ -72,12 +81,24 @@ func (s *stubNilGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters 
 
 func (s *stubGoalMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
 	return &domainmasterdata.GoalMasters{
-		AchievementTypesByCode: map[string]domainmasterdata.Item{"score_count": {ID: 2, Name: "score_count"}, "overpower_percent": {ID: 8, Name: "overpower_percent"}},
-		AchievementTypesByID:   map[int]string{2: "score_count", 8: "overpower_percent"},
-		DifficultyNamesByID:    map[int]string{4: "MASTER"},
-		GenreNamesByID:         map[int]string{1: "POPS & ANIME"},
-		VersionsByID:           map[int]domainmasterdata.Version{20: {ID: 20, Name: "VERSE"}},
+		AchievementTypesByCode: map[string]domainmasterdata.Item{
+			"score_count":       {ID: 2, Name: "score_count"},
+			"rank_count":        {ID: 1, Name: "rank_count"},
+			"total_score":       {ID: 6, Name: "total_score"},
+			"overpower_value":   {ID: 7, Name: "overpower_value"},
+			"overpower_percent": {ID: 8, Name: "overpower_percent"},
+		},
+		AchievementTypesByID: map[int]string{1: "rank_count", 2: "score_count", 6: "total_score", 7: "overpower_value", 8: "overpower_percent"},
+		DifficultyNamesByID:  map[int]string{4: "MASTER"},
+		GenreNamesByID:       map[int]string{1: "POPS & ANIME"},
+		VersionsByID:         map[int]domainmasterdata.Version{20: {ID: 20, Name: "VERSE", ReleasedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}},
 	}
+}
+
+func (s *stubMissingTypeMasterProvider) GoalMasters() *domainmasterdata.GoalMasters {
+	m := (&stubGoalMasterProvider{}).GoalMasters()
+	delete(m.AchievementTypesByID, 2)
+	return m
 }
 
 func TestGoalUsecase_Create(t *testing.T) {
@@ -161,20 +182,19 @@ func TestGoalUsecase_CreateConstAttributeWithOmittedMinUsesDefault(t *testing.T)
 	assert.Equal(t, map[string]any{"const": map[string]any{"min": float64(1), "max": float64(15.9)}}, out.Attributes)
 }
 
-func TestGoalUsecase_CreateConstAttributeWithOmittedMaxUsesDefault(t *testing.T) {
+func TestGoalUsecase_CreateConstAttributeRejectsMoreThanOneDecimal(t *testing.T) {
 	repo := &stubGoalRepo{}
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
-	out, err := u.Create(context.Background(), 1, &GoalInput{
+	_, err := u.Create(context.Background(), 1, &GoalInput{
 		Title:             "test",
 		AchievementType:   "score_count",
 		AchievementParams: []byte(`{"score":1000000,"count":1}`),
-		Attributes:        []byte(`{"const":{"min":1.2}}`),
+		Attributes:        []byte(`{"const":{"min":1.23,"max":15.9}}`),
 	})
-	require.NoError(t, err)
-	assert.Equal(t, map[string]any{"const": map[string]any{"min": float64(1.2), "max": float64(15.9)}}, out.Attributes)
+	assert.True(t, errors.Is(err, ErrInvalidGoalAttributes))
 }
 
-func TestGoalUsecase_CreateOverpowerPercentAcceptsRealValue(t *testing.T) {
+func TestGoalUsecase_CreateOverpowerPercentRejectsOver100(t *testing.T) {
 	repo := &stubGoalRepo{}
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	_, err := u.Create(context.Background(), 1, &GoalInput{
@@ -183,17 +203,72 @@ func TestGoalUsecase_CreateOverpowerPercentAcceptsRealValue(t *testing.T) {
 		AchievementParams: []byte(`{"total":123.456}`),
 		Attributes:        []byte(`{}`),
 	})
-	require.NoError(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidAchievementParam))
 }
 
-func TestGoalUsecase_CreateOverpowerPercentRejectsMoreThan3Decimals(t *testing.T) {
+func TestGoalUsecase_CreateRejectsControlCharacterInTitle(t *testing.T) {
+	repo := &stubGoalRepo{}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "bad\ntitle",
+		AchievementType:   "score_count",
+		AchievementParams: []byte(`{"score":1000000,"count":1}`),
+		Attributes:        []byte(`{}`),
+	})
+	assert.True(t, errors.Is(err, ErrInvalidGoalTitle))
+}
+
+func TestGoalUsecase_CreateRejectsUnknownAttributeKey(t *testing.T) {
 	repo := &stubGoalRepo{}
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	_, err := u.Create(context.Background(), 1, &GoalInput{
 		Title:             "test",
-		AchievementType:   "overpower_percent",
-		AchievementParams: []byte(`{"total":12.3456}`),
+		AchievementType:   "score_count",
+		AchievementParams: []byte(`{"score":1000000,"count":1}`),
+		Attributes:        []byte(`{"unknown":1}`),
+	})
+	assert.True(t, errors.Is(err, ErrInvalidGoalAttributes))
+}
+
+func TestGoalUsecase_CreateRejectsCountOverDynamicUpperBound(t *testing.T) {
+	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalOverpowerMax: 100}}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "score_count",
+		AchievementParams: []byte(`{"score":1000000,"count":3}`),
 		Attributes:        []byte(`{}`),
 	})
 	assert.True(t, errors.Is(err, ErrInvalidAchievementParam))
+}
+
+func TestGoalUsecase_CreateRejectsTotalScoreOverDynamicUpperBound(t *testing.T) {
+	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalOverpowerMax: 100}}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "total_score",
+		AchievementParams: []byte(`{"total":2020001}`),
+		Attributes:        []byte(`{}`),
+	})
+	assert.True(t, errors.Is(err, ErrInvalidAchievementParam))
+}
+
+func TestGoalUsecase_CreateRejectsOverpowerValueOverDynamicUpperBound(t *testing.T) {
+	repo := &stubGoalRepo{stats: &repository.GoalTargetStats{ChartCount: 2, TotalOverpowerMax: 99.9}}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
+	_, err := u.Create(context.Background(), 1, &GoalInput{
+		Title:             "test",
+		AchievementType:   "overpower_value",
+		AchievementParams: []byte(`{"total":100.0}`),
+		Attributes:        []byte(`{}`),
+	})
+	assert.True(t, errors.Is(err, ErrInvalidAchievementParam))
+}
+
+func TestGoalUsecase_ListReturnsInternalErrorWhenAchievementTypeMissing(t *testing.T) {
+	repo := &stubGoalRepo{goal: &entity.Goal{ID: 1, UserID: 1, Title: "test", AchievementTypeID: 2, AchievementParams: []byte(`{"score":1000000,"count":1}`), Attributes: []byte(`{}`)}}
+	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubMissingTypeMasterProvider{})
+	_, err := u.List(context.Background(), 1)
+	assert.True(t, errors.Is(err, ErrInternalError))
 }


### PR DESCRIPTION
### Motivation

- `overpower_percent` を実数値運用から割合（0〜100、小数3桁）に戻して仕様と実装を一致させる必要があった。 
- `attributes` による絞り込みに基づく動的上限検証が不足しており、不正な保存を防ぐためにサーバ側で動的上限チェックを導入する必要があった。 
- マスタ欠損時の扱いやエラー分類が曖昧だったため、エラーコードを細分化しマスタ欠損は内部エラーとして扱う方針に揃える必要があった。

### Description

- Usecaseに動的上限検証を追加し、対象譜面数/理論値合計を基に `count` 系、`total_score.total`、`overpower_value.total` の上限を検証する `validateDynamicUpperBound` を実装しました。 
- `overpower_percent` を割合（0〜100、小数3桁）として検証するよう変更し、該当条件は動的上限から除外しました。 
- 目標対象統計取得用に `GoalRepository` に `GetTargetStats` インターフェースを追加し、`charts` × `songs` のJOINで `ChartCount` と `TotalOverpowerMax` を算出する実装を追加しました。 
- 入力バリデーション強化として `title` の制御文字禁止、`attributes.const` の小数1桁制約、未知キーの拒否、`ver` のバージョン期間による絞り込みを導入しました。 
- APIエラーコードを細分化して `goal_invalid_title` / `goal_invalid_achievement_type` / `goal_invalid_achievement_params` / `goal_invalid_attributes` を追加し、`usecase` → `apierror` マッピングを更新してマスタ欠損時は `internal_error` を返すようにしました。 
- ドキュメント（`docs/API.md`、`_report/goal_achievement_design.md`、`_report/goal_remain.md`）を更新してバリデーション仕様・エラー一覧・`overpower_percent` 仕様を明記しました。 

### Testing

- `gofmt` を実行してコード整形を行い、`go test ./...` を実行して全テストが成功したことを確認しました。 
- 目標機能のユースケース向けテスト群（`internal/usecase/goal_usecase_impl_test.go`）に動的上限・const小数桁・percent上限・title制御文字・未知attributesキー・マスタ欠損時のケースを追加して全て通過しました。 
- セルフレビューとして `gofmt` と `go test` を複数回実行して整合性とスタイルを確認済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699869fc89cc832dae6b2e1f1d956e6a)