### PR TITLE
docs: _report/refactor.mdの解決済み指摘を削除

### DIFF
--- a/_report/refactor.md
+++ b/_report/refactor.md
@@ -158,8 +158,7 @@
 - **現状のTODO箇所一覧**:
   | ファイル | 行 | 内容 |
   |---|---|---|
-  | `internal/app/handler/compat/chunirec/chunirec_handler.go` | 126 | `// TODO: UserProfileWithRecordsDTOにUserIDフィールドを追加してリファクタリング` |
-  | `internal/usecase/user_usecase_impl.go` | 45 | `// TODO: 最適化の余地あり - 現在はユーザー→プレイヤー→称号→レコードで4回クエリを発行している。` |
+  | `internal/usecase/user_usecase_impl.go` | 50 | `// TODO: 最適化の余地あり - 現在はユーザー→プレイヤー→称号→レコードで4回クエリを発行している。` |
 - **修正案**:
   - 解消またはIssue化。
 
@@ -238,7 +237,7 @@
   - 該当箇所:
     - `api_internal/song_handler.go`: `DeleteSong`, `RestoreSong`
     - `api_internal/api_token_handler.go`: `Generate`, `Delete`
-    - `api_internal/auth_handler.go`: `DeleteAccount`, `Logout`, `UpdatePrivacy`
+    - `api_internal/auth_handler.go`: `Logout`
   - 他のハンドラ（WorldsendHandler等）は正しく `FromUsecaseError()` を使用しており不整合。
 - **影響範囲**:
   - 404系エラー（楽曲/トークン/ユーザー未発見）が500で返されてしまい、クライアント側の適切なエラーハンドリングが困難。


### PR DESCRIPTION
### Motivation
- リファクタリング指摘書（`_report/refactor.md`）を現行コードに合わせて整備し、既に解決または存在しない指摘を削除してレポートの正確性を保つため。

### Description
- `_report/refactor.md` を編集し、存在しない `chunirec_handler.go` の TODO を削除、`internal/usecase/user_usecase_impl.go` の TODO 行番号を現行の `50` に更新し、`HDL-004` の `auth_handler` 対象メソッドを `Logout` のみに絞る変更を行いました（ドキュメントのみの修正）。

### Testing
- コード整形で `gofmt -w $(rg --files -g '*.go')` を実行してコードフォーマットを適用しました。実行は成功しました。 
- `go test ./...` を複数回実行してテストを検証し、全パッケージのテストが成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85f6c5274832da3ae6cd5b3c3b8c0)