### PR TITLE
feat: `sql.ErrNoRows` の判定を各リポジトリでのカスタムエラーに置き換え、エラーハンドリングを改善

### DIFF
--- a/_report/overengineering_simplification_candidates.md
+++ b/_report/overengineering_simplification_candidates.md
@@ -9,24 +9,22 @@
 
 ## 結論
 
-現時点で優先して整理したい候補は次の2件です。
+現時点で優先して整理したい候補は次の1件です。
 
-1. Usecase 層での `sql.ErrNoRows` 判定の削減
-2. `Executor` 抽象の整理
+1. `Executor` 抽象の整理
 
-まずは 1 を先に進め、その後に 2 を検討するのが安全です。
+Usecase 層での `sql.ErrNoRows` 直接判定は解消済みです。
 `Executor` は価値のある見直し候補ですが、影響範囲が広く、先に周辺の責務整理を進めた方が差分を抑えられます。
 
 ## 要約表
 
 | 優先順位 | 候補 | 現状の問題 | 効果 | 影響範囲 | 着手しやすさ |
 |---|---|---|---|---|---|
-| 1 | `sql.ErrNoRows` 判定削減 | Usecase が infra 由来エラーを知っている | 中 | 中 | 中 |
-| 2 | `Executor` 整理 | 抽象の割に `sqlx` 依存を隠し切れていない | 高い | 大きい | 低い |
+| 1 | `Executor` 整理 | 抽象の割に `sqlx` 依存を隠し切れていない | 高い | 大きい | 低い |
 
 ---
 
-## 優先度1: Usecase 層での `sql.ErrNoRows` 判定の削減
+## 解決済み: Usecase 層での `sql.ErrNoRows` 判定の削減
 
 ### 対象
 
@@ -39,31 +37,31 @@
 
 ### 現状
 
-Usecase 層で `errors.Is(err, sql.ErrNoRows)` を直接判定している箇所がまだ複数残っています。
-一方で一部の Repository 実装では `repository.ErrUserNotFound` などへの変換が始まっており、方針が混在しています。
+Repository 実装で not found 系エラーへ変換し、Usecase 層から `errors.Is(err, sql.ErrNoRows)` の直接判定を除去しました。
+Usecase は `repository.ErrUserNotFound` などの repository エラーのみを扱う構成に統一しています。
 
 ### 過剰実装と判断した理由
 
-- Usecase が infra 由来のエラー知識を持っている
-- Repository 境界で吸収すべき責務が Usecase へ漏れている
-- 一部だけ変換済みのため、読み手がどこで何を判定すべきか迷いやすい
+- Usecase が infra 由来のエラー知識を持たなくなった
+- Repository 境界で吸収すべき責務を明確化できた
+- not found 判定の置き場所が統一された
 
 ### 推奨方針
 
-- not found 系は Repository 実装で domain / repository エラーへ変換する
+- not found 系は Repository 実装で repository エラーへ変換済み
 - Usecase は repository 層で定義されたエラーのみを扱う
-- テストも `sql.ErrNoRows` 前提から repository エラー前提へ寄せる
+- テストも repository エラー前提へ寄せた
 
 ### 期待効果
 
-- エラー責務が整理される
-- Usecase 実装が読みやすくなる
-- DB 実装の詳細が上位層に漏れにくくなる
+- エラー責務が整理された
+- Usecase 実装が読みやすくなった
+- DB 実装の詳細が上位層に漏れにくくなった
 
 ### 注意点
 
-- 1件ごとの差分は小さいが、横断的に揃えないと中途半端になりやすい
-- `ErrUserNotFound` 以外の not found 系エラーの置き場所を先に決めた方がよい
+- `FindByUserID` のように「見つからない場合は `nil, nil`」を契約にしている箇所はそのまま維持する
+- 今後も not found をエラーで返す Repository は repository エラーへ変換する
 
 ### 完了条件
 
@@ -73,7 +71,7 @@ Usecase 層で `errors.Is(err, sql.ErrNoRows)` を直接判定している箇所
 
 ---
 
-## 優先度2: `Executor` 抽象の整理
+## 優先度1: `Executor` 抽象の整理
 
 ### 対象
 
@@ -140,13 +138,8 @@ Usecase 層で `errors.Is(err, sql.ErrNoRows)` を直接判定している箇所
 
 ### フェーズ1
 
-`sql.ErrNoRows` の扱いを Repository 側へ寄せます。
-Usecase の見通しがよくなり、局所的な差分で進めやすい候補です。
-
-### フェーズ2
-
 最後に `Executor` を整理します。
-ここは横断的な変更なので、周辺責務を先に整えてから着手する方が安全です。
+ここは横断的な変更なので、周辺責務を先に整えた現状から着手する方が安全です。
 
 ---
 

--- a/internal/domain/repository/api_token_repository.go
+++ b/internal/domain/repository/api_token_repository.go
@@ -10,7 +10,7 @@ import (
 type APITokenRepository interface {
 	// CreateOrReplace はユーザーに紐づくトークンを保存し、既存のトークンがあれば置き換えます。
 	CreateOrReplace(ctx context.Context, exec Executor, token *entity.APIToken) error
-	// FindByHashedToken はハッシュ化トークンで検索します。
+	// FindByHashedToken はハッシュ化トークンで検索します。対象が存在しない場合は ErrAPITokenNotFound を返します。
 	FindByHashedToken(ctx context.Context, exec Executor, hashedToken string) (*entity.APIToken, error)
 	// DeleteByUserID はユーザーIDに紐づくAPIトークンを削除します。
 	DeleteByUserID(ctx context.Context, exec Executor, userID int) error

--- a/internal/domain/repository/errors.go
+++ b/internal/domain/repository/errors.go
@@ -8,6 +8,21 @@ var (
 	// ErrUserNotFound はユーザーが見つからなかった場合に返されるエラーです。
 	ErrUserNotFound = errors.New("user not found")
 
+	// ErrSessionNotFound はセッションが見つからなかった場合に返されるエラーです。
+	ErrSessionNotFound = errors.New("session not found")
+
+	// ErrPlayerNotFound はプレイヤーが見つからなかった場合に返されるエラーです。
+	ErrPlayerNotFound = errors.New("player not found")
+
+	// ErrRecoveryCodeNotFound はリカバリーコードが見つからなかった場合に返されるエラーです。
+	ErrRecoveryCodeNotFound = errors.New("recovery code not found")
+
+	// ErrAPITokenNotFound はAPIトークンが見つからなかった場合に返されるエラーです。
+	ErrAPITokenNotFound = errors.New("api token not found")
+
+	// ErrGoalNotFound は目標が見つからなかった場合に返されるエラーです。
+	ErrGoalNotFound = errors.New("goal not found")
+
 	// ErrSongNotFound は楽曲が見つからなかった場合に返されるエラーです。
 	ErrSongNotFound = errors.New("song not found")
 

--- a/internal/domain/repository/goal_repository.go
+++ b/internal/domain/repository/goal_repository.go
@@ -10,9 +10,12 @@ import (
 // GoalRepository は目標の永続化を扱います。
 type GoalRepository interface {
 	ListByUserID(ctx context.Context, exec Executor, userID int) ([]*entity.Goal, error)
+	// FindByIDAndUserID は対象が存在しない場合に ErrGoalNotFound を返します。
 	FindByIDAndUserID(ctx context.Context, exec Executor, id uint32, userID int) (*entity.Goal, error)
 	Create(ctx context.Context, exec Executor, goal *entity.Goal) error
+	// Update は対象が存在しない場合に ErrGoalNotFound を返します。
 	Update(ctx context.Context, exec Executor, goal *entity.Goal) error
+	// DeleteByIDAndUserID は対象が存在しない場合に ErrGoalNotFound を返します。
 	DeleteByIDAndUserID(ctx context.Context, exec Executor, id uint32, userID int) error
 	CountByUserID(ctx context.Context, exec Executor, userID int) (int, error)
 	LockUserByID(ctx context.Context, exec Executor, userID int) error

--- a/internal/domain/repository/player_repository.go
+++ b/internal/domain/repository/player_repository.go
@@ -21,9 +21,9 @@ type PlayerWithHonors struct {
 
 // PlayerRepository はプレイヤーに関する永続化を扱うリポジトリです。
 type PlayerRepository interface {
-	// FindByID はIDでプレイヤーを検索します。
+	// FindByID はIDでプレイヤーを検索します。対象が存在しない場合は ErrPlayerNotFound を返します。
 	FindByID(ctx context.Context, exec Executor, id int) (*entity.Player, error)
-	// FindByIDWithHonors はIDでプレイヤーと称号情報をまとめて検索します。
+	// FindByIDWithHonors はIDでプレイヤーと称号情報をまとめて検索します。対象が存在しない場合は ErrPlayerNotFound を返します。
 	FindByIDWithHonors(ctx context.Context, exec Executor, id int) (*PlayerWithHonors, error)
 	// FindByUserID はユーザーIDでプレイヤーを検索します。見つからない場合は(nil, nil)を返します。
 	FindByUserID(ctx context.Context, exec Executor, userID int) (*entity.Player, error)

--- a/internal/domain/repository/recovery_code_repository.go
+++ b/internal/domain/repository/recovery_code_repository.go
@@ -14,8 +14,8 @@ type RecoveryCodeRepository interface {
 	DeleteByUserID(ctx context.Context, exec Executor, userID int) error
 	// DeleteByID はリカバリーコードを削除します。
 	DeleteByID(ctx context.Context, exec Executor, id uint32) error
-	// FindByHash はハッシュでリカバリーコードを検索します。
+	// FindByHash はハッシュでリカバリーコードを検索します。対象が存在しない場合は ErrRecoveryCodeNotFound を返します。
 	FindByHash(ctx context.Context, exec Executor, codeHash []byte) (*entity.RecoveryCode, error)
-	// FindByHashForUpdate はハッシュでリカバリーコードを検索し、ロックします。
+	// FindByHashForUpdate はハッシュでリカバリーコードを検索し、ロックします。対象が存在しない場合は ErrRecoveryCodeNotFound を返します。
 	FindByHashForUpdate(ctx context.Context, exec Executor, codeHash []byte) (*entity.RecoveryCode, error)
 }

--- a/internal/domain/repository/session_repository.go
+++ b/internal/domain/repository/session_repository.go
@@ -10,7 +10,7 @@ import (
 type SessionRepository interface {
 	// Create は新しいセッションを保存します。
 	Create(ctx context.Context, exec Executor, session *entity.Session) error
-	// FindByID はセッションIDでセッションを検索します。
+	// FindByID はセッションIDでセッションを検索します。対象が存在しない場合は ErrSessionNotFound を返します。
 	FindByID(ctx context.Context, exec Executor, id string) (*entity.Session, error)
 	// Delete はセッションIDでセッションを削除します。
 	Delete(ctx context.Context, exec Executor, id string) error

--- a/internal/infra/repository/api_token_repository_impl.go
+++ b/internal/infra/repository/api_token_repository_impl.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
@@ -43,6 +45,9 @@ func (r *apiTokenRepository) FindByHashedToken(ctx context.Context, exec reposit
 	var tokenModel models.APITokenModel
 	query := `SELECT id, user_id, hashed_token, created_at FROM api_tokens WHERE hashed_token = ?`
 	if err := exec.GetContext(ctx, &tokenModel, query, hashedToken); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Join(repository.ErrAPITokenNotFound, err)
+		}
 		return nil, err
 	}
 	return tokenModel.ToEntity(), nil

--- a/internal/infra/repository/goal_repository_impl.go
+++ b/internal/infra/repository/goal_repository_impl.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -39,6 +40,9 @@ func (r *goalRepository) FindByIDAndUserID(ctx context.Context, exec repository.
 	var m models.GoalModel
 	query := `SELECT id, user_id, title, achievement_type_id, achievement_params, attributes, invert, created_at FROM goals WHERE id = ? AND user_id = ?`
 	if err := exec.GetContext(ctx, &m, query, id, userID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Join(repository.ErrGoalNotFound, err)
+		}
 		return nil, err
 	}
 	return m.ToEntity(), nil
@@ -72,7 +76,7 @@ func (r *goalRepository) Update(ctx context.Context, exec repository.Executor, g
 		return err
 	}
 	if affected == 0 {
-		return sql.ErrNoRows
+		return repository.ErrGoalNotFound
 	}
 	return nil
 }
@@ -88,7 +92,7 @@ func (r *goalRepository) DeleteByIDAndUserID(ctx context.Context, exec repositor
 		return err
 	}
 	if affected == 0 {
-		return sql.ErrNoRows
+		return repository.ErrGoalNotFound
 	}
 	return nil
 }

--- a/internal/infra/repository/player_repository_impl.go
+++ b/internal/infra/repository/player_repository_impl.go
@@ -35,6 +35,9 @@ func (r *playerRepository) FindByID(ctx context.Context, exec repository.Executo
 	`
 	var playerModel models.PlayerModel
 	if err := exec.GetContext(ctx, &playerModel, query, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Join(repository.ErrPlayerNotFound, err)
+		}
 		return nil, err
 	}
 	return playerModel.ToEntity()
@@ -109,7 +112,7 @@ func (r *playerRepository) FindByIDWithHonors(ctx context.Context, exec reposito
 	}
 
 	if result == nil {
-		return nil, sql.ErrNoRows
+		return nil, repository.ErrPlayerNotFound
 	}
 
 	return result, nil

--- a/internal/infra/repository/player_repository_impl_test.go
+++ b/internal/infra/repository/player_repository_impl_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	domainrepo "github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
@@ -59,6 +60,34 @@ func (e *noRowsWrappedExecutor) GetContext(ctx context.Context, dest any, query 
 
 var _ domainrepo.Executor = (*noRowsWrappedExecutor)(nil)
 
+type rowsAffectedResult struct {
+	lastInsertID int64
+	rowsAffected int64
+}
+
+func (r rowsAffectedResult) LastInsertId() (int64, error) {
+	return r.lastInsertID, nil
+}
+
+func (r rowsAffectedResult) RowsAffected() (int64, error) {
+	return r.rowsAffected, nil
+}
+
+type execResultExecutor struct {
+	baseExecutor
+	result sql.Result
+	err    error
+}
+
+func (e *execResultExecutor) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	return e.result, nil
+}
+
+var _ domainrepo.Executor = (*execResultExecutor)(nil)
+
 func TestFindByUserID_ReturnsNilWhenWrappedNoRows(t *testing.T) {
 	repo := &playerRepository{}
 	exec := &noRowsWrappedExecutor{}
@@ -66,6 +95,76 @@ func TestFindByUserID_ReturnsNilWhenWrappedNoRows(t *testing.T) {
 	player, err := repo.FindByUserID(context.Background(), exec, 10)
 	require.NoError(t, err)
 	require.Nil(t, player)
+}
+
+func TestFindByID_ReturnsErrPlayerNotFoundWhenWrappedNoRows(t *testing.T) {
+	repo := &playerRepository{}
+	exec := &noRowsWrappedExecutor{}
+
+	player, err := repo.FindByID(context.Background(), exec, 10)
+	require.ErrorIs(t, err, domainrepo.ErrPlayerNotFound)
+	require.Nil(t, player)
+}
+
+func TestSessionFindByID_ReturnsErrSessionNotFoundWhenWrappedNoRows(t *testing.T) {
+	repo := &sessionRepository{}
+	exec := &noRowsWrappedExecutor{}
+
+	session, err := repo.FindByID(context.Background(), exec, "550e8400-e29b-41d4-a716-446655440000")
+	require.ErrorIs(t, err, domainrepo.ErrSessionNotFound)
+	require.Nil(t, session)
+}
+
+func TestRecoveryCodeFindByHash_ReturnsErrRecoveryCodeNotFoundWhenWrappedNoRows(t *testing.T) {
+	repo := &recoveryCodeRepository{}
+	exec := &noRowsWrappedExecutor{}
+
+	code, err := repo.FindByHash(context.Background(), exec, []byte("hash"))
+	require.ErrorIs(t, err, domainrepo.ErrRecoveryCodeNotFound)
+	require.Nil(t, code)
+}
+
+func TestRecoveryCodeFindByHashForUpdate_ReturnsErrRecoveryCodeNotFoundWhenWrappedNoRows(t *testing.T) {
+	repo := &recoveryCodeRepository{}
+	exec := &noRowsWrappedExecutor{}
+
+	code, err := repo.FindByHashForUpdate(context.Background(), exec, []byte("hash"))
+	require.ErrorIs(t, err, domainrepo.ErrRecoveryCodeNotFound)
+	require.Nil(t, code)
+}
+
+func TestAPITokenFindByHashedToken_ReturnsErrAPITokenNotFoundWhenWrappedNoRows(t *testing.T) {
+	repo := &apiTokenRepository{}
+	exec := &noRowsWrappedExecutor{}
+
+	token, err := repo.FindByHashedToken(context.Background(), exec, "hashed-token")
+	require.ErrorIs(t, err, domainrepo.ErrAPITokenNotFound)
+	require.Nil(t, token)
+}
+
+func TestGoalFindByIDAndUserID_ReturnsErrGoalNotFoundWhenWrappedNoRows(t *testing.T) {
+	repo := &goalRepository{}
+	exec := &noRowsWrappedExecutor{}
+
+	goal, err := repo.FindByIDAndUserID(context.Background(), exec, 1, 1)
+	require.ErrorIs(t, err, domainrepo.ErrGoalNotFound)
+	require.Nil(t, goal)
+}
+
+func TestGoalUpdate_ReturnsErrGoalNotFoundWhenNoRowsAffected(t *testing.T) {
+	repo := &goalRepository{}
+	exec := &execResultExecutor{result: rowsAffectedResult{rowsAffected: 0}}
+
+	err := repo.Update(context.Background(), exec, &entity.Goal{ID: 1, UserID: 1})
+	require.ErrorIs(t, err, domainrepo.ErrGoalNotFound)
+}
+
+func TestGoalDelete_ReturnsErrGoalNotFoundWhenNoRowsAffected(t *testing.T) {
+	repo := &goalRepository{}
+	exec := &execResultExecutor{result: rowsAffectedResult{rowsAffected: 0}}
+
+	err := repo.DeleteByIDAndUserID(context.Background(), exec, 1, 1)
+	require.ErrorIs(t, err, domainrepo.ErrGoalNotFound)
 }
 
 func setupPlayerRepositorySQLite(t *testing.T) *sqlx.DB {
@@ -196,6 +295,6 @@ func TestFindByIDWithHonors_ReturnsNoRowsWhenPlayerMissing(t *testing.T) {
 	repo := &playerRepository{}
 
 	result, err := repo.FindByIDWithHonors(context.Background(), db, 999)
-	require.ErrorIs(t, err, sql.ErrNoRows)
+	require.ErrorIs(t, err, domainrepo.ErrPlayerNotFound)
 	require.Nil(t, result)
 }

--- a/internal/infra/repository/recovery_code_repository_impl.go
+++ b/internal/infra/repository/recovery_code_repository_impl.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"strings"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -67,6 +69,9 @@ func (r *recoveryCodeRepository) FindByHash(ctx context.Context, exec repository
 	var model models.RecoveryCodeModel
 	query := `SELECT id, user_id, code_hash, created_at FROM user_recovery_codes WHERE code_hash = ?`
 	if err := exec.GetContext(ctx, &model, query, codeHash); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Join(repository.ErrRecoveryCodeNotFound, err)
+		}
 		return nil, err
 	}
 	return model.ToEntity(), nil
@@ -77,6 +82,9 @@ func (r *recoveryCodeRepository) FindByHashForUpdate(ctx context.Context, exec r
 	var model models.RecoveryCodeModel
 	query := `SELECT id, user_id, code_hash, created_at FROM user_recovery_codes WHERE code_hash = ? FOR UPDATE`
 	if err := exec.GetContext(ctx, &model, query, codeHash); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Join(repository.ErrRecoveryCodeNotFound, err)
+		}
 		return nil, err
 	}
 	return model.ToEntity(), nil

--- a/internal/infra/repository/session_repository_impl.go
+++ b/internal/infra/repository/session_repository_impl.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
@@ -39,6 +41,9 @@ func (r *sessionRepository) FindByID(ctx context.Context, exec repository.Execut
 	var sessionModel models.SessionModel
 	query := `SELECT id, user_id, expires_at, created_at FROM sessions WHERE id = ?`
 	if err := exec.GetContext(ctx, &sessionModel, query, model.ID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Join(repository.ErrSessionNotFound, err)
+		}
 		return nil, err
 	}
 	return sessionModel.ToEntity()

--- a/internal/usecase/api_token_usecase_impl.go
+++ b/internal/usecase/api_token_usecase_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -64,7 +63,7 @@ func (us *apiTokenUsecase) Validate(ctx context.Context, rawToken string) (*enti
 	hashed := hashToken(rawToken)
 	token, err := us.tokenRepo.FindByHashedToken(ctx, us.db, hashed)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrAPITokenNotFound) {
 			return nil, nil, ErrInvalidAPIToken
 		}
 		return nil, nil, err
@@ -72,7 +71,7 @@ func (us *apiTokenUsecase) Validate(ctx context.Context, rawToken string) (*enti
 
 	user, err := us.userRepo.FindByID(ctx, us.db, token.UserID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrUserNotFound) {
 			return nil, nil, ErrInvalidAPIToken
 		}
 		return nil, nil, err

--- a/internal/usecase/api_token_usecase_impl_test.go
+++ b/internal/usecase/api_token_usecase_impl_test.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 
@@ -33,10 +32,10 @@ func (s *stubAPITokenRepository) FindByHashedToken(ctx context.Context, exec rep
 		return nil, s.lookupErr
 	}
 	if s.lookupToken == nil {
-		return nil, sql.ErrNoRows
+		return nil, repository.ErrAPITokenNotFound
 	}
 	if s.lookupToken.HashedToken != hashedToken {
-		return nil, sql.ErrNoRows
+		return nil, repository.ErrAPITokenNotFound
 	}
 	tokenCopy := *s.lookupToken
 	return &tokenCopy, nil
@@ -60,7 +59,7 @@ func (s *tokenStubUserRepository) FindByID(ctx context.Context, exec repository.
 		return nil, s.findErr
 	}
 	if s.user == nil {
-		return nil, sql.ErrNoRows
+		return nil, repository.ErrUserNotFound
 	}
 	userCopy := *s.user
 	return &userCopy, nil

--- a/internal/usecase/auth_usecase_impl.go
+++ b/internal/usecase/auth_usecase_impl.go
@@ -2,13 +2,13 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/auth"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/passwordhash"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/username"
 	"github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
@@ -27,7 +27,7 @@ func (s *authUsecaseImpl) Register(ctx context.Context, usernameStr, password st
 
 	if _, err := s.userRepo.FindByUsername(ctx, s.db, usernameStr); err == nil {
 		return nil, "", ErrUsernameTaken
-	} else if !errors.Is(err, sql.ErrNoRows) {
+	} else if !errors.Is(err, repository.ErrUserNotFound) {
 		slog.Error("failed to find user by username", "username", usernameStr, "error", err)
 		return nil, "", err
 	}
@@ -64,7 +64,7 @@ func (s *authUsecaseImpl) Register(ctx context.Context, usernameStr, password st
 func (s *authUsecaseImpl) Login(ctx context.Context, usernameStr, password string) (string, error) {
 	user, err := s.userRepo.FindByUsername(ctx, s.db, usernameStr)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrUserNotFound) {
 			return "", ErrInvalidCredentials
 		}
 		slog.Error("failed to find user by username", "username", usernameStr, "error", err)
@@ -110,7 +110,7 @@ func (s *authUsecaseImpl) Logout(ctx context.Context, sessionID string) error {
 func (s *authUsecaseImpl) Authenticate(ctx context.Context, userID int, sessionID string) (*entity.User, error) {
 	session, err := s.sessionRepo.FindByID(ctx, s.db, sessionID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrSessionNotFound) {
 			return nil, ErrInvalidSession
 		}
 		slog.Error("failed to find session by id", "session_id", sessionID, "error", err)
@@ -128,7 +128,7 @@ func (s *authUsecaseImpl) Authenticate(ctx context.Context, userID int, sessionI
 
 	user, err := s.userRepo.FindByID(ctx, s.db, userID)
 	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
+		if !errors.Is(err, repository.ErrUserNotFound) {
 			slog.Error("failed to find user by id", "user_id", userID, "error", err)
 			return nil, err
 		}

--- a/internal/usecase/auth_usecase_test.go
+++ b/internal/usecase/auth_usecase_test.go
@@ -2,11 +2,11 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/passwordhash"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/username"
 	"github.com/chunisupport/chunisupport-api/internal/info"
@@ -22,7 +22,7 @@ func TestAuthUsecase_Register(t *testing.T) {
 	authUsecase := newTestAuthUsecase(mockUserRepo, mockSessionRepo, "test-pepper")
 
 	t.Run("Register_正常系_ユーザー登録が成功する", func(t *testing.T) {
-		mockUserRepo.On("FindByUsername", mock.Anything, mock.Anything, "testuser").Return(nil, sql.ErrNoRows).Once()
+		mockUserRepo.On("FindByUsername", mock.Anything, mock.Anything, "testuser").Return(nil, repository.ErrUserNotFound).Once()
 		mockUserRepo.On("Create", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 		mockSessionRepo.On("Create", mock.Anything, mock.Anything, mock.AnythingOfType("*entity.Session")).Return(nil).Once()
 		mockSessionRepo.On("DeleteOldestSessionsOverLimit", mock.Anything, mock.Anything, mock.Anything, info.MaxSessionsPerUser).Return(nil).Once()
@@ -126,7 +126,7 @@ func TestAuthUsecase_Authenticate(t *testing.T) {
 		mockSessionRepo := new(MockSessionRepository)
 		authUsecase := newTestAuthUsecase(mockUserRepo, mockSessionRepo, "test-pepper")
 
-		mockSessionRepo.On("FindByID", mock.Anything, mock.Anything, "invalidsession").Return(nil, sql.ErrNoRows).Once()
+		mockSessionRepo.On("FindByID", mock.Anything, mock.Anything, "invalidsession").Return(nil, repository.ErrSessionNotFound).Once()
 
 		_, err := authUsecase.Authenticate(context.Background(), mockUser.ID, "invalidsession")
 		assert.ErrorIs(t, err, ErrInvalidSession)

--- a/internal/usecase/goal_usecase_impl.go
+++ b/internal/usecase/goal_usecase_impl.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -97,7 +96,7 @@ func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *
 	}
 	goal, err := u.goalRepo.FindByIDAndUserID(ctx, u.db, id, userID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrGoalNotFound) {
 			return nil, ErrGoalNotFound
 		}
 		return nil, err
@@ -108,7 +107,7 @@ func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *
 	goal.Attributes = validated.Attributes
 	goal.Invert = validated.Invert
 	if err := u.goalRepo.Update(ctx, u.db, goal); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrGoalNotFound) {
 			return nil, ErrGoalNotFound
 		}
 		return nil, err
@@ -122,7 +121,7 @@ func (u *goalUsecase) Update(ctx context.Context, userID int, id uint32, input *
 
 func (u *goalUsecase) Delete(ctx context.Context, userID int, id uint32) error {
 	err := u.goalRepo.DeleteByIDAndUserID(ctx, u.db, id, userID)
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, repository.ErrGoalNotFound) {
 		return ErrGoalNotFound
 	}
 	return err

--- a/internal/usecase/goal_usecase_impl_test.go
+++ b/internal/usecase/goal_usecase_impl_test.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -26,7 +25,7 @@ func (s *stubGoalRepo) ListByUserID(ctx context.Context, exec repository.Executo
 }
 func (s *stubGoalRepo) FindByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) (*entity.Goal, error) {
 	if s.goal == nil || s.goal.ID != id {
-		return nil, sql.ErrNoRows
+		return nil, repository.ErrGoalNotFound
 	}
 	return s.goal, nil
 }
@@ -45,7 +44,7 @@ func (s *stubGoalRepo) Update(ctx context.Context, exec repository.Executor, goa
 }
 func (s *stubGoalRepo) DeleteByIDAndUserID(ctx context.Context, exec repository.Executor, id uint32, userID int) error {
 	if s.goal == nil || s.goal.ID != id {
-		return sql.ErrNoRows
+		return repository.ErrGoalNotFound
 	}
 	s.goal = nil
 	return nil
@@ -158,7 +157,7 @@ func TestGoalUsecase_DeleteNotFound(t *testing.T) {
 }
 
 func TestGoalUsecase_UpdateNotFoundOnSave(t *testing.T) {
-	repo := &stubGoalRepo{goal: &entity.Goal{ID: 1, UserID: 1}, updateErr: sql.ErrNoRows}
+	repo := &stubGoalRepo{goal: &entity.Goal{ID: 1, UserID: 1}, updateErr: repository.ErrGoalNotFound}
 	u := NewGoalUsecase(nil, &stubTM{}, repo, &stubGoalMasterProvider{})
 	_, err := u.Update(context.Background(), 1, 1, &GoalInput{
 		Title:             "updated",

--- a/internal/usecase/recovery_usecase.go
+++ b/internal/usecase/recovery_usecase.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
-	"database/sql"
 	"errors"
 	"fmt"
 	"math/big"
@@ -37,7 +36,7 @@ func NewRecoveryUsecase(db repository.Executor, tm TransactionManager, userRepo 
 
 func (s *recoveryUsecaseImpl) IssueRecoveryCodes(ctx context.Context, userID int) ([]string, error) {
 	if _, err := s.userRepo.FindByID(ctx, s.db, userID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrUserNotFound) {
 			return nil, ErrUserNotFound
 		}
 		return nil, err
@@ -86,14 +85,14 @@ func (s *recoveryUsecaseImpl) RecoverWithRecoveryCode(ctx context.Context, recov
 	return s.tm.Transactional(ctx, func(tx repository.Executor) error {
 		code, err := s.recoveryCodeRepo.FindByHashForUpdate(ctx, tx, hashBytes)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, repository.ErrRecoveryCodeNotFound) {
 				return ErrInvalidRecoveryCredentials
 			}
 			return err
 		}
 		user, err := s.userRepo.FindByID(ctx, tx, code.UserID)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, repository.ErrUserNotFound) {
 				return ErrInvalidRecoveryCredentials
 			}
 			return err

--- a/internal/usecase/recovery_usecase_test.go
+++ b/internal/usecase/recovery_usecase_test.go
@@ -2,12 +2,12 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/passwordhash"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/username"
 	"github.com/chunisupport/chunisupport-api/internal/info"
@@ -51,7 +51,7 @@ func TestRecoveryUsecase_IssueRecoveryCodes(t *testing.T) {
 		tm := &mockTransactionManager{}
 		recoveryUsecase := newTestRecoveryUsecase(tm, mockUserRepo, mockRecoveryRepo, "test-pepper")
 
-		mockUserRepo.On("FindByID", mock.Anything, mock.Anything, 1).Return(nil, sql.ErrNoRows).Once()
+		mockUserRepo.On("FindByID", mock.Anything, mock.Anything, 1).Return(nil, repository.ErrUserNotFound).Once()
 
 		_, err := recoveryUsecase.IssueRecoveryCodes(context.Background(), 1)
 		assert.ErrorIs(t, err, ErrUserNotFound)
@@ -113,7 +113,7 @@ func TestRecoveryUsecase_RecoverWithRecoveryCode(t *testing.T) {
 			name:        "RecoverWithRecoveryCode_異常系_リカバリーコードが見つからない",
 			newPassword: "new-password",
 			setupMock: func(userRepo *MockUserRepository, recoveryRepo *MockRecoveryCodeRepository) {
-				recoveryRepo.On("FindByHashForUpdate", mock.Anything, mock.Anything, hash).Return(nil, sql.ErrNoRows).Once()
+				recoveryRepo.On("FindByHashForUpdate", mock.Anything, mock.Anything, hash).Return(nil, repository.ErrRecoveryCodeNotFound).Once()
 			},
 			wantErr: ErrInvalidRecoveryCredentials,
 		},
@@ -122,7 +122,7 @@ func TestRecoveryUsecase_RecoverWithRecoveryCode(t *testing.T) {
 			newPassword: "new-password",
 			setupMock: func(userRepo *MockUserRepository, recoveryRepo *MockRecoveryCodeRepository) {
 				recoveryRepo.On("FindByHashForUpdate", mock.Anything, mock.Anything, hash).Return(newTestCode(), nil).Once()
-				userRepo.On("FindByID", mock.Anything, mock.Anything, 1).Return(nil, sql.ErrNoRows).Once()
+				userRepo.On("FindByID", mock.Anything, mock.Anything, 1).Return(nil, repository.ErrUserNotFound).Once()
 			},
 			wantErr: ErrInvalidRecoveryCredentials,
 		},

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"time"
@@ -200,7 +199,7 @@ func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, us
 	// 1. ユーザーを取得
 	user, err := s.userRepo.FindByUsername(ctx, s.db, username)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrUserNotFound) {
 			return ErrUserNotFound
 		}
 		slog.Error("failed to find user by username", "username", username, "error", err)
@@ -234,7 +233,7 @@ func (s *userUsecase) RestoreUser(ctx context.Context, requester *entity.User, u
 	// 1. ユーザーを取得
 	user, err := s.userRepo.FindByUsername(ctx, s.db, username)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrUserNotFound) {
 			return ErrUserNotFound
 		}
 		slog.Error("failed to find user by username", "username", username, "error", err)
@@ -474,7 +473,7 @@ func initializeRatingSlotMap() map[string][]*dto.PlayerRecordDTO {
 func (s *userUsecase) getUserAndPlayer(ctx context.Context, username string, requester *entity.User) (*entity.User, *dto.PlayerDTO, error) {
 	user, err := s.userRepo.FindByUsername(ctx, s.db, username)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrUserNotFound) {
 			return nil, nil, ErrUserNotFound
 		}
 		slog.Error("failed to find user by username", "username", username, "error", err)
@@ -495,7 +494,7 @@ func (s *userUsecase) getUserAndPlayer(ctx context.Context, username string, req
 
 	playerWithHonors, err := s.playerRepo.FindByIDWithHonors(ctx, s.db, *user.PlayerID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, repository.ErrPlayerNotFound) {
 			return nil, nil, ErrPlayerNotLinked
 		}
 		if errors.Is(err, context.Canceled) {

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -212,7 +211,7 @@ func (s *stubWorldsendChartRepository) UpdateSongs(ctx context.Context, exec rep
 }
 
 func TestUserService_GetUserProfileWithRecords_UserNotFound(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{err: sql.ErrNoRows}, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{err: repository.ErrUserNotFound}, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
 
 	_, err := service.GetUserProfileWithRecords(context.Background(), "missing", nil, false)
 	require.ErrorIs(t, err, ErrUserNotFound)
@@ -254,7 +253,7 @@ func TestUserService_GetUserProfileWithRecords_PlayerRepositoryNoRows(t *testing
 		Username: un,
 		PlayerID: intPointer(1),
 	}
-	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRepository{err: sql.ErrNoRows}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
+	service := NewUserService(nil, &stubUserRepository{user: user}, &stubPlayerRepository{err: repository.ErrPlayerNotFound}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
 
 	_, err := service.GetUserProfileWithRecords(context.Background(), "tester", nil, false)
 	require.ErrorIs(t, err, ErrPlayerNotLinked)
@@ -724,7 +723,7 @@ func TestUserService_DeleteUser_Success(t *testing.T) {
 
 func TestUserService_DeleteUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
-	repo := &stubUserRepository{err: sql.ErrNoRows}
+	repo := &stubUserRepository{err: repository.ErrUserNotFound}
 	service := NewUserService(nil, repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), adminRequester, "missing")
@@ -790,7 +789,7 @@ func TestUserService_RestoreUser_Success(t *testing.T) {
 
 func TestUserService_RestoreUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
-	repo := &stubUserRepository{err: sql.ErrNoRows}
+	repo := &stubUserRepository{err: repository.ErrUserNotFound}
 	service := NewUserService(nil, repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
 
 	err := service.RestoreUser(context.Background(), adminRequester, "missing")


### PR DESCRIPTION
feat: `Executor` 抽象の整理を進め、関連するリポジトリメソッドにエラーメッセージを追加
fix: Usecase 層での `sql.ErrNoRows` 判定を削除し、リポジトリエラーに統一
docs: `FindByHashedToken` などのメソッドに対象が存在しない場合のエラーを明記
test: 各リポジトリメソッドのテストを更新し、カスタムエラーを使用するように修正