### PR TITLE
Refactor master entities into value objects and introduce RatingBand VO

### DIFF
--- a/internal/app/handler/api_internal/song_handler_test.go
+++ b/internal/app/handler/api_internal/song_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/notes"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/ratingband"
 	"github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
 	"github.com/chunisupport/chunisupport-api/internal/infra/masterdata"
 	"github.com/chunisupport/chunisupport-api/internal/testutil"
@@ -325,7 +326,7 @@ func TestGetSongs(t *testing.T) {
 
 	// ハンドラーの準備
 	staticMasterCache := &masterdata.StaticCache{
-		RatingBands: []*entity.RatingBand{},
+		RatingBands: []*ratingband.RatingBand{},
 	}
 	handler := NewSongHandler(mockUsecase, &testutil.MockChartStatsUsecase{}, masterCache, staticMasterCache)
 

--- a/internal/domain/entity/account_type.go
+++ b/internal/domain/entity/account_type.go
@@ -1,7 +1,6 @@
 package entity
 
-// AccountType はアカウントタイプマスタのエンティティを表します
-type AccountType struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// AccountType はアカウントタイプマスタの互換エイリアスです。
+type AccountType = master.AccountType

--- a/internal/domain/entity/chart_difficulty.go
+++ b/internal/domain/entity/chart_difficulty.go
@@ -1,7 +1,6 @@
 package entity
 
-// ChartDifficulty は譜面難易度マスタのエンティティを表します
-type ChartDifficulty struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// ChartDifficulty は譜面難易度マスタの互換エイリアスです。
+type ChartDifficulty = master.ChartDifficulty

--- a/internal/domain/entity/chart_stats.go
+++ b/internal/domain/entity/chart_stats.go
@@ -1,14 +1,5 @@
 package entity
 
-// RatingBand はレーティング帯のマスタ情報です。
-type RatingBand struct {
-	ID           int
-	Label        string
-	MinInclusive *float64
-	MaxExclusive *float64
-	SortOrder    int
-}
-
 // ChartRankStats はランク別の人数統計です。
 type ChartRankStats struct {
 	AAAL int

--- a/internal/domain/entity/class_emblem.go
+++ b/internal/domain/entity/class_emblem.go
@@ -1,7 +1,6 @@
 package entity
 
-// ClassEmblem はクラスエンブレムマスタのエンティティを表します
-type ClassEmblem struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// ClassEmblem はクラスエンブレムマスタの互換エイリアスです。
+type ClassEmblem = master.ClassEmblem

--- a/internal/domain/entity/class_emblem_base.go
+++ b/internal/domain/entity/class_emblem_base.go
@@ -1,7 +1,6 @@
 package entity
 
-// ClassEmblemBase はクラスエンブレムベースマスタのエンティティを表します
-type ClassEmblemBase struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// ClassEmblemBase はクラスエンブレムベースマスタの互換エイリアスです。
+type ClassEmblemBase = master.ClassEmblemBase

--- a/internal/domain/entity/clear_lamp_type.go
+++ b/internal/domain/entity/clear_lamp_type.go
@@ -1,7 +1,6 @@
 package entity
 
-// ClearLampType はクリアランプマスタのエンティティを表します
-type ClearLampType struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// ClearLampType はクリアランプマスタの互換エイリアスです。
+type ClearLampType = master.ClearLampType

--- a/internal/domain/entity/combo_lamp_type.go
+++ b/internal/domain/entity/combo_lamp_type.go
@@ -1,7 +1,6 @@
 package entity
 
-// ComboLampType はコンボランプマスタのエンティティを表します
-type ComboLampType struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// ComboLampType はコンボランプマスタの互換エイリアスです。
+type ComboLampType = master.ComboLampType

--- a/internal/domain/entity/full_chain_type.go
+++ b/internal/domain/entity/full_chain_type.go
@@ -1,7 +1,6 @@
 package entity
 
-// FullChainType はフルチェインランプマスタのエンティティを表します
-type FullChainType struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// FullChainType はフルチェインランプマスタの互換エイリアスです。
+type FullChainType = master.FullChainType

--- a/internal/domain/entity/genre.go
+++ b/internal/domain/entity/genre.go
@@ -1,7 +1,6 @@
 package entity
 
-// Genre はジャンルマスタのエンティティを表します
-type Genre struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// Genre はジャンルマスタの互換エイリアスです。
+type Genre = master.Genre

--- a/internal/domain/entity/honor_type.go
+++ b/internal/domain/entity/honor_type.go
@@ -1,7 +1,6 @@
 package entity
 
-// HonorType は称号種類マスタのエンティティを表します
-type HonorType struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// HonorType は称号種類マスタの互換エイリアスです。
+type HonorType = master.HonorType

--- a/internal/domain/entity/slot.go
+++ b/internal/domain/entity/slot.go
@@ -1,7 +1,6 @@
 package entity
 
-// Slot はプレイヤーレコードのスロット種別を表します。
-type Slot struct {
-	ID   int
-	Name string
-}
+import "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+
+// Slot はプレイヤーレコードのスロット種別の互換エイリアスです。
+type Slot = master.Slot

--- a/internal/domain/repository/chart_stats_repository.go
+++ b/internal/domain/repository/chart_stats_repository.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/ratingband"
 )
 
 // ChartStatsRepository は統計データの参照を扱うリポジトリです。
 type ChartStatsRepository interface {
 	// FindRatingBands はレーティング帯マスタ一覧を返します。
-	FindRatingBands(ctx context.Context, exec Executor) ([]*entity.RatingBand, error)
+	FindRatingBands(ctx context.Context, exec Executor) ([]*ratingband.RatingBand, error)
 	// FindChartStatsByChartIDs は譜面ID一覧に対する統計を返します。
 	FindChartStatsByChartIDs(ctx context.Context, exec Executor, chartIDs []int) ([]*entity.ChartStatsByRatingBand, error)
 }

--- a/internal/domain/repository/master_data_provider.go
+++ b/internal/domain/repository/master_data_provider.go
@@ -1,8 +1,8 @@
 package repository
 
 import (
-	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/ratingband"
 )
 
 // PlayerDataMasterProvider は、プレイヤーデータ登録時に必要なマスタデータを提供します。
@@ -26,7 +26,7 @@ type AccountTypeMasterProvider interface {
 // ChartStatsMasterProvider は譜面統計取得で必要なマスタデータを提供します。
 // Interface Segregation Principleに従い、ChartStatsUsecaseが必要とするメソッドのみを定義します。
 type ChartStatsMasterProvider interface {
-	RatingBands() []*entity.RatingBand
+	RatingBands() []*ratingband.RatingBand
 }
 
 // GoalMasterProvider は目標機能で必要なマスタデータを提供します。

--- a/internal/domain/service/record_completion_service.go
+++ b/internal/domain/service/record_completion_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
 	"math"
 	"sort"
 
@@ -49,7 +50,7 @@ func (s *RecordCompletionService) CompletePlayerRecords(records []*entity.Player
 				ChartID: chart.ID,
 				Chart:   chart,
 				Song:    song,
-				ChartDifficulty: &entity.ChartDifficulty{
+				ChartDifficulty: &master.ChartDifficulty{
 					ID:   chart.DifficultyID,
 					Name: difficultyNameByID(chart.DifficultyID, difficultyNamesByID),
 				},

--- a/internal/domain/service/record_completion_service_test.go
+++ b/internal/domain/service/record_completion_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
 	"testing"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -37,7 +38,7 @@ func TestRecordCompletionService_CompletePlayerRecords(t *testing.T) {
 			ChartID: 11,
 			Song:    songs[0],
 			Chart:   songs[0].Charts[0],
-			ChartDifficulty: &entity.ChartDifficulty{
+			ChartDifficulty: &master.ChartDifficulty{
 				ID:   3,
 				Name: "expert",
 			},

--- a/internal/domain/vo/master/master.go
+++ b/internal/domain/vo/master/master.go
@@ -1,61 +1,37 @@
 package master
 
-// AccountType はアカウントタイプマスタの値オブジェクトです。
-type AccountType struct {
+// BaseMasterVO は、IDとNameを持つ単純なマスタ値オブジェクトの基本構造体です。
+type BaseMasterVO struct {
 	ID   int
 	Name string
 }
+
+// AccountType はアカウントタイプマスタの値オブジェクトです。
+type AccountType BaseMasterVO
 
 // ChartDifficulty は譜面難易度マスタの値オブジェクトです。
-type ChartDifficulty struct {
-	ID   int
-	Name string
-}
+type ChartDifficulty BaseMasterVO
 
 // ClassEmblem はクラスエンブレムマスタの値オブジェクトです。
-type ClassEmblem struct {
-	ID   int
-	Name string
-}
+type ClassEmblem BaseMasterVO
 
 // ClassEmblemBase はクラスエンブレムベースマスタの値オブジェクトです。
-type ClassEmblemBase struct {
-	ID   int
-	Name string
-}
+type ClassEmblemBase BaseMasterVO
 
 // ClearLampType はクリアランプマスタの値オブジェクトです。
-type ClearLampType struct {
-	ID   int
-	Name string
-}
+type ClearLampType BaseMasterVO
 
 // ComboLampType はコンボランプマスタの値オブジェクトです。
-type ComboLampType struct {
-	ID   int
-	Name string
-}
+type ComboLampType BaseMasterVO
 
 // FullChainType はフルチェインランプマスタの値オブジェクトです。
-type FullChainType struct {
-	ID   int
-	Name string
-}
+type FullChainType BaseMasterVO
 
 // Genre はジャンルマスタの値オブジェクトです。
-type Genre struct {
-	ID   int
-	Name string
-}
+type Genre BaseMasterVO
 
 // HonorType は称号種類マスタの値オブジェクトです。
-type HonorType struct {
-	ID   int
-	Name string
-}
+type HonorType BaseMasterVO
 
 // Slot はプレイヤーレコードのスロット種別の値オブジェクトです。
-type Slot struct {
-	ID   int
-	Name string
-}
+type Slot BaseMasterVO

--- a/internal/domain/vo/master/master.go
+++ b/internal/domain/vo/master/master.go
@@ -1,0 +1,61 @@
+package master
+
+// AccountType はアカウントタイプマスタの値オブジェクトです。
+type AccountType struct {
+	ID   int
+	Name string
+}
+
+// ChartDifficulty は譜面難易度マスタの値オブジェクトです。
+type ChartDifficulty struct {
+	ID   int
+	Name string
+}
+
+// ClassEmblem はクラスエンブレムマスタの値オブジェクトです。
+type ClassEmblem struct {
+	ID   int
+	Name string
+}
+
+// ClassEmblemBase はクラスエンブレムベースマスタの値オブジェクトです。
+type ClassEmblemBase struct {
+	ID   int
+	Name string
+}
+
+// ClearLampType はクリアランプマスタの値オブジェクトです。
+type ClearLampType struct {
+	ID   int
+	Name string
+}
+
+// ComboLampType はコンボランプマスタの値オブジェクトです。
+type ComboLampType struct {
+	ID   int
+	Name string
+}
+
+// FullChainType はフルチェインランプマスタの値オブジェクトです。
+type FullChainType struct {
+	ID   int
+	Name string
+}
+
+// Genre はジャンルマスタの値オブジェクトです。
+type Genre struct {
+	ID   int
+	Name string
+}
+
+// HonorType は称号種類マスタの値オブジェクトです。
+type HonorType struct {
+	ID   int
+	Name string
+}
+
+// Slot はプレイヤーレコードのスロット種別の値オブジェクトです。
+type Slot struct {
+	ID   int
+	Name string
+}

--- a/internal/domain/vo/ratingband/ratingband.go
+++ b/internal/domain/vo/ratingband/ratingband.go
@@ -1,0 +1,11 @@
+package ratingband
+
+// RatingBand はレーティング帯の値オブジェクトです。
+// 中身が同一であれば同値として扱います。
+type RatingBand struct {
+	ID           int
+	Label        string
+	MinInclusive *float64
+	MaxExclusive *float64
+	SortOrder    int
+}

--- a/internal/dto/chart_stats_dto.go
+++ b/internal/dto/chart_stats_dto.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/ratingband"
 )
 
 // ChartStatsResponse は譜面統計APIのレスポンスです。
@@ -65,7 +66,7 @@ type SingleChartStatsResponse struct {
 }
 
 // ToChartStatsResponse は SongChartStats を ChartStatsResponse に変換します。
-func ToChartStatsResponse(stats *entity.SongChartStats, ratingBands []*entity.RatingBand) *ChartStatsResponse {
+func ToChartStatsResponse(stats *entity.SongChartStats, ratingBands []*ratingband.RatingBand) *ChartStatsResponse {
 	if stats == nil {
 		return nil
 	}
@@ -127,7 +128,7 @@ func ToChartStatsResponse(stats *entity.SongChartStats, ratingBands []*entity.Ra
 }
 
 // ToSingleChartStatsResponse は SingleChartStats を SingleChartStatsResponse に変換します。
-func ToSingleChartStatsResponse(stats *entity.SingleChartStats, ratingBands []*entity.RatingBand) *SingleChartStatsResponse {
+func ToSingleChartStatsResponse(stats *entity.SingleChartStats, ratingBands []*ratingband.RatingBand) *SingleChartStatsResponse {
 	if stats == nil {
 		return nil
 	}

--- a/internal/dto/player_record_dto.go
+++ b/internal/dto/player_record_dto.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
 	"strings"
 	"time"
 
@@ -77,24 +78,24 @@ func ToPlayerRecordDTO(record *entity.PlayerRecord) *PlayerRecordDTO {
 }
 
 // toMasterName はマスタエンティティからName文字列を取り出します。nilの場合は空文字を返します。
-func toMasterName(master any) string {
-	switch v := master.(type) {
-	case *entity.ClearLampType:
+func toMasterName(masterValue any) string {
+	switch v := masterValue.(type) {
+	case *master.ClearLampType:
 		if v == nil {
 			return ""
 		}
 		return v.Name
-	case *entity.ComboLampType:
+	case *master.ComboLampType:
 		if v == nil {
 			return ""
 		}
 		return v.Name
-	case *entity.FullChainType:
+	case *master.FullChainType:
 		if v == nil {
 			return ""
 		}
 		return v.Name
-	case *entity.Slot:
+	case *master.Slot:
 		if v == nil {
 			return ""
 		}
@@ -111,8 +112,8 @@ func isNoneValue(name string) bool {
 
 // toMasterNamePtr はマスタエンティティからName文字列のポインタを取り出します。
 // nilの場合、または「NONE」「none」など便宜上の値の場合はnilを返します。
-func toMasterNamePtr(master any) *string {
-	name := toMasterName(master)
+func toMasterNamePtr(masterValue any) *string {
+	name := toMasterName(masterValue)
 	if name == "" || isNoneValue(name) {
 		return nil
 	}

--- a/internal/infra/masterdata/chart_stats_master_provider.go
+++ b/internal/infra/masterdata/chart_stats_master_provider.go
@@ -1,8 +1,8 @@
 package masterdata
 
 import (
-	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/ratingband"
 )
 
 // ChartStatsMasterProviderAdapter はStaticCacheを譜面統計用マスタプロバイダとして公開するアダプタです。
@@ -16,12 +16,12 @@ func NewChartStatsMasterProviderAdapter(cache *StaticCache) repository.ChartStat
 }
 
 // RatingBands は譜面統計で参照するレーティング帯一覧を返します。
-func (a *ChartStatsMasterProviderAdapter) RatingBands() []*entity.RatingBand {
+func (a *ChartStatsMasterProviderAdapter) RatingBands() []*ratingband.RatingBand {
 	if a == nil || a.cache == nil {
-		return []*entity.RatingBand{}
+		return []*ratingband.RatingBand{}
 	}
 	if a.cache.RatingBands == nil {
-		return []*entity.RatingBand{}
+		return []*ratingband.RatingBand{}
 	}
 	return a.cache.RatingBands
 }

--- a/internal/infra/masterdata/chart_stats_master_provider.go
+++ b/internal/infra/masterdata/chart_stats_master_provider.go
@@ -20,8 +20,5 @@ func (a *ChartStatsMasterProviderAdapter) RatingBands() []*ratingband.RatingBand
 	if a == nil || a.cache == nil {
 		return []*ratingband.RatingBand{}
 	}
-	if a.cache.RatingBands == nil {
-		return []*ratingband.RatingBand{}
-	}
 	return a.cache.RatingBands
 }

--- a/internal/infra/masterdata/static_cache.go
+++ b/internal/infra/masterdata/static_cache.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/ratingband"
 	"github.com/jmoiron/sqlx"
 )
 
 // StaticCache は統計DB（SQLite）から起動時にプリロードされるマスタのセットです。
 type StaticCache struct {
-	RatingBands        []*entity.RatingBand
-	RatingBandsByID    map[int]*entity.RatingBand
-	RatingBandsByLabel map[string]*entity.RatingBand
+	RatingBands        []*ratingband.RatingBand
+	RatingBandsByID    map[int]*ratingband.RatingBand
+	RatingBandsByLabel map[string]*ratingband.RatingBand
 }
 
 // PreloadStatic は統計DBから固定値が INSERT されているマスタを読み込み、キャッシュを構築します。
@@ -22,8 +22,8 @@ func PreloadStatic(ctx context.Context, staticDB *sqlx.DB) (*StaticCache, error)
 		return nil, fmt.Errorf("failed to preload rating_bands: %w", err)
 	}
 
-	ratingBandsByID := make(map[int]*entity.RatingBand, len(ratingBands))
-	ratingBandsByLabel := make(map[string]*entity.RatingBand, len(ratingBands))
+	ratingBandsByID := make(map[int]*ratingband.RatingBand, len(ratingBands))
+	ratingBandsByLabel := make(map[string]*ratingband.RatingBand, len(ratingBands))
 	for _, band := range ratingBands {
 		ratingBandsByID[band.ID] = band
 		ratingBandsByLabel[band.Label] = band
@@ -36,7 +36,7 @@ func PreloadStatic(ctx context.Context, staticDB *sqlx.DB) (*StaticCache, error)
 	}, nil
 }
 
-func loadRatingBands(ctx context.Context, db *sqlx.DB) ([]*entity.RatingBand, error) {
+func loadRatingBands(ctx context.Context, db *sqlx.DB) ([]*ratingband.RatingBand, error) {
 	const query = `
 		SELECT id, label, min_inclusive, max_exclusive, sort_order
 		FROM rating_bands
@@ -56,9 +56,9 @@ func loadRatingBands(ctx context.Context, db *sqlx.DB) ([]*entity.RatingBand, er
 		return nil, err
 	}
 
-	results := make([]*entity.RatingBand, 0, len(rows))
+	results := make([]*ratingband.RatingBand, 0, len(rows))
 	for _, row := range rows {
-		results = append(results, &entity.RatingBand{
+		results = append(results, &ratingband.RatingBand{
 			ID:           row.ID,
 			Label:        row.Label,
 			MinInclusive: row.MinInclusive,
@@ -72,7 +72,7 @@ func loadRatingBands(ctx context.Context, db *sqlx.DB) ([]*entity.RatingBand, er
 
 // GetRatingBandByID はIDからRatingBandを取得します。
 // 見つからない場合はnilを返します。
-func (c *StaticCache) GetRatingBandByID(id int) *entity.RatingBand {
+func (c *StaticCache) GetRatingBandByID(id int) *ratingband.RatingBand {
 	if c == nil {
 		return nil
 	}
@@ -81,7 +81,7 @@ func (c *StaticCache) GetRatingBandByID(id int) *entity.RatingBand {
 
 // GetRatingBandByLabel はラベルからRatingBandを取得します。
 // 見つからない場合はnilを返します。
-func (c *StaticCache) GetRatingBandByLabel(label string) *entity.RatingBand {
+func (c *StaticCache) GetRatingBandByLabel(label string) *ratingband.RatingBand {
 	if c == nil {
 		return nil
 	}

--- a/internal/infra/models/master_model.go
+++ b/internal/infra/models/master_model.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/chunisupport/chunisupport-api/internal/domain/entity"
+import (
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+)
 
 // MasterModel は全てのマスタテーブルで共通のモデル構造です。
 type MasterModel struct {
@@ -8,81 +10,81 @@ type MasterModel struct {
 	Name string `db:"name"`
 }
 
-// ToAccountType はMasterModelをentity.AccountTypeに変換します。
-func (m *MasterModel) ToAccountType() *entity.AccountType {
-	return &entity.AccountType{
+// ToAccountType はMasterModelをmaster.AccountTypeに変換します。
+func (m *MasterModel) ToAccountType() *master.AccountType {
+	return &master.AccountType{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToClearLampType はMasterModelをentity.ClearLampTypeに変換します。
-func (m *MasterModel) ToClearLampType() *entity.ClearLampType {
-	return &entity.ClearLampType{
+// ToClearLampType はMasterModelをmaster.ClearLampTypeに変換します。
+func (m *MasterModel) ToClearLampType() *master.ClearLampType {
+	return &master.ClearLampType{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToComboLampType はMasterModelをentity.ComboLampTypeに変換します。
-func (m *MasterModel) ToComboLampType() *entity.ComboLampType {
-	return &entity.ComboLampType{
+// ToComboLampType はMasterModelをmaster.ComboLampTypeに変換します。
+func (m *MasterModel) ToComboLampType() *master.ComboLampType {
+	return &master.ComboLampType{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToFullChainType はMasterModelをentity.FullChainTypeに変換します。
-func (m *MasterModel) ToFullChainType() *entity.FullChainType {
-	return &entity.FullChainType{
+// ToFullChainType はMasterModelをmaster.FullChainTypeに変換します。
+func (m *MasterModel) ToFullChainType() *master.FullChainType {
+	return &master.FullChainType{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToHonorType はMasterModelをentity.HonorTypeに変換します。
-func (m *MasterModel) ToHonorType() *entity.HonorType {
-	return &entity.HonorType{
+// ToHonorType はMasterModelをmaster.HonorTypeに変換します。
+func (m *MasterModel) ToHonorType() *master.HonorType {
+	return &master.HonorType{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToChartDifficulty はMasterModelをentity.ChartDifficultyに変換します。
-func (m *MasterModel) ToChartDifficulty() *entity.ChartDifficulty {
-	return &entity.ChartDifficulty{
+// ToChartDifficulty はMasterModelをmaster.ChartDifficultyに変換します。
+func (m *MasterModel) ToChartDifficulty() *master.ChartDifficulty {
+	return &master.ChartDifficulty{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToGenre はMasterModelをentity.Genreに変換します。
-func (m *MasterModel) ToGenre() *entity.Genre {
-	return &entity.Genre{
+// ToGenre はMasterModelをmaster.Genreに変換します。
+func (m *MasterModel) ToGenre() *master.Genre {
+	return &master.Genre{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToSlot はMasterModelをentity.Slotに変換します。
-func (m *MasterModel) ToSlot() *entity.Slot {
-	return &entity.Slot{
+// ToSlot はMasterModelをmaster.Slotに変換します。
+func (m *MasterModel) ToSlot() *master.Slot {
+	return &master.Slot{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToClassEmblem はMasterModelをentity.ClassEmblemに変換します。
-func (m *MasterModel) ToClassEmblem() *entity.ClassEmblem {
-	return &entity.ClassEmblem{
+// ToClassEmblem はMasterModelをmaster.ClassEmblemに変換します。
+func (m *MasterModel) ToClassEmblem() *master.ClassEmblem {
+	return &master.ClassEmblem{
 		ID:   m.ID,
 		Name: m.Name,
 	}
 }
 
-// ToClassEmblemBase はMasterModelをentity.ClassEmblemBaseに変換します。
-func (m *MasterModel) ToClassEmblemBase() *entity.ClassEmblemBase {
-	return &entity.ClassEmblemBase{
+// ToClassEmblemBase はMasterModelをmaster.ClassEmblemBaseに変換します。
+func (m *MasterModel) ToClassEmblemBase() *master.ClassEmblemBase {
+	return &master.ClassEmblemBase{
 		ID:   m.ID,
 		Name: m.Name,
 	}

--- a/internal/infra/repository/chart_stats_repository_impl.go
+++ b/internal/infra/repository/chart_stats_repository_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/ratingband"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -51,7 +52,7 @@ type chartStatsRow struct {
 }
 
 // FindRatingBands はレーティング帯マスタ一覧を返します。
-func (r *chartStatsRepository) FindRatingBands(ctx context.Context, exec repository.Executor) ([]*entity.RatingBand, error) {
+func (r *chartStatsRepository) FindRatingBands(ctx context.Context, exec repository.Executor) ([]*ratingband.RatingBand, error) {
 	const query = `
 		SELECT id, label, min_inclusive, max_exclusive, sort_order
 		FROM rating_bands
@@ -63,9 +64,9 @@ func (r *chartStatsRepository) FindRatingBands(ctx context.Context, exec reposit
 		return nil, err
 	}
 
-	results := make([]*entity.RatingBand, 0, len(rows))
+	results := make([]*ratingband.RatingBand, 0, len(rows))
 	for _, row := range rows {
-		results = append(results, &entity.RatingBand{
+		results = append(results, &ratingband.RatingBand{
 			ID:           row.ID,
 			Label:        row.Label,
 			MinInclusive: row.MinInclusive,

--- a/internal/infra/repository/player_record_repository_impl.go
+++ b/internal/infra/repository/player_record_repository_impl.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
 	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -216,23 +217,23 @@ func buildPlayerRecords(rows []playerRecordRow) []*entity.PlayerRecord {
 				Charts:      []*entity.Chart{},
 				IsDeleted:   row.SongIsDeleted,
 			},
-			ClearLamp: &entity.ClearLampType{
+			ClearLamp: &master.ClearLampType{
 				ID:   row.ClearLampID,
 				Name: row.ClearLampName,
 			},
-			ComboLamp: &entity.ComboLampType{
+			ComboLamp: &master.ComboLampType{
 				ID:   row.ComboLampID,
 				Name: row.ComboLampName,
 			},
-			FullChain: &entity.FullChainType{
+			FullChain: &master.FullChainType{
 				ID:   row.FullChainID,
 				Name: row.FullChainName,
 			},
-			Slot: &entity.Slot{
+			Slot: &master.Slot{
 				ID:   row.SlotID,
 				Name: row.SlotName,
 			},
-			ChartDifficulty: &entity.ChartDifficulty{
+			ChartDifficulty: &master.ChartDifficulty{
 				ID:   row.ChartDifficultyID,
 				Name: row.DifficultyName,
 			},

--- a/internal/infra/repository/worldsend_record_repository_impl.go
+++ b/internal/infra/repository/worldsend_record_repository_impl.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
 	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -129,15 +130,15 @@ func (r *worldsendRecordRepository) FindByPlayerID(ctx context.Context, exec rep
 				Charts:      []*entity.Chart{},
 				IsDeleted:   row.SongIsDeleted,
 			},
-			ClearLamp: &entity.ClearLampType{
+			ClearLamp: &master.ClearLampType{
 				ID:   row.ClearLampID,
 				Name: row.ClearLampName,
 			},
-			ComboLamp: &entity.ComboLampType{
+			ComboLamp: &master.ComboLampType{
 				ID:   row.ComboLampID,
 				Name: row.ComboLampName,
 			},
-			FullChain: &entity.FullChainType{
+			FullChain: &master.FullChainType{
 				ID:   row.FullChainID,
 				Name: row.FullChainName,
 			},

--- a/internal/usecase/chart_stats_usecase_test.go
+++ b/internal/usecase/chart_stats_usecase_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/ratingband"
 	"github.com/chunisupport/chunisupport-api/internal/info"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -16,7 +17,7 @@ type MockChartStatsRepository struct {
 	mock.Mock
 }
 
-func (m *MockChartStatsRepository) FindRatingBands(ctx context.Context, exec repository.Executor) ([]*entity.RatingBand, error) {
+func (m *MockChartStatsRepository) FindRatingBands(ctx context.Context, exec repository.Executor) ([]*ratingband.RatingBand, error) {
 	panic("FindRatingBands is not used")
 }
 
@@ -29,10 +30,10 @@ func (m *MockChartStatsRepository) FindChartStatsByChartIDs(ctx context.Context,
 }
 
 type StubChartStatsMasterProvider struct {
-	bands []*entity.RatingBand
+	bands []*ratingband.RatingBand
 }
 
-func (s *StubChartStatsMasterProvider) RatingBands() []*entity.RatingBand {
+func (s *StubChartStatsMasterProvider) RatingBands() []*ratingband.RatingBand {
 	return s.bands
 }
 
@@ -43,7 +44,7 @@ func TestGetSongStatsByDisplayID_SortByRatingBandOrder(t *testing.T) {
 	mockStatsRepo := new(MockChartStatsRepository)
 	mockSongMasterProvider := new(MockSongMasterProvider)
 	mockExec := new(MockExecutor)
-	stubMasterProvider := &StubChartStatsMasterProvider{bands: []*entity.RatingBand{{ID: 10, SortOrder: 2}, {ID: 20, SortOrder: 1}}}
+	stubMasterProvider := &StubChartStatsMasterProvider{bands: []*ratingband.RatingBand{{ID: 10, SortOrder: 2}, {ID: 20, SortOrder: 1}}}
 
 	u := NewChartStatsUsecase(mockSongRepo, mockWorldsendRepo, mockStatsRepo, mockSongMasterProvider, stubMasterProvider, mockExec, mockExec)
 
@@ -128,7 +129,7 @@ func TestGetChartStatsByDisplayIDAndDifficulty_WorldsendBranch(t *testing.T) {
 	mockStatsRepo := new(MockChartStatsRepository)
 	mockSongMasterProvider := new(MockSongMasterProvider)
 	mockExec := new(MockExecutor)
-	stubMasterProvider := &StubChartStatsMasterProvider{bands: []*entity.RatingBand{{ID: 1, SortOrder: 2}, {ID: 2, SortOrder: 1}}}
+	stubMasterProvider := &StubChartStatsMasterProvider{bands: []*ratingband.RatingBand{{ID: 1, SortOrder: 2}, {ID: 2, SortOrder: 1}}}
 
 	u := NewChartStatsUsecase(mockSongRepo, mockWorldsendRepo, mockStatsRepo, mockSongMasterProvider, stubMasterProvider, mockExec, mockExec)
 

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
 	"testing"
 	"time"
 
@@ -261,11 +262,11 @@ func TestUserService_GetUserProfileWithRecords_Success(t *testing.T) {
 				Artist:    "Artist A",
 				Charts:    []*entity.Chart{},
 			},
-			ClearLamp:       &entity.ClearLampType{ID: 1, Name: "FAILED"},
-			ComboLamp:       &entity.ComboLampType{ID: 1, Name: "NONE"},
-			FullChain:       &entity.FullChainType{ID: 1, Name: "NONE"},
-			Slot:            &entity.Slot{ID: 1, Name: "best"},
-			ChartDifficulty: &entity.ChartDifficulty{ID: 2, Name: "EXPERT"},
+			ClearLamp:       &master.ClearLampType{ID: 1, Name: "FAILED"},
+			ComboLamp:       &master.ComboLampType{ID: 1, Name: "NONE"},
+			FullChain:       &master.FullChainType{ID: 1, Name: "NONE"},
+			Slot:            &master.Slot{ID: 1, Name: "best"},
+			ChartDifficulty: &master.ChartDifficulty{ID: 2, Name: "EXPERT"},
 		},
 		{
 			PlayerID:    1,
@@ -290,11 +291,11 @@ func TestUserService_GetUserProfileWithRecords_Success(t *testing.T) {
 				Artist:    "Artist B",
 				Charts:    []*entity.Chart{},
 			},
-			ClearLamp:       &entity.ClearLampType{ID: 2, Name: "CLEAR"},
-			ComboLamp:       &entity.ComboLampType{ID: 2, Name: "FC"},
-			FullChain:       &entity.FullChainType{ID: 2, Name: "FC"},
-			Slot:            &entity.Slot{ID: 2, Name: "new_candidate"},
-			ChartDifficulty: &entity.ChartDifficulty{ID: 3, Name: "MASTER"},
+			ClearLamp:       &master.ClearLampType{ID: 2, Name: "CLEAR"},
+			ComboLamp:       &master.ComboLampType{ID: 2, Name: "FC"},
+			FullChain:       &master.FullChainType{ID: 2, Name: "FC"},
+			Slot:            &master.Slot{ID: 2, Name: "new_candidate"},
+			ChartDifficulty: &master.ChartDifficulty{ID: 3, Name: "MASTER"},
 		},
 	}
 
@@ -373,7 +374,7 @@ func TestUserService_GetUserProfileWithRecords_IncludeNoPlay(t *testing.T) {
 			UpdatedAt:       now,
 			Chart:           playedSong.Charts[0],
 			Song:            playedSong,
-			ChartDifficulty: &entity.ChartDifficulty{ID: 3, Name: "expert"},
+			ChartDifficulty: &master.ChartDifficulty{ID: 3, Name: "expert"},
 		}}},
 		&stubWorldsendRecordRepository{},
 		&stubPlayerService{player: player},
@@ -464,11 +465,11 @@ func TestUserService_GetUserProfileRatingView_Success(t *testing.T) {
 				Artist:    "Artist A",
 				Charts:    []*entity.Chart{},
 			},
-			ClearLamp:       &entity.ClearLampType{ID: 1, Name: "FAILED"},
-			ComboLamp:       &entity.ComboLampType{ID: 1, Name: "NONE"},
-			FullChain:       &entity.FullChainType{ID: 1, Name: "NONE"},
-			Slot:            &entity.Slot{ID: 1, Name: "best"},
-			ChartDifficulty: &entity.ChartDifficulty{ID: 2, Name: "EXPERT"},
+			ClearLamp:       &master.ClearLampType{ID: 1, Name: "FAILED"},
+			ComboLamp:       &master.ComboLampType{ID: 1, Name: "NONE"},
+			FullChain:       &master.FullChainType{ID: 1, Name: "NONE"},
+			Slot:            &master.Slot{ID: 1, Name: "best"},
+			ChartDifficulty: &master.ChartDifficulty{ID: 2, Name: "EXPERT"},
 		},
 		{
 			PlayerID:    1,
@@ -493,11 +494,11 @@ func TestUserService_GetUserProfileRatingView_Success(t *testing.T) {
 				Artist:    "Artist B",
 				Charts:    []*entity.Chart{},
 			},
-			ClearLamp:       &entity.ClearLampType{ID: 2, Name: "CLEAR"},
-			ComboLamp:       &entity.ComboLampType{ID: 2, Name: "FC"},
-			FullChain:       &entity.FullChainType{ID: 2, Name: "FC"},
-			Slot:            &entity.Slot{ID: 2, Name: "new_candidate"},
-			ChartDifficulty: &entity.ChartDifficulty{ID: 3, Name: "MASTER"},
+			ClearLamp:       &master.ClearLampType{ID: 2, Name: "CLEAR"},
+			ComboLamp:       &master.ComboLampType{ID: 2, Name: "FC"},
+			FullChain:       &master.FullChainType{ID: 2, Name: "FC"},
+			Slot:            &master.Slot{ID: 2, Name: "new_candidate"},
+			ChartDifficulty: &master.ChartDifficulty{ID: 3, Name: "MASTER"},
 		},
 	}
 


### PR DESCRIPTION
### Motivation

- Centralize small master-type definitions into a dedicated value-object package to reduce duplication and improve type reuse across the codebase.
- Introduce a dedicated `ratingband` VO to represent rating-band data and unify its usage across repositories, DTOs, and caches.
- Maintain compatibility with existing code by aliasing legacy `entity` master types to the new `master` VOs where appropriate.

### Description

- Added `internal/domain/vo/master/master.go` to contain master-type value objects (e.g. `AccountType`, `ChartDifficulty`, `Genre`, `Slot`, etc.) and replaced several small master `entity` structs with type aliases to `master` VOs (e.g. `entity.AccountType = master.AccountType`).
- Added `internal/domain/vo/ratingband/ratingband.go` and migrated all usage of `entity.RatingBand` to `ratingband.RatingBand`, including repository interfaces, repository implementations, DTO conversion functions, and the static cache.
- Updated infra/model conversions in `internal/infra/models/master_model.go` and repository implementations (`player_record_repository_impl.go`, `worldsend_record_repository_impl.go`, `chart_stats_repository_impl.go`, etc.) to construct and return the new VO types from DB rows.
- Adjusted DTOs and helper functions (e.g. `player_record_dto.go` and `chart_stats_dto.go`), services, and tests to use the new `master` and `ratingband` VOs and renamed helper parameters for clarity where relevant.

### Testing

- Ran unit tests via `go test ./...` across the repository, which executed updated package tests and verified compilation with the new VO types.
- All affected unit tests completed successfully with no test failures.
- Updated test files to use the new VO types to ensure coverage of changed conversion and repository logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e083e5e0832daa7df25527de3359)