### PR TITLE
Precompile username regex; use errors.Is for sql.ErrNoRows in player repo; add unit test

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,7 +18,7 @@ internal/
 ├── domain/      # ドメインモデルとリポジトリインターフェース
 │   ├── entity/  # エンティティ（純粋なドメインモデル、db/jsonタグなし）
 │   ├── vo/      # 値オブジェクト
-│   ├── rating/  # レーティング計算ドメインサービス
+│   ├── service/  # レーティング計算ドメインサービス
 │   └── repository/ # リポジトリインターフェース
 ├── dto/         # データ転送オブジェクト（API入出力用）
 ├── info/        # アプリケーションの基本情報
@@ -44,7 +44,7 @@ internal/
 - **`entity`**: アプリケーションで扱うエンティティ（例: `User`, `Player`）を定義します。**ドメインの純粋性を保つため、`db`タグや`json`タグは一切含まれません**。エンティティは振る舞いメソッド（例: `User.IsActive()`, `PlayerRecord.IsRanked()`）を持ち、ビジネスロジックをカプセル化します。
 - **`vo`**: 値オブジェクト（Value Object）を定義します。エンティティの属性を型安全に表現し、不変性とバリデーションを保証します（例: `username.UserName`, `score.Score`）。
 - **`repository`**: データベースなどへの永続化処理を抽象化するためのインターフェースを定義します。具体的な実装は`infra/repository`層が担当します。全メソッドは `context.Context` を第一引数に取ります。
-- **`rating`**: CHUNITHM特有のレーティング計算ロジックを提供するドメインサービスです（例: `CalcSingleRating`, `CalcSingleOverpower`）。
+- **`service`**: CHUNITHM特有のレーティング計算ロジックを提供するドメインサービスです（例: `CalcSingleRating`, `CalcSingleOverpower`）。
 
 ### `internal/usecase` - ユースケース層
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,7 +142,7 @@ repo.Save(ctx, user)
 
 複数エンティティにまたがる、またはエンティティに属さないドメインロジックは、ドメインサービスとして実装されています：
 
-- **domain/rating**: CHUNITHMのレーティング計算ロジック（`CalcSingleRating`, `CalcSingleOverpower`）
+- **domain/service**: CHUNITHMのレーティング計算ロジック（`CalcSingleRating`, `CalcSingleOverpower`）
 
 ---
 

--- a/_report/refactor.md
+++ b/_report/refactor.md
@@ -75,7 +75,6 @@
 | **QUAL-009** | **Medium** | Usecase層でのインフラ層エラー直接参照 | `sql.ErrNoRows` をUsecase層で直接参照している。リポジトリ層でドメインエラーに変換すべき。 |
 | **QUAL-010** | **Medium** | Domain層のExecutorインターフェースがsqlxに依存 | `internal/domain/repository/executor.go` で `*sqlx.Rows`, `*sqlx.Row` を直接参照。ドメイン層がインフラ実装に依存している。 |
 | **QUAL-012** | **Low** | ハンドラーでのValidate呼び出し漏れ | `authRequest`, `changePasswordRequest` 等のリクエスト構造体に `validate` タグがなく、`c.Validate()` も呼ばれていない。 |
-| **QUAL-017** | **Low** | ARCHITECTURE.mdのディレクトリ表記不整合 | `domain/rating` と記載されているが、実際は `domain/service`。参照ドキュメントとの不整合。 |
 
 ---
 
@@ -209,19 +208,6 @@
 
 ---
 
-### QUAL-017: ARCHITECTURE.mdのディレクトリ表記不整合
-- **根拠**:
-  - `ARCHITECTURE.md:21` に `domain/rating` と記載されているが、実際のディレクトリ構造は `internal/domain/service`。
-  - レーティング計算サービスは `internal/domain/service/rating_service.go` に配置されている。
-- **影響範囲**:
-  - AGENTS.mdから参照される関連ドキュメントの不整合は、AIエージェントが正しいディレクトリを判断できない原因となる。
-  - 新規参加者がドキュメントを読んだ際に混乱する。
-- **修正案**:
-  - `ARCHITECTURE.md` の該当箇所を `domain/service` に修正。
-  - プロジェクト全体のドキュメントで他にも古い記載がないか確認。
-
----
-
 ### INFRA-001: `playerRepository.Create` のカラム名誤りによる実行時エラー
 - **根拠**:
   - `internal/infra/repository/player_repository_impl.go` の `Create` メソッドが `INSERT INTO players (name) VALUES (?)` を実行するが、DBスキーマ上のカラム名は `player_name`。さらに `user_id`（NOT NULL）と `player_level`（NOT NULL, CHECK >= 1）が欠落。
@@ -230,16 +216,6 @@
   - `CreatePlayer` ハンドラ → usecase → `playerRepo.Create` の呼び出しチェーンで、プレイヤー作成APIが実行時に必ずSQLエラーで失敗する。
 - **修正案**:
   - `Create` メソッドを廃止し、`Save` メソッドに統一する。
-
----
-
-### INFRA-003: `FindByUserID` の文字列比較によるエラー判定
-- **根拠**:
-  - `internal/infra/repository/player_repository_impl.go` で `err.Error() == "sql: no rows in result set"` という文字列比較で `sql.ErrNoRows` を判定している。
-- **影響範囲**:
-  - Goのバージョンアップやエラーラッピングでメッセージが変更された場合、エラー判定が壊れる。
-- **修正案**:
-  - `errors.Is(err, sql.ErrNoRows)` に変更する。
 
 ---
 
@@ -284,17 +260,6 @@
   - DBやJSON入力に不正な値（負値等）が存在した場合、バリデーションなしで不正なVOが生成される。
 - **修正案**:
   - `Scan`/`UnmarshalJSON` 内で `NewChartConstant`/`NewNotes` を経由してバリデーションを実行する。`score.Score` のパターンに統一。
-
----
-
-### DOM-015: `username.validateUserName` で毎回正規表現をコンパイル
-- **根拠**:
-  - `internal/domain/vo/username/username.go` で `regexp.MatchString("^[a-z0-9]+$", value)` を使用。これは呼び出しのたびに正規表現をコンパイルする。
-  - 同パッケージの `internal/domain/vo/displayid/displayid.go` では `regexp.MustCompile` でプリコンパイル済みの正規表現を使用しており、パターンが不一致。
-- **影響範囲**:
-  - ユーザー登録・ログイン時に毎回コンパイルコストが発生。高負荷時にパフォーマンス影響。
-- **修正案**:
-  - パッケージレベルで `var usernamePattern = regexp.MustCompile(...)` として定義し、`usernamePattern.MatchString(value)` を使用する。
 
 ---
 
@@ -349,7 +314,6 @@
 | **DOM-012** | **Low** | `WorldsendSongWithChart` と `WorldsendSongChartPair` の重複 | `repository` 層と `service` 層にフィールド同一の重複構造体。entity層に統一構造体を定義すべき。 |
 | **DOM-013** | **Low** | エラーメッセージの日英混在 | 値オブジェクトは英語、エンティティバリデーションは日本語。同一パッケージ内でも混在あり。方針を統一すべき。 |
 | **DOM-014** | **Medium** | `PlayerDataChart.Const` がVO未使用 | `float64` で定義されており、通常の `Chart` が使う `chartconstant.ChartConstant` と不整合。VOによるバリデーションが適用されない。 |
-| **DOM-015** | **Medium** | `username.validateUserName` で毎回正規表現をコンパイル | `regexp.MatchString` は呼び出しのたびにコンパイル。`displayid.go` では `regexp.MustCompile` でプリコンパイル済みであり一貫性がない。 |
 | **DOM-016** | **Low** | `record_completion_service.go` が `sort.Slice` 使用 | `rating_service.go` は `slices.SortFunc` 使用。Go 1.25で推奨される `slices` パッケージに統一すべき。 |
 | **DOM-017** | **Low** | `PlayerHonor` がrepository層に定義 | ドメイン概念だが `repository` パッケージ内に定義。`entity` パッケージに移動すべき。 |
 | **DOM-018** | **Medium** | `repository.errors.go` のエラー定義不足 | `ErrSongNotFound` のみで `ErrUserNotFound` 等はusecase層に定義。リポジトリが適切なドメインエラーを返せず、QUAL-009の根本原因となっている。 |
@@ -365,7 +329,6 @@
 |---|---|---|---|
 | **INFRA-001** | **Critical** | `playerRepository.Create` のカラム名誤り | `INSERT INTO players (name)` だがDBスキーマでは `player_name`。さらに `user_id`/`player_level` 等の必須カラムが欠落。プレイヤー作成APIが実行時に必ず失敗する。`Create` を廃止し `Save` に統一すべき。 |
 | **INFRA-002** | **Low** | `validation.go` のテーブル名組み立ての安全性改善余地 | 現状は内部固定値のみで直ちに脆弱性とは言えないが、将来の誤用防止のためテーブル名をホワイトリスト化し、任意入力を受け付けないAPIに制限すべき。 |
-| **INFRA-003** | **High** | `FindByUserID` の文字列比較によるエラー判定 | `err.Error() == "sql: no rows in result set"` は脆弱。`errors.Is(err, sql.ErrNoRows)` に変更すべき。 |
 | **INFRA-004** | **Medium** | WORLD'S END楽曲 `UpdateSongs` のN+1問題 | 楽曲と譜面を個別ループでUPDATE。通常楽曲はCASE式一括更新を実装済みであり不整合。バルク更新パターンに統一すべき。 |
 | **INFRA-005** | **Medium** | `validation.go` の全関数でContext未伝播 | `context.Context` を引数に取らず、`db.Get` を使用（`GetContext` ではない）。起動時のキャンセル不能の原因。 |
 | **INFRA-007** | **Medium** | `FindAllWithPlayer` と `FindAllWithPlayerForAdmin` のコード重複 | クエリ構築・LIKE検索・rows反復がほぼ同一。共通ヘルパーに抽出すべき。 |

--- a/internal/domain/vo/username/username.go
+++ b/internal/domain/vo/username/username.go
@@ -13,6 +13,8 @@ type UserName struct {
 	value string
 }
 
+var usernamePattern = regexp.MustCompile("^[a-z0-9]+$")
+
 // NewUserName はバリデーション付きで新しい UserName を作成します
 func NewUserName(value string) (UserName, error) {
 	if err := validateUserName(value); err != nil {
@@ -104,11 +106,7 @@ func validateUserName(value string) error {
 	if len(value) > 50 {
 		return errors.New("username must be 50 characters or less")
 	}
-	matched, err := regexp.MatchString("^[a-z0-9]+$", value)
-	if err != nil {
-		return err
-	}
-	if !matched {
+	if !usernamePattern.MatchString(value) {
 		return errors.New("username can only contain lowercase letters and numbers")
 	}
 	return nil

--- a/internal/infra/repository/player_repository_impl.go
+++ b/internal/infra/repository/player_repository_impl.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
@@ -122,7 +124,7 @@ func (r *playerRepository) FindByUserID(ctx context.Context, exec repository.Exe
 	`
 	var playerModel models.PlayerModel
 	if err := exec.GetContext(ctx, &playerModel, query, userID); err != nil {
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/infra/repository/player_repository_impl_test.go
+++ b/internal/infra/repository/player_repository_impl_test.go
@@ -11,38 +11,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type noRowsWrappedExecutor struct{}
+type baseExecutor struct{}
+
+func (e *baseExecutor) GetContext(ctx context.Context, dest any, query string, args ...any) error {
+	panic("unexpected call to GetContext")
+}
+
+func (e *baseExecutor) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
+	panic("unexpected call to SelectContext")
+}
+
+func (e *baseExecutor) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	panic("unexpected call to ExecContext")
+}
+
+func (e *baseExecutor) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
+	panic("unexpected call to NamedExecContext")
+}
+
+func (e *baseExecutor) Rebind(query string) string {
+	panic("unexpected call to Rebind")
+}
+
+func (e *baseExecutor) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	panic("unexpected call to QueryContext")
+}
+
+func (e *baseExecutor) QueryxContext(ctx context.Context, query string, args ...any) (*sqlx.Rows, error) {
+	panic("unexpected call to QueryxContext")
+}
+
+func (e *baseExecutor) QueryRowxContext(ctx context.Context, query string, args ...any) *sqlx.Row {
+	panic("unexpected call to QueryRowxContext")
+}
+
+var _ domainrepo.Executor = (*baseExecutor)(nil)
+
+type noRowsWrappedExecutor struct {
+	baseExecutor
+}
 
 func (e *noRowsWrappedExecutor) GetContext(ctx context.Context, dest any, query string, args ...any) error {
 	return errors.Join(errors.New("wrapped no rows"), sql.ErrNoRows)
-}
-
-func (e *noRowsWrappedExecutor) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
-	return nil
-}
-
-func (e *noRowsWrappedExecutor) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	return nil, nil
-}
-
-func (e *noRowsWrappedExecutor) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
-	return nil, nil
-}
-
-func (e *noRowsWrappedExecutor) Rebind(query string) string {
-	return query
-}
-
-func (e *noRowsWrappedExecutor) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	return nil, nil
-}
-
-func (e *noRowsWrappedExecutor) QueryxContext(ctx context.Context, query string, args ...any) (*sqlx.Rows, error) {
-	return nil, nil
-}
-
-func (e *noRowsWrappedExecutor) QueryRowxContext(ctx context.Context, query string, args ...any) *sqlx.Row {
-	return nil
 }
 
 var _ domainrepo.Executor = (*noRowsWrappedExecutor)(nil)

--- a/internal/infra/repository/player_repository_impl_test.go
+++ b/internal/infra/repository/player_repository_impl_test.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	domainrepo "github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+type noRowsWrappedExecutor struct{}
+
+func (e *noRowsWrappedExecutor) GetContext(ctx context.Context, dest any, query string, args ...any) error {
+	return errors.Join(errors.New("wrapped no rows"), sql.ErrNoRows)
+}
+
+func (e *noRowsWrappedExecutor) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
+	return nil
+}
+
+func (e *noRowsWrappedExecutor) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return nil, nil
+}
+
+func (e *noRowsWrappedExecutor) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
+	return nil, nil
+}
+
+func (e *noRowsWrappedExecutor) Rebind(query string) string {
+	return query
+}
+
+func (e *noRowsWrappedExecutor) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return nil, nil
+}
+
+func (e *noRowsWrappedExecutor) QueryxContext(ctx context.Context, query string, args ...any) (*sqlx.Rows, error) {
+	return nil, nil
+}
+
+func (e *noRowsWrappedExecutor) QueryRowxContext(ctx context.Context, query string, args ...any) *sqlx.Row {
+	return nil
+}
+
+var _ domainrepo.Executor = (*noRowsWrappedExecutor)(nil)
+
+func TestFindByUserID_ReturnsNilWhenWrappedNoRows(t *testing.T) {
+	repo := &playerRepository{}
+	exec := &noRowsWrappedExecutor{}
+
+	player, err := repo.FindByUserID(context.Background(), exec, 10)
+	require.NoError(t, err)
+	require.Nil(t, player)
+}


### PR DESCRIPTION
### Motivation

- Improve performance by avoiding repetitive regexp compilation when validating `UserName` values. 
- Make repository error handling robust against wrapped errors by using `errors.Is` to detect `sql.ErrNoRows`. 
- Ensure the `FindByUserID` behavior returns `(nil, nil)` even when `sql.ErrNoRows` is wrapped, via an automated test. 

### Description

- Precompile the username validation pattern as `usernamePattern` and switch `validateUserName` to use `usernamePattern.MatchString`, replacing repeated `regexp.MatchString` calls in `internal/domain/vo/username/username.go`.
- Replace fragile string comparison of the error message with `errors.Is(err, sql.ErrNoRows)` in `internal/infra/repository/player_repository_impl.go`'s `FindByUserID` implementation and add the necessary imports (`database/sql`, `errors`).
- Add `internal/infra/repository/player_repository_impl_test.go` which defines a `noRowsWrappedExecutor` that returns a wrapped `sql.ErrNoRows` and asserts that `FindByUserID` returns `(nil, nil)` in that case.
- Minor documentation alignment: update `ARCHITECTURE.md` to reference `domain/service` instead of `domain/rating` and adjust report references in `_report/refactor.md`.

### Testing

- Added and ran `TestFindByUserID_ReturnsNilWhenWrappedNoRows` in `internal/infra/repository`, which passed successfully.
- Ran repository package tests with `go test ./internal/infra/repository -v`, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e57f602d0832d8495d35c968e47ea)