### PR TITLE
update: 難易度ID固定依存を廃止し難易度名基準へ移行

### DIFF
--- a/internal/app/handler/api_internal/song_handler.go
+++ b/internal/app/handler/api_internal/song_handler.go
@@ -179,7 +179,7 @@ func (h *SongHandler) convertToSongDTOs(songs []*entity.Song) []*api_internal.So
 
 // convertToSongDTO は Song を SongDTO に変換します。
 // Charts フィールドは難易度名をキーとするマップに変換されます。
-// マッピングルール: 1->"BASIC", 2->"ADVANCED", 3->"EXPERT", 4->"MASTER", 5->"ULTIMA"
+// マッピングルールは難易度マスタ（DifficultyNamesByID）を参照します。
 func (h *SongHandler) convertToSongDTO(song *entity.Song) *api_internal.SongDTO {
 	maxOP := h.songUsecase.CalcSongMaxOP(song)
 	songDTO := api_internal.ToSongDTO(song, h.masterCache.GenreNamesByID, maxOP)

--- a/internal/app/handler/api_v1/song_handler.go
+++ b/internal/app/handler/api_v1/song_handler.go
@@ -99,7 +99,7 @@ func (h *V1SongHandler) convertToV1SongDTOs(songs []*entity.Song) []*api_v1.V1So
 
 // convertToV1SongDTO は Song を V1SongDTO に変換します。
 // Charts フィールドは難易度名をキーとするマップに変換されます。
-// マッピングルール: 1->"BASIC", 2->"ADVANCED", 3->"EXPERT", 4->"MASTER", 5->"ULTIMA"
+// マッピングルールは難易度マスタ（DifficultyNamesByID）を参照します。
 func (h *V1SongHandler) convertToV1SongDTO(song *entity.Song) *api_v1.V1SongDTO {
 	maxOP := h.songUsecase.CalcSongMaxOP(song)
 	v1SongDTO := api_v1.ToV1SongDTO(song, h.masterCache.GenreNamesByID, maxOP)

--- a/internal/app/handler/song_helper.go
+++ b/internal/app/handler/song_helper.go
@@ -6,10 +6,13 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-const (
-	MinDifficultyID = 1
-	MaxDifficultyID = 5
-)
+var standardDifficultyNames = map[string]struct{}{
+	"BASIC":    {},
+	"ADVANCED": {},
+	"EXPERT":   {},
+	"MASTER":   {},
+	"ULTIMA":   {},
+}
 
 // ParseDifficultyPath はパスパラメータを内部難易度名に変換します。
 // 無効なパラメータの場合は空文字とfalseを返します。
@@ -27,16 +30,20 @@ func BuildChartsMap[T any](
 ) map[string]T {
 	// Initialize map with nil for all difficulty levels
 	chartsMap := make(map[string]T)
-	for diffID, diffName := range difficultyNames {
-		if diffID >= MinDifficultyID && diffID <= MaxDifficultyID {
-			var zero T
-			chartsMap[diffName] = zero
+	for _, diffName := range difficultyNames {
+		if _, ok := standardDifficultyNames[diffName]; !ok {
+			continue
 		}
+		var zero T
+		chartsMap[diffName] = zero
 	}
 
 	// Populate map with actual chart data
 	for _, chart := range charts {
 		if diffName, ok := difficultyNames[chart.DifficultyID]; ok {
+			if _, isStandard := standardDifficultyNames[diffName]; !isStandard {
+				continue
+			}
 			chartsMap[diffName] = converter(chart)
 		}
 	}

--- a/internal/app/handler/song_helper_test.go
+++ b/internal/app/handler/song_helper_test.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildChartsMap_難易度IDが非連番でも通常譜面キーを初期化する(t *testing.T) {
+	difficultyNames := map[int]string{
+		10: "BASIC",
+		30: "ADVANCED",
+		50: "EXPERT",
+		70: "MASTER",
+		90: "ULTIMA",
+	}
+	charts := []*entity.Chart{
+		{DifficultyID: 50},
+		{DifficultyID: 70},
+	}
+
+	chartsMap := BuildChartsMap(charts, difficultyNames, func(c *entity.Chart) int {
+		return c.DifficultyID
+	})
+
+	require.Len(t, chartsMap, 5)
+	assert.Equal(t, 0, chartsMap["BASIC"])
+	assert.Equal(t, 0, chartsMap["ADVANCED"])
+	assert.Equal(t, 50, chartsMap["EXPERT"])
+	assert.Equal(t, 70, chartsMap["MASTER"])
+	assert.Equal(t, 0, chartsMap["ULTIMA"])
+}
+
+func TestBuildChartsMap_通常譜面以外の難易度は初期化対象外(t *testing.T) {
+	difficultyNames := map[int]string{
+		10: "BASIC",
+		20: "ADVANCED",
+		30: "EXPERT",
+		40: "MASTER",
+		50: "ULTIMA",
+		99: "WORLD'S END",
+	}
+	charts := []*entity.Chart{
+		{DifficultyID: 99},
+	}
+
+	chartsMap := BuildChartsMap(charts, difficultyNames, func(c *entity.Chart) int {
+		return c.DifficultyID
+	})
+
+	require.Len(t, chartsMap, 5)
+	_, exists := chartsMap["WORLD'S END"]
+	assert.False(t, exists)
+}

--- a/internal/domain/service/song_aggregation_service.go
+++ b/internal/domain/service/song_aggregation_service.go
@@ -2,10 +2,10 @@ package service
 
 import "github.com/chunisupport/chunisupport-api/internal/domain/entity"
 
-// MASTER/ULTIMA の難易度ID
+// MaxOPのunknown判定対象になる難易度名
 const (
-	difficultyIDMaster = 4
-	difficultyIDUltima = 5
+	difficultyNameMaster = "MASTER"
+	difficultyNameUltima = "ULTIMA"
 )
 
 // SongAggregation は楽曲の譜面集約結果を保持します。
@@ -18,9 +18,9 @@ type SongAggregation struct {
 //
 // 判定ルール:
 //   - MaxChartConst: 全譜面のうち最大の定数値
-//   - IsMaxOPUnknown: MASTER(4)またはULTIMA(5)の譜面に is_const_unknown=true が
+//   - IsMaxOPUnknown: MASTERまたはULTIMAの譜面に is_const_unknown=true が
 //     1件でも含まれれば true。EXPERT以下のunknownは判定対象外。
-func AggregateSongCharts(charts []*entity.Chart) SongAggregation {
+func AggregateSongCharts(charts []*entity.Chart, difficultyNamesByID map[int]string) SongAggregation {
 	var maxConst float64
 	isMaxOPUnknown := false
 
@@ -31,7 +31,8 @@ func AggregateSongCharts(charts []*entity.Chart) SongAggregation {
 		}
 
 		// MASTER/ULTIMA の is_const_unknown をチェック
-		if (c.DifficultyID == difficultyIDMaster || c.DifficultyID == difficultyIDUltima) && c.IsConstUnknown {
+		difficultyName, exists := difficultyNamesByID[c.DifficultyID]
+		if exists && c.IsConstUnknown && (difficultyName == difficultyNameMaster || difficultyName == difficultyNameUltima) {
 			isMaxOPUnknown = true
 		}
 	}
@@ -44,8 +45,8 @@ func AggregateSongCharts(charts []*entity.Chart) SongAggregation {
 
 // ApplyAggregation は楽曲エンティティの譜面リストから集約結果を計算し、
 // MaxChartConst と IsMaxOPUnknown をエンティティに適用します。
-func ApplyAggregation(song *entity.Song) {
-	agg := AggregateSongCharts(song.Charts)
+func ApplyAggregation(song *entity.Song, difficultyNamesByID map[int]string) {
+	agg := AggregateSongCharts(song.Charts, difficultyNamesByID)
 	song.MaxChartConst = agg.MaxChartConst
 	song.IsMaxOPUnknown = agg.IsMaxOPUnknown
 }

--- a/internal/domain/service/song_aggregation_service_test.go
+++ b/internal/domain/service/song_aggregation_service_test.go
@@ -19,10 +19,11 @@ func helperChart(difficultyID int, constVal float64, isConstUnknown bool) *entit
 
 func TestAggregateSongCharts(t *testing.T) {
 	tests := []struct {
-		name               string
-		charts             []*entity.Chart
-		wantMaxChartConst  float64
-		wantIsMaxOPUnknown bool
+		name                string
+		charts              []*entity.Chart
+		difficultyNamesByID map[int]string
+		wantMaxChartConst   float64
+		wantIsMaxOPUnknown  bool
 	}{
 		{
 			name:               "譜面なし楽曲はゼロ値",
@@ -39,6 +40,13 @@ func TestAggregateSongCharts(t *testing.T) {
 				helperChart(4, 13.8, false), // MASTER
 				helperChart(5, 14.5, false), // ULTIMA
 			},
+			difficultyNamesByID: map[int]string{
+				1: "BASIC",
+				2: "ADVANCED",
+				3: "EXPERT",
+				4: "MASTER",
+				5: "ULTIMA",
+			},
 			wantMaxChartConst:  14.5,
 			wantIsMaxOPUnknown: false,
 		},
@@ -49,6 +57,11 @@ func TestAggregateSongCharts(t *testing.T) {
 				helperChart(4, 14.6, false), // MASTER known
 				helperChart(5, 14.5, true),  // ULTIMA unknown（暫定値）
 			},
+			difficultyNamesByID: map[int]string{
+				3: "EXPERT",
+				4: "MASTER",
+				5: "ULTIMA",
+			},
 			wantMaxChartConst:  14.6,
 			wantIsMaxOPUnknown: true,
 		},
@@ -58,6 +71,11 @@ func TestAggregateSongCharts(t *testing.T) {
 				helperChart(3, 10.5, false), // EXPERT
 				helperChart(4, 13.5, true),  // MASTER unknown
 				helperChart(5, 14.8, false), // ULTIMA known
+			},
+			difficultyNamesByID: map[int]string{
+				3: "EXPERT",
+				4: "MASTER",
+				5: "ULTIMA",
 			},
 			wantMaxChartConst:  14.8,
 			wantIsMaxOPUnknown: true,
@@ -71,6 +89,13 @@ func TestAggregateSongCharts(t *testing.T) {
 				helperChart(4, 13.8, false), // MASTER known
 				helperChart(5, 14.5, false), // ULTIMA known
 			},
+			difficultyNamesByID: map[int]string{
+				1: "BASIC",
+				2: "ADVANCED",
+				3: "EXPERT",
+				4: "MASTER",
+				5: "ULTIMA",
+			},
 			wantMaxChartConst:  14.5,
 			wantIsMaxOPUnknown: false,
 		},
@@ -79,6 +104,10 @@ func TestAggregateSongCharts(t *testing.T) {
 			charts: []*entity.Chart{
 				helperChart(4, 13.5, true), // MASTER unknown
 				helperChart(5, 14.5, true), // ULTIMA unknown
+			},
+			difficultyNamesByID: map[int]string{
+				4: "MASTER",
+				5: "ULTIMA",
 			},
 			wantMaxChartConst:  14.5,
 			wantIsMaxOPUnknown: true,
@@ -89,6 +118,10 @@ func TestAggregateSongCharts(t *testing.T) {
 				helperChart(3, 10.5, false), // EXPERT known
 				helperChart(4, 13.5, true),  // MASTER unknown
 			},
+			difficultyNamesByID: map[int]string{
+				3: "EXPERT",
+				4: "MASTER",
+			},
 			wantMaxChartConst:  13.5,
 			wantIsMaxOPUnknown: true,
 		},
@@ -97,6 +130,10 @@ func TestAggregateSongCharts(t *testing.T) {
 			charts: []*entity.Chart{
 				helperChart(3, 10.5, false), // EXPERT known
 				helperChart(4, 13.8, false), // MASTER known
+			},
+			difficultyNamesByID: map[int]string{
+				3: "EXPERT",
+				4: "MASTER",
 			},
 			wantMaxChartConst:  13.8,
 			wantIsMaxOPUnknown: false,
@@ -108,6 +145,11 @@ func TestAggregateSongCharts(t *testing.T) {
 				helperChart(2, 6.0, false),  // ADVANCED known
 				helperChart(3, 10.5, false), // EXPERT known
 			},
+			difficultyNamesByID: map[int]string{
+				1: "BASIC",
+				2: "ADVANCED",
+				3: "EXPERT",
+			},
 			wantMaxChartConst:  10.5,
 			wantIsMaxOPUnknown: false,
 		},
@@ -117,14 +159,33 @@ func TestAggregateSongCharts(t *testing.T) {
 				helperChart(4, 14.0, false), // MASTER known
 				helperChart(5, 14.0, true),  // ULTIMA unknown（同定数）
 			},
+			difficultyNamesByID: map[int]string{
+				4: "MASTER",
+				5: "ULTIMA",
+			},
 			wantMaxChartConst:  14.0,
+			wantIsMaxOPUnknown: true,
+		},
+		{
+			name: "MASTER/ULTIMAのIDが4/5でなくても難易度名で判定できる",
+			charts: []*entity.Chart{
+				helperChart(30, 10.5, false), // EXPERT
+				helperChart(40, 14.8, false), // MASTER known
+				helperChart(50, 14.7, true),  // ULTIMA unknown
+			},
+			difficultyNamesByID: map[int]string{
+				30: "EXPERT",
+				40: "MASTER",
+				50: "ULTIMA",
+			},
+			wantMaxChartConst:  14.8,
 			wantIsMaxOPUnknown: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			agg := AggregateSongCharts(tt.charts)
+			agg := AggregateSongCharts(tt.charts, tt.difficultyNamesByID)
 
 			if agg.MaxChartConst != tt.wantMaxChartConst {
 				t.Errorf("MaxChartConst = %v, want %v", agg.MaxChartConst, tt.wantMaxChartConst)
@@ -145,7 +206,10 @@ func TestApplyAggregation(t *testing.T) {
 		},
 	}
 
-	ApplyAggregation(song)
+	ApplyAggregation(song, map[int]string{
+		4: "MASTER",
+		5: "ULTIMA",
+	})
 
 	if song.MaxChartConst != 14.6 {
 		t.Errorf("MaxChartConst = %v, want %v", song.MaxChartConst, 14.6)

--- a/internal/infra/repository/song_repository_find_test.go
+++ b/internal/infra/repository/song_repository_find_test.go
@@ -137,6 +137,47 @@ func TestFindByDisplayIDs_SetsIsMaxOPUnknownWhenMasterOrUltimaIsConstUnknown(t *
 	assert.True(t, songs[0].IsMaxOPUnknown)
 }
 
+func TestFindByDisplayIDs_MASTERとULTIMAのIDが4と5以外でもIsMaxOPUnknownを判定できる(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	_, err := db.Exec(`
+		DELETE FROM difficulties;
+		INSERT INTO difficulties (id, name) VALUES
+			(10, 'BASIC'),
+			(20, 'ADVANCED'),
+			(30, 'EXPERT'),
+			(40, 'MASTER'),
+			(50, 'ULTIMA')
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO songs (id, display_id, title, artist, genre_id, bpm, released_at, official_idx, jacket, is_worldsend, is_deleted)
+		VALUES
+			(1, 'DISPLAY001', 'Song 1', 'Artist 1', 1, 180, NULL, 'IDX001', NULL, 0, 0)
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO charts (song_id, difficulty_id, const, is_const_unknown, notes)
+		VALUES
+			(1, 40, 14.8, 0, 1050),
+			(1, 50, 14.7, 1, 1100)
+	`)
+	require.NoError(t, err)
+
+	repo := &songRepository{db: db}
+	songs, err := repo.FindByDisplayIDs(ctx, db, []string{"DISPLAY001"})
+	require.NoError(t, err)
+	require.Len(t, songs, 1)
+
+	assert.InDelta(t, 14.8, songs[0].MaxChartConst, 0.001)
+	assert.True(t, songs[0].IsMaxOPUnknown)
+}
+
 func TestFindByDisplayIDs_ExcludesWorldsendSongs(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()

--- a/internal/infra/repository/song_repository_impl.go
+++ b/internal/infra/repository/song_repository_impl.go
@@ -46,6 +46,7 @@ type chartRow struct {
 	ID             int     `db:"id"`
 	SongID         int     `db:"song_id"`
 	DifficultyID   int     `db:"difficulty_id"`
+	DifficultyName string  `db:"difficulty_name"`
 	Const          float64 `db:"const"`
 	IsConstUnknown bool    `db:"is_const_unknown"`
 	Notes          *int    `db:"notes"`
@@ -85,10 +86,20 @@ func (r *songRepository) FindAllExcludingWorldsend(ctx context.Context, exec rep
 
 	// 3. 該当する楽曲の譜面を一括取得（N+1問題回避）
 	chartsQuery, args, err := sqlx.In(`
-		SELECT id, song_id, difficulty_id, const, is_const_unknown, notes
-		FROM charts
+		SELECT c.id, c.song_id, c.difficulty_id, d.name AS difficulty_name, c.const, c.is_const_unknown, c.notes
+		FROM charts c
+		INNER JOIN difficulties d ON c.difficulty_id = d.id
 		WHERE song_id IN (?)
-		ORDER BY song_id, difficulty_id
+		ORDER BY c.song_id,
+			CASE d.name
+				WHEN 'BASIC' THEN 1
+				WHEN 'ADVANCED' THEN 2
+				WHEN 'EXPERT' THEN 3
+				WHEN 'MASTER' THEN 4
+				WHEN 'ULTIMA' THEN 5
+				ELSE 999
+			END,
+			c.difficulty_id
 	`, songIDs)
 	if err != nil {
 		return nil, err
@@ -119,8 +130,9 @@ func (r *songRepository) FindAllExcludingWorldsend(ctx context.Context, exec rep
 	}
 
 	// 6. ドメインサービスで譜面集約を適用（MaxChartConst, IsMaxOPUnknown）
+	difficultyNamesByID := buildDifficultyNamesByID(chartRows)
 	for _, song := range results {
-		service.ApplyAggregation(song)
+		service.ApplyAggregation(song, difficultyNamesByID)
 	}
 
 	return results, nil
@@ -200,10 +212,20 @@ func (r *songRepository) FindByDisplayIDs(ctx context.Context, exec repository.E
 
 	// 3. 該当する楽曲の譜面を一括取得（N+1問題回避）
 	chartsQuery, chartArgs, err := sqlx.In(`
-		SELECT id, song_id, difficulty_id, const, is_const_unknown, notes
-		FROM charts
+		SELECT c.id, c.song_id, c.difficulty_id, d.name AS difficulty_name, c.const, c.is_const_unknown, c.notes
+		FROM charts c
+		INNER JOIN difficulties d ON c.difficulty_id = d.id
 		WHERE song_id IN (?)
-		ORDER BY song_id, difficulty_id
+		ORDER BY c.song_id,
+			CASE d.name
+				WHEN 'BASIC' THEN 1
+				WHEN 'ADVANCED' THEN 2
+				WHEN 'EXPERT' THEN 3
+				WHEN 'MASTER' THEN 4
+				WHEN 'ULTIMA' THEN 5
+				ELSE 999
+			END,
+			c.difficulty_id
 	`, songIDs)
 	if err != nil {
 		return nil, err
@@ -234,8 +256,9 @@ func (r *songRepository) FindByDisplayIDs(ctx context.Context, exec repository.E
 	}
 
 	// 6. ドメインサービスで譜面集約を適用（MaxChartConst, IsMaxOPUnknown）
+	difficultyNamesByID := buildDifficultyNamesByID(chartRows)
 	for _, song := range songs {
-		service.ApplyAggregation(song)
+		service.ApplyAggregation(song, difficultyNamesByID)
 	}
 
 	return songs, nil
@@ -262,10 +285,19 @@ func (r *songRepository) FindByDisplayID(ctx context.Context, exec repository.Ex
 
 	// 2. 譜面を取得
 	chartsQuery := `
-		SELECT id, song_id, difficulty_id, const, is_const_unknown, notes
-		FROM charts
-		WHERE song_id = ?
-		ORDER BY difficulty_id
+		SELECT c.id, c.song_id, c.difficulty_id, d.name AS difficulty_name, c.const, c.is_const_unknown, c.notes
+		FROM charts c
+		INNER JOIN difficulties d ON c.difficulty_id = d.id
+		WHERE c.song_id = ?
+		ORDER BY CASE d.name
+			WHEN 'BASIC' THEN 1
+			WHEN 'ADVANCED' THEN 2
+			WHEN 'EXPERT' THEN 3
+			WHEN 'MASTER' THEN 4
+			WHEN 'ULTIMA' THEN 5
+			ELSE 999
+		END,
+		c.difficulty_id
 	`
 	var chartRows []chartRow
 	if err := exec.SelectContext(ctx, &chartRows, chartsQuery, songRow.ID); err != nil {
@@ -280,9 +312,17 @@ func (r *songRepository) FindByDisplayID(ctx context.Context, exec repository.Ex
 	song.Charts = charts
 
 	// 3. ドメインサービスで譜面集約を適用（MaxChartConst, IsMaxOPUnknown）
-	service.ApplyAggregation(song)
+	service.ApplyAggregation(song, buildDifficultyNamesByID(chartRows))
 
 	return song, nil
+}
+
+func buildDifficultyNamesByID(chartRows []chartRow) map[int]string {
+	difficultyNamesByID := make(map[int]string, len(chartRows))
+	for _, chart := range chartRows {
+		difficultyNamesByID[chart.DifficultyID] = chart.DifficultyName
+	}
+	return difficultyNamesByID
 }
 
 // Save は楽曲エンティティの現在の状態を永続化します。


### PR DESCRIPTION
### Motivation
- AUTO_INCREMENT な `difficulties.id` に順序や意味を持たせる実装（4/5 固定判定や 1..5 レンジ前提）を除去し、マスタ名（大文字）基準で判定・初期化することで再投入や環境差分に強い実装にするため。

### Description
- `internal/domain/service/song_aggregation_service.go` を変更し、MASTER/ULTIMA 判定を難易度IDではなく難易度名（`MASTER`/`ULTIMA`）で行うようにし、`AggregateSongCharts` / `ApplyAggregation` に `difficultyNamesByID` マップを渡す形にしました。
- `internal/infra/repository/song_repository_impl.go` を変更し、`charts` クエリで `difficulties` を JOIN して難易度名を取得し、譜面取得順を難易度名の明示順（BASIC→ADVANCED→EXPERT→MASTER→ULTIMA）へ変更し、取得した難易度名から `difficultyNamesByID` を構築してドメインサービスへ渡すようにしました。
- `internal/app/handler/song_helper.go` の `BuildChartsMap` を ID レンジ依存から通常譜面名セット（BASIC/ADVANCED/EXPERT/MASTER/ULTIMA）判定へ変更し、WORLD'S END 等の通常譜面外を初期化対象外に統一しました。
- テストを追加/更新して TDD に従い ID 非連番ケースや除外ケースをカバーしました（`internal/domain/service/song_aggregation_service_test.go`, `internal/app/handler/song_helper_test.go`, `internal/infra/repository/song_repository_find_test.go`）。
- ハンドラ内の固定的なコメントをマスタ参照ベースの説明へ更新し、必要箇所を `gofmt` で整形しました。

### Testing
- 追加・更新したユニットテストを含めて `go test ./...` を実行し最終的に全テストが成功しました（途中で1件失敗したテストを修正して再実行し合格）。
- 変更後に `gofmt -w` を実行してコード整形を行いました。 
- 依存箇所の検索で固定ID/レンジ比較や `ORDER BY difficulty_id` への影響を確認しています（対象箇所の明示的置換・安全化を実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1d366b39c832d87f89a52c2b0c158)