### PR TITLE
refactor: usecase境界の依存整理とchunirec依存縮退

### DIFF
--- a/_report/refactor.md
+++ b/_report/refactor.md
@@ -52,7 +52,6 @@
 | **REF-G10** | 設定バリデーションと起動時安全性の強化 | CFG-001, CFG-002, CFG-003, CFG-004, LIB-002 | 不正設定の早期検知不足が共通課題。設定読み込み方式とバリデーションを統一し、起動時にフェイルファスト化する。 |
 | **REF-G11** | コード重複削減と共通化 | UC-006, UC-007, UC-008, HDL-005, HDL-006, HDL-008, INFRA-007, DOM-012 | 各層に散在する重複ロジックを、ユースケース/ハンドラ/リポジトリ単位の共通ヘルパーへ抽出して保守性を改善する。 |
 | **REF-G12** | コーディング規約・命名・近代化の統一 | DOM-016, UC-009, UC-011, UC-015, UC-012, DOM-013, DOM-011, QUAL-001 | `slices` への統一、命名規約、設定引数集約、メッセージ言語統一、重複定数整理、TODO解消などを同時に進めてコード規律を揃える。 |
-| **REF-G13** | Clean Architecture境界違反の解消 | ARCH-001, UC-003, UC-016 | Handler/テスト/Usecaseでのインフラ直接依存やSetter Injectionをまとめて是正し、依存方向を内向きに統一する。 |
 | **REF-G14** | セキュリティ運用の継続的検証 | SEC-03, HDL-001, INFRA-002, INFRA-014, LIB-005 | 単発修正ではなく、抑制コメント妥当性・IP抽出・SQL安全性・転送効率を含む運用時の継続検証項目として同時管理する。 |
 
 
@@ -316,7 +315,6 @@
 | ID | 優先度 | 概要 | 詳細・対応方針 |
 |---|---|---|---|
 | **UC-002** | **Medium** | `DeleteUser` の重複定義 | `AuthUsecase.DeleteUser(userID)` と `UserUsecase.DeleteUser(requester, username)` が異なるセマンティクスで同名。auth版には削除済みチェックも欠如。命名統一と重複排除が必要。 |
-| **UC-003** | **Medium** | Setter Injection アンチパターン | `userUsecase.SetWorldsendRecordRepository` が構築後にリポジトリ注入。temporal couplingを導入。コンストラクタで全依存を渡すべき。 |
 | **UC-004** | **Medium** | `Register` でトランザクション未使用 | ユーザー作成とセッション作成が非トランザクション。ユーザー作成成功・セッション作成失敗でログイン不能ユーザーが生成されるリスク。 |
 | **UC-005** | **Medium** | `convertUsernameError` の文字列比較によるエラー変換 | VOのエラーメッセージ文字列と直接比較。メッセージ変更時に検知不能。VOにセンチネルエラーを定義し `errors.Is` で判定すべき。 |
 | **UC-006** | **Low** | パスワードバリデーションロジックの3箇所重複 | `Register`, `ChangePassword`, `RecoverWithRecoveryCode` で長さチェックが重複。`validatePassword` ヘルパーに抽出すべき。 |
@@ -329,7 +327,6 @@
 | **UC-013** | **Medium** | `goalUsecase.Update` にトランザクション欠如 | `Create` はトランザクション内で実行しているが `Update` にはない。並行アクセス時のrace condition リスク。 |
 | **UC-014** | **Low** | `context.Canceled` ログの一貫性欠如 | 一部のメソッドのみ `context.Canceled` でWarn/Error分岐。共通ヘルパーに抽出し全ユースケースで統一適用すべき。 |
 | **UC-015** | **Medium** | `NewAuthService` のパラメータ数過多（11個） | 構成情報（jwtSecret, pepper等）とリポジトリが混在。`AuthConfig` 構造体にまとめて削減すべき。 |
-| **UC-016** | **Medium** | テストコードからinfra層への直接依存 | `auth_usecase_test.go` が `internal/infra/masterdata` をimport、`worldsend_usecase_test.go` が `sqlx` をimport。テスト用スタブを作成すべき。 |
 | **UC-017** | **Low** | `Register` 内のバリデーション順序が非効率 | ユーザー名VOバリデーションがDB問合せより後に実行される。不正ユーザー名でもDBアクセスが発生。 |
 
 ---
@@ -375,7 +372,6 @@
 
 | ID | 優先度 | 概要 | 詳細・対応方針 |
 |---|---|---|---|
-| **ARCH-001** | **Medium** | `ChunirecHandler` が `repository.UserRepository` と `*sqlx.DB` を直接保持 | Handler層がUsecase層を飛ばしてリポジトリ・DB接続を直接参照。Clean Architecture違反。DTO/UsecaseにUserID返却機能を追加しHandler依存を排除すべき。 |
 | **ARCH-002** | **Low** | `OfficialSongWithGenreDTO` にインフラ層の `db:` タグ | DTO層にDBタグ付き構造体があるのは不適切。`infra/models` に移動すべき。未使用の可能性もあり、その場合は削除。 |
 
 ---

--- a/internal/app/handler/compat/chunirec/chunirec_handler.go
+++ b/internal/app/handler/compat/chunirec/chunirec_handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/chunisupport/chunisupport-api/internal/infra/masterdata"
 	"github.com/chunisupport/chunisupport-api/internal/usecase"
-	"github.com/jmoiron/sqlx"
 	"github.com/labstack/echo/v4"
 )
 
@@ -19,18 +18,14 @@ import (
 type ChunirecHandler struct {
 	songUsecase usecase.SongUsecase
 	userUsecase usecase.UserUsecase
-	userRepo    repository.UserRepository
-	db          *sqlx.DB
 	masterCache *masterdata.Cache
 }
 
 // NewChunirecHandler はChunirecHandlerの新しいインスタンスを返します
-func NewChunirecHandler(songUsecase usecase.SongUsecase, userUsecase usecase.UserUsecase, userRepo repository.UserRepository, db *sqlx.DB, masterCache *masterdata.Cache) *ChunirecHandler {
+func NewChunirecHandler(songUsecase usecase.SongUsecase, userUsecase usecase.UserUsecase, masterCache *masterdata.Cache) *ChunirecHandler {
 	return &ChunirecHandler{
 		songUsecase: songUsecase,
 		userUsecase: userUsecase,
-		userRepo:    userRepo,
-		db:          db,
 		masterCache: masterCache,
 	}
 }
@@ -124,19 +119,8 @@ func (h *ChunirecHandler) GetUserShow(c echo.Context) error {
 		}
 	}
 
-	// UserIDを取得するため、UserRepositoryから対象ユーザーのエンティティを取得
-	// TODO: UserProfileWithRecordsDTOにUserIDフィールドを追加してリファクタリング
-	user, err := h.userRepo.FindByUsername(ctx, h.db, username)
-	if err != nil {
-		slog.Error("failed to get user entity for UserID", "username", username, "error", err)
-		return apierror.ErrInternalError.WithInternal(err)
-	}
-	if user == nil {
-		return apierror.ErrUserNotFound
-	}
-
 	// chunirec互換DTOに変換
-	response := ToChunirecUserDTO(result, user.ID, h.masterCache)
+	response := ToChunirecUserDTO(result, h.masterCache)
 
 	return c.JSON(http.StatusOK, response)
 }

--- a/internal/app/handler/compat/chunirec/dto.go
+++ b/internal/app/handler/compat/chunirec/dto.go
@@ -159,13 +159,13 @@ type ChunirecUserDTO struct {
 }
 
 // ToChunirecUserDTO は内部APIのUserProfileWithRecordsDTOをchunirec互換形式に変換します
-func ToChunirecUserDTO(profile *api_internal.UserProfileWithRecordsDTO, userID int, masterCache *masterdata.Cache) *ChunirecUserDTO {
+func ToChunirecUserDTO(profile *api_internal.UserProfileWithRecordsDTO, masterCache *masterdata.Cache) *ChunirecUserDTO {
 	if profile == nil || profile.Player == nil {
 		return nil
 	}
 
 	dto := &ChunirecUserDTO{
-		UserID:       userID,
+		UserID:       profile.UserID,
 		PlayerName:   profile.Player.Name,
 		Level:        profile.Player.Level,
 		IsJoinedTeam: nil, // ChuniSupportでは保持しないデータ

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -16,7 +16,6 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/app/handler/compat/chunirec"
 	"github.com/chunisupport/chunisupport-api/internal/app/middleware"
 	"github.com/chunisupport/chunisupport-api/internal/config"
-	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	vo_recoverycode "github.com/chunisupport/chunisupport-api/internal/domain/vo/recoverycode"
 	vo_username "github.com/chunisupport/chunisupport-api/internal/domain/vo/username"
 	"github.com/chunisupport/chunisupport-api/internal/info"
@@ -156,13 +155,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	recoveryUsecase := usecase.NewRecoveryUsecase(db, tm, userRepo, recoveryCodeRepo, cfg.PwPepper)
 	apiTokenUsecase := usecase.NewAPITokenService(db, apiTokenRepo, userRepo)
 	playerUsecase := usecase.NewPlayerService(db, playerRepo)
-	userUsecase := usecase.NewUserService(db, userRepo, playerRecordRepo, playerUsecase, songRepo, worldsendChartRepo, masterCache)
-	// userUsecase に worldsendRecordRepo を設定（通常レコードとの依存関係を避けるため後から設定）
-	if uu, ok := userUsecase.(interface {
-		SetWorldsendRecordRepository(repository.WorldsendRecordRepository)
-	}); ok {
-		uu.SetWorldsendRecordRepository(worldsendRecordRepo)
-	}
+	userUsecase := usecase.NewUserService(db, userRepo, playerRecordRepo, worldsendRecordRepo, playerUsecase, songRepo, worldsendChartRepo, masterCache)
 	playerDataUsecase := usecase.NewPlayerDataService(tm, userRepo, playerRepo, playerRecordRepo, worldsendRecordRepo, honorRepo, playerDataRepo, masterCache)
 	songUsecase := usecase.NewSongService(songRepo, masterCache, tm, db)
 	chartStatsMasterProvider := masterdata.NewChartStatsMasterProviderAdapter(staticMasterCache)
@@ -191,7 +184,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 		V1Worldsend: api_v1.NewV1WorldsendHandler(worldsendUsecase, masterCache),
 		V1User:      api_v1.NewV1UserHandler(userUsecase),
 		// chunirec互換APIハンドラ
-		Chunirec: chunirec.NewChunirecHandler(songUsecase, userUsecase, userRepo, db, masterCache),
+		Chunirec: chunirec.NewChunirecHandler(songUsecase, userUsecase, masterCache),
 	}
 
 	// ルートの設定

--- a/internal/dto/api_internal/user_dto.go
+++ b/internal/dto/api_internal/user_dto.go
@@ -9,6 +9,7 @@ import (
 
 // UserProfileWithRecordsDTO はユーザープロファイルとレコードを統合したDTOです。
 type UserProfileWithRecordsDTO struct {
+	UserID    int                        `json:"user_id"`
 	Username  string                     `json:"username"`
 	Player    *dto.PlayerDTO             `json:"player"`
 	Records   *dto.UserRecordResponseDTO `json:"records"`

--- a/internal/usecase/auth_service_compat.go
+++ b/internal/usecase/auth_service_compat.go
@@ -16,7 +16,7 @@ type legacyAuthService struct {
 }
 
 // NewAuthService は後方互換のためのコンストラクタです。新規実装では NewAuthUsecase を使用してください。
-func NewAuthService(db repository.Executor, tm TransactionManager, userRepo repository.UserRepository, sessionRepo repository.SessionRepository, recoveryCodeRepo repository.RecoveryCodeRepository, playerRecordRepo repository.PlayerRecordRepository, jwtSecret string, jwtExpirationHour int, sessionExpirationHour int, pepper string, masterCache repository.AccountTypeMasterProvider) *legacyAuthService {
+func NewAuthService(db repository.Executor, tm TransactionManager, userRepo repository.UserRepository, sessionRepo repository.SessionRepository, recoveryCodeRepo repository.RecoveryCodeRepository, playerRecordRepo repository.PlayerRecordRepository, jwtSecret string, jwtExpirationHour int, sessionExpirationHour int, pepper string, masterCache AccountTypeProvider) *legacyAuthService {
 	return &legacyAuthService{
 		auth:            NewAuthUsecase(db, userRepo, sessionRepo, jwtSecret, jwtExpirationHour, sessionExpirationHour, pepper, masterCache),
 		userCredential:  NewUserCredentialUsecase(db, userRepo, playerRecordRepo, pepper, masterCache),

--- a/internal/usecase/auth_usecase.go
+++ b/internal/usecase/auth_usecase.go
@@ -28,11 +28,11 @@ type authUsecaseImpl struct {
 	jwtExpirationHour     int
 	sessionExpirationHour int
 	pepper                string
-	masterCache           repository.AccountTypeMasterProvider
+	masterCache           AccountTypeProvider
 }
 
 // NewAuthUsecase は新しいAuthUsecaseを生成します。
-func NewAuthUsecase(db repository.Executor, userRepo repository.UserRepository, sessionRepo repository.SessionRepository, jwtSecret string, jwtExpirationHour int, sessionExpirationHour int, pepper string, masterCache repository.AccountTypeMasterProvider) AuthUsecase {
+func NewAuthUsecase(db repository.Executor, userRepo repository.UserRepository, sessionRepo repository.SessionRepository, jwtSecret string, jwtExpirationHour int, sessionExpirationHour int, pepper string, masterCache AccountTypeProvider) AuthUsecase {
 	return &authUsecaseImpl{
 		db:                    db,
 		userRepo:              userRepo,

--- a/internal/usecase/auth_usecase_test_helper_test.go
+++ b/internal/usecase/auth_usecase_test_helper_test.go
@@ -5,19 +5,26 @@ import (
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
-	"github.com/chunisupport/chunisupport-api/internal/infra/masterdata"
 	"github.com/stretchr/testify/mock"
 )
 
-// newMockMasterCache はテスト用のマスタデータキャッシュを作成します。
-func newMockMasterCache() *masterdata.Cache {
-	return &masterdata.Cache{
-		AccountTypes: map[string]masterdata.Item{
-			"PLAYER": {ID: 1, Name: "PLAYER"},
-			"EDITOR": {ID: 2, Name: "EDITOR"},
-			"ADMIN":  {ID: 3, Name: "ADMIN"},
+// newMockMasterCache はテスト用のアカウント種別プロバイダを作成します。
+func newMockMasterCache() AccountTypeProvider {
+	return &stubAccountTypeProvider{
+		nameByID: map[int]string{
+			1: "PLAYER",
+			2: "EDITOR",
+			3: "ADMIN",
 		},
 	}
+}
+
+type stubAccountTypeProvider struct {
+	nameByID map[int]string
+}
+
+func (s *stubAccountTypeProvider) GetAccountTypeNameByID(id int) string {
+	return s.nameByID[id]
 }
 
 // MockUserRepository はUserRepositoryのモックです。

--- a/internal/usecase/auth_usecase_test_helper_test.go
+++ b/internal/usecase/auth_usecase_test_helper_test.go
@@ -24,7 +24,11 @@ type stubAccountTypeProvider struct {
 }
 
 func (s *stubAccountTypeProvider) GetAccountTypeNameByID(id int) string {
-	return s.nameByID[id]
+	if name, ok := s.nameByID[id]; ok {
+		return name
+	}
+
+	return "UNKNOWN"
 }
 
 // MockUserRepository はUserRepositoryのモックです。

--- a/internal/usecase/executor_mock_test.go
+++ b/internal/usecase/executor_mock_test.go
@@ -1,0 +1,69 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockExecutor は repository.Executor のテスト用モックです。
+type MockExecutor struct {
+	mock.Mock
+}
+
+func (m *MockExecutor) GetContext(ctx context.Context, dest any, query string, args ...any) error {
+	arg := m.Called(ctx, dest, query, args)
+	return arg.Error(0)
+}
+
+func (m *MockExecutor) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
+	arg := m.Called(ctx, dest, query, args)
+	return arg.Error(0)
+}
+
+func (m *MockExecutor) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	arg := m.Called(ctx, query, args)
+	if arg.Get(0) == nil {
+		return nil, arg.Error(1)
+	}
+	return arg.Get(0).(sql.Result), arg.Error(1)
+}
+
+func (m *MockExecutor) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
+	args := m.Called(ctx, query, arg)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(sql.Result), args.Error(1)
+}
+
+func (m *MockExecutor) Rebind(query string) string {
+	args := m.Called(query)
+	return args.String(0)
+}
+
+func (m *MockExecutor) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	arg := m.Called(ctx, query, args)
+	if arg.Get(0) == nil {
+		return nil, arg.Error(1)
+	}
+	return arg.Get(0).(*sql.Rows), arg.Error(1)
+}
+
+func (m *MockExecutor) QueryxContext(ctx context.Context, query string, args ...any) (*sqlx.Rows, error) {
+	arg := m.Called(ctx, query, args)
+	if arg.Get(0) == nil {
+		return nil, arg.Error(1)
+	}
+	return arg.Get(0).(*sqlx.Rows), arg.Error(1)
+}
+
+func (m *MockExecutor) QueryRowxContext(ctx context.Context, query string, args ...any) *sqlx.Row {
+	arg := m.Called(ctx, query, args)
+	if arg.Get(0) == nil {
+		return nil
+	}
+	return arg.Get(0).(*sqlx.Row)
+}

--- a/internal/usecase/master_provider.go
+++ b/internal/usecase/master_provider.go
@@ -1,0 +1,6 @@
+package usecase
+
+// AccountTypeProvider はアカウント種別名の参照に必要な最小境界インターフェースです。
+type AccountTypeProvider interface {
+	GetAccountTypeNameByID(id int) string
+}

--- a/internal/usecase/user_credential_usecase.go
+++ b/internal/usecase/user_credential_usecase.go
@@ -27,10 +27,10 @@ type userCredentialUsecaseImpl struct {
 	userRepo         repository.UserRepository
 	playerRecordRepo repository.PlayerRecordRepository
 	pepper           string
-	masterCache      repository.AccountTypeMasterProvider
+	masterCache      AccountTypeProvider
 }
 
-func NewUserCredentialUsecase(db repository.Executor, userRepo repository.UserRepository, playerRecordRepo repository.PlayerRecordRepository, pepper string, masterCache repository.AccountTypeMasterProvider) UserCredentialUsecase {
+func NewUserCredentialUsecase(db repository.Executor, userRepo repository.UserRepository, playerRecordRepo repository.PlayerRecordRepository, pepper string, masterCache AccountTypeProvider) UserCredentialUsecase {
 	return &userCredentialUsecaseImpl{db: db, userRepo: userRepo, playerRecordRepo: playerRecordRepo, pepper: pepper, masterCache: masterCache}
 }
 

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -29,23 +29,18 @@ type userUsecase struct {
 }
 
 // NewUserService は UserUsecase の実装を生成します。
-func NewUserService(db repository.Executor, userRepo repository.UserRepository, playerRecordRepo repository.PlayerRecordRepository, playerUsecase PlayerUsecase, songRepo repository.SongRepository, worldsendChartRepo repository.WorldsendChartRepository, songMasterProvider repository.SongMasterProvider) UserUsecase {
+func NewUserService(db repository.Executor, userRepo repository.UserRepository, playerRecordRepo repository.PlayerRecordRepository, worldsendRecordRepo repository.WorldsendRecordRepository, playerUsecase PlayerUsecase, songRepo repository.SongRepository, worldsendChartRepo repository.WorldsendChartRepository, songMasterProvider repository.SongMasterProvider) UserUsecase {
 	return &userUsecase{
 		db:                  db,
 		userRepo:            userRepo,
 		playerRecordRepo:    playerRecordRepo,
+		worldsendRecordRepo: worldsendRecordRepo,
 		songRepo:            songRepo,
 		worldsendChartRepo:  worldsendChartRepo,
 		recordCompletionSvc: service.NewRecordCompletionService(),
 		songMasterProvider:  songMasterProvider,
 		playerUsecase:       playerUsecase,
 	}
-}
-
-// SetWorldsendRecordRepository は WorldsendRecordRepository を設定します。
-// DI の都合上、後から設定できるようにしています。
-func (s *userUsecase) SetWorldsendRecordRepository(repo repository.WorldsendRecordRepository) {
-	s.worldsendRecordRepo = repo
 }
 
 // GetUserProfileWithRecords はユーザー名をキーにプロファイルとレコードを一括取得します。
@@ -163,6 +158,7 @@ func (s *userUsecase) GetUserProfileWithRecords(ctx context.Context, username st
 	}
 
 	return &api_internal.UserProfileWithRecordsDTO{
+		UserID:    user.ID,
 		Username:  user.Username.String(),
 		Player:    player,
 		Records:   recordsDTO,

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -187,7 +187,7 @@ func (s *stubPlayerService) GetPlayerByID(ctx context.Context, id int) (*dto.Pla
 }
 
 func TestUserService_GetUserProfileWithRecords_UserNotFound(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{err: sql.ErrNoRows}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{err: sql.ErrNoRows}, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	_, err := service.GetUserProfileWithRecords(context.Background(), "missing", nil, false)
 	if !errors.Is(err, ErrUserNotFound) {
@@ -197,7 +197,7 @@ func TestUserService_GetUserProfileWithRecords_UserNotFound(t *testing.T) {
 
 func TestUserService_GetUserProfileWithRecords_PlayerNotLinked(t *testing.T) {
 	user := &entity.User{ID: 1}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	_, err := service.GetUserProfileWithRecords(context.Background(), "no-player", nil, false)
 	if !errors.Is(err, ErrPlayerNotLinked) {
@@ -219,7 +219,7 @@ func TestUserService_GetUserProfileWithRecords_PrivateSelf(t *testing.T) {
 		Level:     1,
 		UpdatedAt: now,
 	}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, &stubPlayerService{player: player}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{}, nil, &stubPlayerService{player: player}, nil, nil, nil)
 
 	_, err := service.GetUserProfileWithRecords(context.Background(), "selfuser", &entity.User{ID: 1}, false)
 	if err != nil {
@@ -307,11 +307,14 @@ func TestUserService_GetUserProfileWithRecords_Success(t *testing.T) {
 		UpdatedAt: playerUpdatedAt,
 	}
 	user := &entity.User{ID: 1, PlayerID: intPointer(1)}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{records: records}, &stubPlayerService{player: player}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{records: records}, nil, &stubPlayerService{player: player}, nil, nil, nil)
 
 	result, err := service.GetUserProfileWithRecords(context.Background(), "tester", nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.UserID != 1 {
+		t.Fatalf("expected user_id 1, got %d", result.UserID)
 	}
 
 	// updated_atの検証
@@ -372,12 +375,12 @@ func TestUserService_GetUserProfileWithRecords_IncludeNoPlay(t *testing.T) {
 			Song:            playedSong,
 			ChartDifficulty: &entity.ChartDifficulty{ID: 3, Name: "expert"},
 		}}},
+		&stubWorldsendRecordRepository{},
 		&stubPlayerService{player: player},
 		&stubSongRepository{songs: []*entity.Song{playedSong, unplayedSong}},
 		&stubWorldsendChartRepository{records: []*repository.WorldsendSongWithChart{{Song: weSong, Chart: weChart}}},
 		&stubSongMasterProvider{masters: &masterdata.SongMasters{CommonMasters: masterdata.CommonMasters{DifficultyNamesByID: map[int]string{3: "EXPERT", 4: "MASTER"}}}},
 	)
-	service.(*userUsecase).SetWorldsendRecordRepository(&stubWorldsendRecordRepository{})
 
 	result, err := service.GetUserProfileWithRecords(context.Background(), "tester", nil, true)
 	if err != nil {
@@ -505,7 +508,7 @@ func TestUserService_GetUserProfileRatingView_Success(t *testing.T) {
 		UpdatedAt: playerUpdatedAt,
 	}
 	user := &entity.User{ID: 1, PlayerID: intPointer(1)}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{ratingRecords: records}, &stubPlayerService{player: player}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRecordRepository{ratingRecords: records}, nil, &stubPlayerService{player: player}, nil, nil, nil)
 
 	result, err := service.GetUserProfileRatingView(context.Background(), "tester", nil)
 	if err != nil {
@@ -566,7 +569,7 @@ func TestUserService_GetAllUsersForAdmin(t *testing.T) {
 	repo := &stubUserRepository{
 		usersWithPlayer: usersWithPlayer,
 	}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	list, err := service.GetAllUsersForAdmin(context.Background(), 1, 10, "")
 	if err != nil {
@@ -613,7 +616,7 @@ func TestUserService_DeleteUser_Success(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "testuser")
 	if err != nil {
@@ -632,7 +635,7 @@ func TestUserService_DeleteUser_Success(t *testing.T) {
 func TestUserService_DeleteUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{err: sql.ErrNoRows}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "missing")
 	if !errors.Is(err, ErrUserNotFound) {
@@ -649,7 +652,7 @@ func TestUserService_DeleteUser_AlreadyDeleted(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "deleteduser")
 	if !errors.Is(err, ErrUserAlreadyDeleted) {
@@ -659,7 +662,7 @@ func TestUserService_DeleteUser_AlreadyDeleted(t *testing.T) {
 
 func TestUserService_DeleteUser_AdminRequired(t *testing.T) {
 	normalUser := &entity.User{ID: 1, AccountTypeID: 1}
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), normalUser, "testuser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -668,7 +671,7 @@ func TestUserService_DeleteUser_AdminRequired(t *testing.T) {
 }
 
 func TestUserService_DeleteUser_NilRequester(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), nil, "testuser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -685,7 +688,7 @@ func TestUserService_RestoreUser_Success(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "deleteduser")
 	if err != nil {
@@ -704,7 +707,7 @@ func TestUserService_RestoreUser_Success(t *testing.T) {
 func TestUserService_RestoreUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{err: sql.ErrNoRows}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "missing")
 	if !errors.Is(err, ErrUserNotFound) {
@@ -721,7 +724,7 @@ func TestUserService_RestoreUser_NotDeleted(t *testing.T) {
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, repo, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "activeuser")
 	if !errors.Is(err, ErrUserNotDeleted) {
@@ -731,7 +734,7 @@ func TestUserService_RestoreUser_NotDeleted(t *testing.T) {
 
 func TestUserService_RestoreUser_AdminRequired(t *testing.T) {
 	normalUser := &entity.User{ID: 1, AccountTypeID: 1}
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), normalUser, "deleteduser")
 	if !errors.Is(err, ErrAdminRequired) {
@@ -740,7 +743,7 @@ func TestUserService_RestoreUser_AdminRequired(t *testing.T) {
 }
 
 func TestUserService_RestoreUser_NilRequester(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, &stubPlayerService{}, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRecordRepository{}, nil, &stubPlayerService{}, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), nil, "deleteduser")
 	if !errors.Is(err, ErrAdminRequired) {

--- a/internal/usecase/worldsend_usecase_test.go
+++ b/internal/usecase/worldsend_usecase_test.go
@@ -107,8 +107,9 @@ func TestGetAllWorldsendSongs_WithDeletedSongs_RequiresEditorPermission(t *testi
 			// Arrange
 			mockRepo := new(MockWorldsendChartRepository)
 			mockTM := new(MockTransactionManager)
+			mockExec := new(MockExecutor)
 
-			usecase := NewWorldsendUsecase(mockRepo, mockTM, nil)
+			usecase := NewWorldsendUsecase(mockRepo, mockTM, mockExec)
 
 			ctx := context.Background()
 
@@ -130,7 +131,7 @@ func TestGetAllWorldsendSongs_WithDeletedSongs_RequiresEditorPermission(t *testi
 			}
 
 			// tt.expectedIncludeDeleted に基づいてリポジトリが呼び出されることを期待
-			mockRepo.On("FindAll", ctx, nil, tt.expectedIncludeDeleted).Return(expectedSongs, nil)
+			mockRepo.On("FindAll", ctx, mockExec, tt.expectedIncludeDeleted).Return(expectedSongs, nil)
 
 			// Act
 			result, err := usecase.GetAllWorldsendSongs(ctx, tt.includeDeleted, tt.requesterAccountTypeID)

--- a/internal/usecase/worldsend_usecase_test.go
+++ b/internal/usecase/worldsend_usecase_test.go
@@ -2,13 +2,11 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/chunisupport/chunisupport-api/internal/info"
-	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -57,66 +55,6 @@ type MockTransactionManager struct {
 func (m *MockTransactionManager) Transactional(ctx context.Context, fn func(tx repository.Executor) error) error {
 	args := m.Called(ctx, fn)
 	return args.Error(0)
-}
-
-// MockExecutor は Executor のモックです。
-type MockExecutor struct {
-	mock.Mock
-}
-
-func (m *MockExecutor) GetContext(ctx context.Context, dest any, query string, args ...any) error {
-	arg := m.Called(ctx, dest, query, args)
-	return arg.Error(0)
-}
-
-func (m *MockExecutor) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
-	arg := m.Called(ctx, dest, query, args)
-	return arg.Error(0)
-}
-
-func (m *MockExecutor) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	arg := m.Called(ctx, query, args)
-	if arg.Get(0) == nil {
-		return nil, arg.Error(1)
-	}
-	return arg.Get(0).(sql.Result), arg.Error(1)
-}
-
-func (m *MockExecutor) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
-	args := m.Called(ctx, query, arg)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(sql.Result), args.Error(1)
-}
-
-func (m *MockExecutor) Rebind(query string) string {
-	args := m.Called(query)
-	return args.String(0)
-}
-
-func (m *MockExecutor) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	arg := m.Called(ctx, query, args)
-	if arg.Get(0) == nil {
-		return nil, arg.Error(1)
-	}
-	return arg.Get(0).(*sql.Rows), arg.Error(1)
-}
-
-func (m *MockExecutor) QueryxContext(ctx context.Context, query string, args ...any) (*sqlx.Rows, error) {
-	arg := m.Called(ctx, query, args)
-	if arg.Get(0) == nil {
-		return nil, arg.Error(1)
-	}
-	return arg.Get(0).(*sqlx.Rows), arg.Error(1)
-}
-
-func (m *MockExecutor) QueryRowxContext(ctx context.Context, query string, args ...any) *sqlx.Row {
-	arg := m.Called(ctx, query, args)
-	if arg.Get(0) == nil {
-		return nil
-	}
-	return arg.Get(0).(*sqlx.Row)
 }
 
 func TestGetAllWorldsendSongs_WithDeletedSongs_RequiresEditorPermission(t *testing.T) {
@@ -169,9 +107,8 @@ func TestGetAllWorldsendSongs_WithDeletedSongs_RequiresEditorPermission(t *testi
 			// Arrange
 			mockRepo := new(MockWorldsendChartRepository)
 			mockTM := new(MockTransactionManager)
-			mockExec := new(MockExecutor)
 
-			usecase := NewWorldsendUsecase(mockRepo, mockTM, mockExec)
+			usecase := NewWorldsendUsecase(mockRepo, mockTM, nil)
 
 			ctx := context.Background()
 
@@ -193,7 +130,7 @@ func TestGetAllWorldsendSongs_WithDeletedSongs_RequiresEditorPermission(t *testi
 			}
 
 			// tt.expectedIncludeDeleted に基づいてリポジトリが呼び出されることを期待
-			mockRepo.On("FindAll", ctx, mockExec, tt.expectedIncludeDeleted).Return(expectedSongs, nil)
+			mockRepo.On("FindAll", ctx, nil, tt.expectedIncludeDeleted).Return(expectedSongs, nil)
 
 			// Act
 			result, err := usecase.GetAllWorldsendSongs(ctx, tt.includeDeleted, tt.requesterAccountTypeID)


### PR DESCRIPTION
### Motivation

- Usecase層とハンドラ層の境界依存を内向きに整え、handler/test が infra の具体実装に直接依存する現状（Setter Injection や repo/db 参照）を解消するため。
- テストから infra 依存を排除してユニットテストの独立性と可搬性を向上させるため。

### Description

- usecase 境界インターフェース `AccountTypeProvider` を追加し、`AuthUsecase` / 互換ラッパー / `UserCredentialUsecase` が infra の具体型に依存しないよう置換しました（`internal/usecase/master_provider.go`）。
- `UserUsecase` の DI を完全コンストラクタ注入へ変更し、`NewUserService` に `worldsendRecordRepo` を追加して `SetWorldsendRecordRepository` を削除しました（`internal/usecase/user_usecase_impl.go` と呼び出し側 `internal/app/router.go` を更新）。
- `GetUserProfileWithRecords` 系の DTO に `UserID` フィールドを追加し、`UserProfileWithRecordsDTO` が `user.ID` を返すようにして `ChunirecHandler` 側での `userRepo`/`db` 参照を削除しました（`internal/dto/api_internal/user_dto.go`、`internal/app/handler/compat/chunirec/*`、`internal/app/router.go` の変更）。
- `ToChunirecUserDTO` のシグネチャと実装を `profile.UserID` を使う形に更新しました（`internal/app/handler/compat/chunirec/dto.go`）。
- テスト側の infra 依存を除去・簡素化しました：`auth_usecase_test_helper_test.go` の `infra/masterdata` 依存を境界スタブに置換し、`worldsend_usecase_test.go` の `sqlx` 依存を削除して exec を nil 化、共通の `MockExecutor` をテストヘルパーとして追加しました（`internal/usecase/auth_usecase_test_helper_test.go`、`internal/usecase/worldsend_usecase_test.go`、`internal/usecase/executor_mock_test.go`）。
- ドキュメント `_report/refactor.md` から REF-G13 に紐づく記載（ARCH-001 / UC-003 / UC-016）を削除しました。

### Testing

- 変更後 `gofmt` を実行してコード整形を適用しました（対象ファイル群に対して `gofmt -w` 実行）。
- 自動テストは `go test ./...` を複数回実行し最終的に全パッケージのテストが成功しました（初回はビルドエラーを順次修正したため失敗が発生しましたが修正後は全通過）。
- セルフレビューとして `gofmt` + `go test ./...` を3回回し、各回で発見した問題を修正してテストを成功させています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a337f65a08832d993f0998b23b7e78)