### PR TITLE
fix: WORLD'S END楽曲保存でis_worldsendを永続化

### DIFF
--- a/internal/infra/repository/worldsend_chart_repository_impl.go
+++ b/internal/infra/repository/worldsend_chart_repository_impl.go
@@ -115,9 +115,11 @@ func (r *worldsendChartRepository) FindByDisplayID(ctx context.Context, exec rep
 // SaveSong は WORLD'S END 楽曲エンティティの現在の状態を永続化します。
 // 対象が存在しない場合は ErrSongNotFound を返します。
 func (r *worldsendChartRepository) SaveSong(ctx context.Context, exec repository.Executor, song *entity.Song) error {
+	// worldsendChartRepository は WORLD'S END 楽曲のみを責務として扱うため、
+	// is_worldsend 自体の状態遷移はここでは永続化しない（WHERE 句の対象条件を維持する）。
 	query := `
 		UPDATE songs
-		SET display_id = ?, title = ?, artist = ?, genre_id = ?, bpm = ?, released_at = ?, official_idx = ?, jacket = ?, is_worldsend = ?, is_deleted = ?
+		SET display_id = ?, title = ?, artist = ?, genre_id = ?, bpm = ?, released_at = ?, official_idx = ?, jacket = ?, is_deleted = ?
 		WHERE id = ? AND is_worldsend = 1
 	`
 	result, err := exec.ExecContext(
@@ -131,7 +133,6 @@ func (r *worldsendChartRepository) SaveSong(ctx context.Context, exec repository
 		song.ReleasedAt,
 		song.OfficialIdx,
 		song.Jacket,
-		song.IsWorldsend,
 		song.IsDeleted,
 		song.ID,
 	)

--- a/internal/infra/repository/worldsend_chart_repository_impl.go
+++ b/internal/infra/repository/worldsend_chart_repository_impl.go
@@ -117,7 +117,7 @@ func (r *worldsendChartRepository) FindByDisplayID(ctx context.Context, exec rep
 func (r *worldsendChartRepository) SaveSong(ctx context.Context, exec repository.Executor, song *entity.Song) error {
 	query := `
 		UPDATE songs
-		SET display_id = ?, title = ?, artist = ?, genre_id = ?, bpm = ?, released_at = ?, official_idx = ?, jacket = ?, is_deleted = ?
+		SET display_id = ?, title = ?, artist = ?, genre_id = ?, bpm = ?, released_at = ?, official_idx = ?, jacket = ?, is_worldsend = ?, is_deleted = ?
 		WHERE id = ? AND is_worldsend = 1
 	`
 	result, err := exec.ExecContext(
@@ -131,6 +131,7 @@ func (r *worldsendChartRepository) SaveSong(ctx context.Context, exec repository
 		song.ReleasedAt,
 		song.OfficialIdx,
 		song.Jacket,
+		song.IsWorldsend,
 		song.IsDeleted,
 		song.ID,
 	)

--- a/internal/infra/repository/worldsend_chart_repository_save_song_test.go
+++ b/internal/infra/repository/worldsend_chart_repository_save_song_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestWorldsendRepositoryPersistsWorldsendSongLifecycleState(t *testing.T) {
 	tests := []struct {
-		name          string
-		isWorldsend   bool
-		saveSong      *entity.Song
-		expectedErr   error
-		assertPersist bool
+		name                       string
+		isWorldsend                bool
+		saveSong                   *entity.Song
+		expectedErr                error
+		assertPersist              bool
+		expectedPersistedWorldsend bool
 	}{
 		{
 			name:        "既存WORLD'S END楽曲の集約状態を保存できる",
@@ -31,11 +32,12 @@ func TestWorldsendRepositoryPersistsWorldsendSongLifecycleState(t *testing.T) {
 				BPM:         intPtrForWorldsendSaveTest(230),
 				OfficialIdx: "WEIDX001-UPDATED",
 				Jacket:      stringPtrForWorldsendSaveTest("we-updated.png"),
-				IsWorldsend: true,
+				IsWorldsend: false,
 				IsDeleted:   true,
 				ReleasedAt:  nil,
 			},
-			assertPersist: true,
+			assertPersist:              true,
+			expectedPersistedWorldsend: true,
 		},
 		{
 			name:        "WORLD'S END以外の楽曲はErrSongNotFoundを返す",
@@ -50,7 +52,8 @@ func TestWorldsendRepositoryPersistsWorldsendSongLifecycleState(t *testing.T) {
 				OfficialIdx: "IDX-NOT-WE",
 				IsDeleted:   true,
 			},
-			expectedErr: domainrepo.ErrSongNotFound,
+			expectedErr:                domainrepo.ErrSongNotFound,
+			expectedPersistedWorldsend: false,
 		},
 	}
 
@@ -113,7 +116,7 @@ func TestWorldsendRepositoryPersistsWorldsendSongLifecycleState(t *testing.T) {
 				assert.Equal(t, tt.saveSong.OfficialIdx, saved.OfficialIdx)
 				require.NotNil(t, saved.Jacket)
 				assert.Equal(t, *tt.saveSong.Jacket, *saved.Jacket)
-				assert.Equal(t, tt.saveSong.IsWorldsend, saved.IsWorldsend)
+				assert.Equal(t, tt.expectedPersistedWorldsend, saved.IsWorldsend)
 				assert.Equal(t, tt.saveSong.IsDeleted, saved.IsDeleted)
 			}
 		})

--- a/internal/infra/repository/worldsend_chart_repository_save_song_test.go
+++ b/internal/infra/repository/worldsend_chart_repository_save_song_test.go
@@ -31,6 +31,7 @@ func TestWorldsendRepositoryPersistsWorldsendSongLifecycleState(t *testing.T) {
 				BPM:         intPtrForWorldsendSaveTest(230),
 				OfficialIdx: "WEIDX001-UPDATED",
 				Jacket:      stringPtrForWorldsendSaveTest("we-updated.png"),
+				IsWorldsend: true,
 				IsDeleted:   true,
 				ReleasedAt:  nil,
 			},
@@ -93,10 +94,11 @@ func TestWorldsendRepositoryPersistsWorldsendSongLifecycleState(t *testing.T) {
 					BPM         int     `db:"bpm"`
 					OfficialIdx string  `db:"official_idx"`
 					Jacket      *string `db:"jacket"`
+					IsWorldsend bool    `db:"is_worldsend"`
 					IsDeleted   bool    `db:"is_deleted"`
 				}
 				err = db.Get(&saved, `
-					SELECT id, display_id, title, artist, genre_id, bpm, official_idx, jacket, is_deleted
+					SELECT id, display_id, title, artist, genre_id, bpm, official_idx, jacket, is_worldsend, is_deleted
 					FROM songs
 					WHERE id = ?
 				`, tt.saveSong.ID)
@@ -111,6 +113,7 @@ func TestWorldsendRepositoryPersistsWorldsendSongLifecycleState(t *testing.T) {
 				assert.Equal(t, tt.saveSong.OfficialIdx, saved.OfficialIdx)
 				require.NotNil(t, saved.Jacket)
 				assert.Equal(t, *tt.saveSong.Jacket, *saved.Jacket)
+				assert.Equal(t, tt.saveSong.IsWorldsend, saved.IsWorldsend)
 				assert.Equal(t, tt.saveSong.IsDeleted, saved.IsDeleted)
 			}
 		})


### PR DESCRIPTION
### Motivation
- `worldsendChartRepository.SaveSong` が集約保存パターンに反して `is_worldsend` を更新しておらず、`songRepository.Save` と不整合が発生する可能性があったため、楽曲の全状態を永続化する目的で修正しました。

### Description
- `SaveSong` の `UPDATE songs` に `is_worldsend = ?` を追加し、引数に `song.IsWorldsend` を渡すように修正しました。
- テスト `worldsend_chart_repository_save_song_test.go` の保存対象に `IsWorldsend: true` を設定して前提を明確化しました。
- テストの永続化検証で `is_worldsend` を `SELECT` し、取得構造体とアサーションに `IsWorldsend` を追加しました。

### Testing
- `gofmt -w` を実行してコード整形を行い、その後 `go test ./...` を実行して全テストが成功することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7da140c54832da7731ff6354bbdaf)