### PR TITLE
Change user deletion to physical remove and add Firebase user deletion integration

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -108,7 +108,7 @@
 | `/internal/me/privacy` | PUT | Cookie | 非公開設定更新 |
 | `/internal/me/password` | PUT | Cookie | パスワード変更 |
 | `/internal/me/recovery-codes` | POST | Cookie | リカバリーコード発行 |
-| `/internal/me` | DELETE | Cookie | アカウント論理削除 |
+| `/internal/me` | DELETE | Cookie | アカウント物理削除 |
 | `/internal/me/register-data` | POST | Cookie | CHUNITHMプレイヤーデータ登録 |
 | `/internal/me/player-data` | DELETE | Cookie | プレイヤー連携を解除し、プレイヤー関連レコードを削除 |
 | `/internal/me/firebase/link` | POST | Cookie | Firebase UID を現在のユーザーへ連携 |
@@ -118,11 +118,11 @@
 | `/internal/me/goals` | POST | Cookie | 目標を作成 |
 | `/internal/me/goals/:id` | PUT | Cookie | 目標を更新 |
 | `/internal/me/goals/:id` | DELETE | Cookie | 目標を削除 |
-| `/internal/users/` | GET | Cookie (ADMIN+) | 全ユーザー一覧取得（プライベート・削除済み・プレイヤー未紐付けを含む） |
+| `/internal/users/` | GET | Cookie (ADMIN+) | 全ユーザー一覧取得（プライベート・プレイヤー未紐付けを含む） |
 | `/internal/users/:username/updated-at` | GET | Cookie (任意) | レコード更新日時のみ取得 |
 | `/internal/users/:username` | GET | Cookie (任意) | プロファイルとレコードを一括取得 |
-| `/internal/users/:username` | DELETE | Cookie (ADMIN+) | ユーザーの論理削除 |
-| `/internal/users/:username/restore` | POST | Cookie (ADMIN+) | ユーザーの復活 |
+| `/internal/users/:username` | DELETE | Cookie (ADMIN+) | ユーザーの物理削除 |
+
 | `/internal/songs` | GET | Cookie (任意) | WORLD'S END以外の楽曲一覧取得 |
 | `/internal/songs/:displayid` | GET | Cookie (任意) | 楽曲詳細取得 |
 | `/internal/songs/:displayid/stats/:difficulty` | GET | Cookie (任意) | 難易度別楽曲統計取得 |
@@ -429,13 +429,12 @@
 - **認証**: Cookie 必須
 - **レスポンス**: 200 OK。ボディは空です。
 
-ユーザーを論理削除し、全セッションを即時失効します。あわせて、当該ユーザーのAPIトークンとリカバリーコードも削除します。
+ユーザーを物理削除します。ユーザーに紐づく `players` / `player_records` / `player_worldsend_records` / `player_honors` / `sessions` / `api_tokens` / `user_recovery_codes` も外部キー制約により削除されます。Firebase UID が連携されている場合は Firebase ユーザー削除も試行します（失敗時はサーバーログに記録し、APIレスポンスは成功を維持します）。
 
 - **主なエラー**:
   - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
   - 404 Not Found (`user_not_found`): ユーザーが見つからない
-  - 400 Bad Request (`operation_failed`): 操作失敗（例: 既に削除済み）
-  - 500 Internal Server Error (`internal_error`): サーバー内部エラー（セッション無効化失敗など）
+  - 500 Internal Server Error (`internal_error`): サーバー内部エラー（DB削除失敗など）
 
 ### DELETE `/internal/me/player-data`
 - **認証**: Cookie 必須
@@ -465,12 +464,12 @@
   - 同一ユーザーに同じ Firebase UID を再連携した場合は、冪等に成功します。
   - 同一ユーザーに別の Firebase UID を連携した場合は、新しい Firebase UID に更新されます。
   - 他ユーザーに既に連携されている Firebase UID は連携できません。
-  - 論理削除済みユーザーに紐付いた Firebase UID も再利用できません。
+
 - **主なエラー**:
   - 400 Bad Request (`bad_request`): リクエスト形式不正（JSONパースエラー）
   - 401 Unauthorized (`invalid_token`): Firebase IDトークンが不正または失効済み
   - 401 Unauthorized (`unauthorized`): 削除済みユーザー
-  - 409 Conflict (`firebase_uid_already_linked`): Firebase UID が他ユーザーまたは削除済みユーザーに連携済み
+  - 409 Conflict (`firebase_uid_already_linked`): Firebase UID が他ユーザーに連携済み
   - 500 Internal Server Error (`internal_error`): 予期しないサーバーエラー
 
 ### GET `/internal/me/sessions`
@@ -620,7 +619,6 @@ curl -X POST \
 **注意事項**:
 - レーティング計算は毎回全レコードを対象に行うため、10万ユーザー規模でも問題なくスケール可能です
 - `official_player_rating` は入力データの `rating` フィールドから設定され、`calculated_player_rating` とは独立して保存されます
-
 
 - **コンテンツタイプ**: `application/json`
 
@@ -1047,7 +1045,7 @@ curl -X POST \
 
 ### GET `/internal/users/`
 - **認証**: Cookie 必須（ADMIN権限必須）
-- **説明**: ADMIN専用のエンドポイントです。プライベートアカウント、削除済みアカウント、プレイヤー未紐付けアカウントを含む全ユーザーの一覧を取得します。
+- **説明**: ADMIN専用のエンドポイントです。プライベートアカウント、プレイヤー未紐付けアカウントを含む全ユーザーの一覧を取得します。
 - **クエリパラメータ**:
     - `page` (任意): ページ番号 (デフォルト: 1)
     - `name` (任意): ユーザー名またはプレイヤー名の前方一致検索
@@ -1066,8 +1064,7 @@ curl -X POST \
     "rating": 17.25,
     "overpower_value": 9500.00,
     "is_suspicious": false,
-    "is_private": false,
-    "is_deleted": false
+    "is_private": false
   },
   {
     "username": "user2",
@@ -1078,20 +1075,7 @@ curl -X POST \
     "rating": null,
     "overpower_value": null,
     "is_suspicious": true,
-    "is_private": true,
-    "is_deleted": false
-  },
-  {
-    "username": "deleted_user",
-    "account_type": "EDITOR",
-    "created_at": "2025-10-01T00:00:00+09:00",
-    "updated_at": "2025-10-15T18:45:00+09:00",
-    "player_name": "deleted_player",
-    "rating": 15.00,
-    "overpower_value": 7500.00,
-    "is_suspicious": false,
-    "is_private": false,
-    "is_deleted": true
+    "is_private": true
   }
 ]
 ```
@@ -1109,7 +1093,6 @@ curl -X POST \
 | `overpower_value` | number \| null | オーバーパワー値（未連携の場合は null） |
 | `is_suspicious` | boolean | 不審アカウントフラグ |
 | `is_private` | boolean | プライベートアカウントかどうか |
-| `is_deleted` | boolean | 削除済みアカウントかどうか |
 
 ---
 
@@ -1266,21 +1249,7 @@ curl -X POST \
 - **パスパラメータ**: `username` - 削除対象ユーザーのユーザー名
 - **レスポンス**: 204 No Content
 
-**説明**: 指定されたユーザー名のユーザーを論理削除（`is_deleted = TRUE`）します。物理削除は行わず、関連データ（プレイヤー、セッション）は保持されます。削除済みユーザーはログインできなくなります。
-
-- **主なエラー**:
-  - 401 Unauthorized (`unauthorized`): Cookie欠如または無効
-  - 403 Forbidden (`forbidden`): ADMIN権限が不足
-  - 404 Not Found (`user_not_found`): ユーザーが存在しない
-  - 400 Bad Request (`operation_failed`): 操作失敗（詳細隠蔽）
-
-### POST `/internal/users/:username/restore`
-- **認証**: Cookie 必須
-- **権限**: ADMIN (account_type_id = 3) 以上
-- **パスパラメータ**: `username` - 復活対象ユーザーのユーザー名
-- **レスポンス**: 204 No Content
-
-**説明**: 論理削除されたユーザーを復活（`is_deleted = FALSE`）させます。復活後はログインが可能になります。
+**説明**: 指定されたユーザー名のユーザーを物理削除します。関連データ（プレイヤー・レコード・セッション・APIトークン・リカバリーコード）も外部キー制約により削除されます。Firebase UID が連携されている場合は Firebase ユーザー削除も試行します（失敗時はサーバーログに記録し、APIレスポンスは成功を維持します）。
 
 - **主なエラー**:
   - 401 Unauthorized (`unauthorized`): Cookie欠如または無効
@@ -2604,4 +2573,4 @@ interface SkippedRecord {
 
 - `.env` の `JWT_SECRET` と `PW_PEPPER` は32文字以上の強度を推奨します。
 - CORSの許可オリジンやCookie属性は環境ごとに設定ファイルで管理します。
-- ユーザーを論理削除するとログインは失敗し、既存セッションも無効化されます。
+- ユーザーを物理削除すると、ログインはできなくなり、関連データも削除されます。

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -44,8 +44,6 @@ func FromUsecaseError(err error) *APIError {
 		return ErrUserNotFound.WithInternal(err) // プレイヤー未紐付も404で隠蔽
 	case errors.Is(err, usecase.ErrUserAlreadyDeleted):
 		return ErrOperationFailed.WithInternal(err) // 409 → 400 で詳細を隠蔽
-	case errors.Is(err, usecase.ErrUserNotDeleted):
-		return ErrOperationFailed.WithInternal(err) // 409 → 400 で詳細を隠蔽
 	case errors.Is(err, usecase.ErrOperationFailed):
 		return ErrOperationFailed.WithInternal(err)
 	case errors.Is(err, usecase.ErrInternalError):

--- a/internal/app/firebase_setup.go
+++ b/internal/app/firebase_setup.go
@@ -9,28 +9,30 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/usecase"
 )
 
+// SetupFirebaseAuthServices は Firebase 認証関連の依存関係をまとめて初期化します。
+func SetupFirebaseAuthServices(ctx context.Context, cfg config.Config) (usecase.TokenVerifier, usecase.FirebaseUserDeleter, error) {
+	client, err := firebaseauth.NewAuthClientFromCredentialsFile(ctx, cfg.Firebase.CredentialsFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize firebase auth client: %w", err)
+	}
+
+	return firebaseauth.NewTokenVerifier(client), firebaseauth.NewFirebaseUserDeleter(client), nil
+}
+
 // SetupFirebaseTokenVerifier は Firebase TokenVerifier を初期化します。
 func SetupFirebaseTokenVerifier(ctx context.Context, cfg config.Config) (usecase.TokenVerifier, error) {
-	verifier, err := firebaseauth.NewTokenVerifierFromCredentialsFile(ctx, cfg.Firebase.CredentialsFile)
+	verifier, _, err := SetupFirebaseAuthServices(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize firebase token verifier: %w", err)
 	}
-	if verifier == nil {
-		return nil, fmt.Errorf("failed to initialize firebase token verifier: verifier is nil")
-	}
-
 	return verifier, nil
 }
 
 // SetupFirebaseUserDeleter は FirebaseUserDeleter を初期化します。
 func SetupFirebaseUserDeleter(ctx context.Context, cfg config.Config) (usecase.FirebaseUserDeleter, error) {
-	deleter, err := firebaseauth.NewFirebaseUserDeleterFromCredentialsFile(ctx, cfg.Firebase.CredentialsFile)
+	_, deleter, err := SetupFirebaseAuthServices(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize firebase user deleter: %w", err)
 	}
-	if deleter == nil {
-		return nil, fmt.Errorf("failed to initialize firebase user deleter: deleter is nil")
-	}
-
 	return deleter, nil
 }

--- a/internal/app/firebase_setup.go
+++ b/internal/app/firebase_setup.go
@@ -21,3 +21,16 @@ func SetupFirebaseTokenVerifier(ctx context.Context, cfg config.Config) (usecase
 
 	return verifier, nil
 }
+
+// SetupFirebaseUserDeleter は FirebaseUserDeleter を初期化します。
+func SetupFirebaseUserDeleter(ctx context.Context, cfg config.Config) (usecase.FirebaseUserDeleter, error) {
+	deleter, err := firebaseauth.NewFirebaseUserDeleterFromCredentialsFile(ctx, cfg.Firebase.CredentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize firebase user deleter: %w", err)
+	}
+	if deleter == nil {
+		return nil, fmt.Errorf("failed to initialize firebase user deleter: deleter is nil")
+	}
+
+	return deleter, nil
+}

--- a/internal/app/handler/api_internal/user_handler.go
+++ b/internal/app/handler/api_internal/user_handler.go
@@ -92,7 +92,7 @@ func (h *UserHandler) handleUserProfileError(err error, username string, context
 	}
 }
 
-// DeleteUser はユーザーを論理削除するハンドラです（ADMIN権限必須）。
+// DeleteUser はユーザーを物理削除するハンドラです（ADMIN権限必須）。
 func (h *UserHandler) DeleteUser(c echo.Context) error {
 	username := c.Param("username")
 	requester, ok := c.Get("userEntity").(*entity.User)
@@ -108,39 +108,8 @@ func (h *UserHandler) DeleteUser(c echo.Context) error {
 			return apierror.ErrForbidden
 		case errors.Is(err, usecase.ErrUserNotFound):
 			return apierror.ErrUserNotFound
-		case errors.Is(err, usecase.ErrUserAlreadyDeleted):
-			// セキュリティ: 削除済みであることを隠蔽
-			return apierror.ErrOperationFailed
 		default:
 			slog.Error("failed to delete user", "username", username, "error", err)
-			return apierror.ErrInternalError.WithInternal(err)
-		}
-	}
-
-	return c.NoContent(http.StatusNoContent)
-}
-
-// RestoreUser はユーザーを復活させるハンドラです（ADMIN権限必須）。
-func (h *UserHandler) RestoreUser(c echo.Context) error {
-	username := c.Param("username")
-	requester, ok := c.Get("userEntity").(*entity.User)
-	if !ok {
-		// 認証ミドルウェアが正しく機能していれば、この分岐に入ることはありません。
-		// 安全のため、不正なリクエストとして処理します。
-		return apierror.ErrUnauthorized
-	}
-
-	if err := h.userUsecase.RestoreUser(c.Request().Context(), requester, username); err != nil {
-		switch {
-		case errors.Is(err, usecase.ErrAdminRequired):
-			return apierror.ErrForbidden
-		case errors.Is(err, usecase.ErrUserNotFound):
-			return apierror.ErrUserNotFound
-		case errors.Is(err, usecase.ErrUserNotDeleted):
-			// セキュリティ: 未削除であることを隠蔽
-			return apierror.ErrOperationFailed
-		default:
-			slog.Error("failed to restore user", "username", username, "error", err)
 			return apierror.ErrInternalError.WithInternal(err)
 		}
 	}

--- a/internal/app/handler/api_internal/user_handler_test.go
+++ b/internal/app/handler/api_internal/user_handler_test.go
@@ -61,11 +61,6 @@ func (m *mockUserService) DeleteUser(ctx context.Context, requester *entity.User
 	return args.Error(0)
 }
 
-func (m *mockUserService) RestoreUser(ctx context.Context, requester *entity.User, username string) error {
-	args := m.Called(ctx, requester, username)
-	return args.Error(0)
-}
-
 func TestUserHandler_GetUserProfileWithRecords(t *testing.T) {
 	e := newTestEcho()
 	mockService := new(mockUserService)
@@ -265,7 +260,6 @@ func TestAdminUserHandler_GetAllUsers(t *testing.T) {
 			OverPowerValue: new(float64(9500)),
 			IsSuspicious:   true,
 			IsPrivate:      false,
-			IsDeleted:      false,
 		},
 		{
 			UserName:       "user2",
@@ -277,7 +271,6 @@ func TestAdminUserHandler_GetAllUsers(t *testing.T) {
 			OverPowerValue: nil,
 			IsSuspicious:   false,
 			IsPrivate:      true,
-			IsDeleted:      false,
 		},
 	}
 
@@ -304,7 +297,6 @@ func TestAdminUserHandler_GetAllUsers(t *testing.T) {
 	assert.Equal(t, 9500.0, body[0]["overpower_value"])
 	assert.Equal(t, true, body[0]["is_suspicious"])
 	assert.Equal(t, false, body[0]["is_private"])
-	assert.Equal(t, false, body[0]["is_deleted"])
 	assert.Equal(t, "user2", body[1]["username"])
 	assert.Equal(t, "PLAYER", body[1]["account_type"])
 	assert.Equal(t, createdAt.Add(time.Hour).Format(time.RFC3339), body[1]["created_at"])
@@ -314,7 +306,6 @@ func TestAdminUserHandler_GetAllUsers(t *testing.T) {
 	assert.Nil(t, body[1]["overpower_value"])
 	assert.Equal(t, false, body[1]["is_suspicious"])
 	assert.Equal(t, true, body[1]["is_private"])
-	assert.Equal(t, false, body[1]["is_deleted"])
 	mockService.AssertExpectations(t)
 }
 
@@ -357,22 +348,6 @@ func TestUserHandler_DeleteUser(t *testing.T) {
 		mockService.AssertExpectations(t)
 	})
 
-	t.Run("異常系: 既に削除済み", func(t *testing.T) {
-		mockService.On("DeleteUser", mock.Anything, adminUser, "deleteduser").Return(usecase.ErrUserAlreadyDeleted).Once()
-
-		req := httptest.NewRequest(http.MethodDelete, "/users/deleteduser", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
-		c.SetParamNames("username")
-		c.SetParamValues("deleteduser")
-		c.Set("userEntity", adminUser)
-
-		err := h.DeleteUser(c)
-
-		assert.Error(t, err)
-		mockService.AssertExpectations(t)
-	})
-
 	t.Run("異常系: ADMIN権限がない", func(t *testing.T) {
 		normalUser := &entity.User{ID: 1, AccountTypeID: 1}
 		mockService.On("DeleteUser", mock.Anything, normalUser, "testuser").Return(usecase.ErrAdminRequired).Once()
@@ -385,79 +360,6 @@ func TestUserHandler_DeleteUser(t *testing.T) {
 		c.Set("userEntity", normalUser)
 
 		err := h.DeleteUser(c)
-
-		assert.ErrorIs(t, err, apierror.ErrForbidden)
-		mockService.AssertExpectations(t)
-	})
-}
-
-func TestUserHandler_RestoreUser(t *testing.T) {
-	e := newTestEcho()
-	mockService := new(mockUserService)
-	h := api_internal.NewUserHandler(mockService)
-	adminUser := &entity.User{ID: 99, AccountTypeID: 3}
-
-	t.Run("正常系: ユーザー復活", func(t *testing.T) {
-		mockService.On("RestoreUser", mock.Anything, adminUser, "deleteduser").Return(nil).Once()
-
-		req := httptest.NewRequest(http.MethodPost, "/users/deleteduser/restore", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
-		c.SetParamNames("username")
-		c.SetParamValues("deleteduser")
-		c.Set("userEntity", adminUser)
-
-		err := h.RestoreUser(c)
-
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusNoContent, rec.Code)
-		mockService.AssertExpectations(t)
-	})
-
-	t.Run("異常系: ユーザーが存在しない", func(t *testing.T) {
-		mockService.On("RestoreUser", mock.Anything, adminUser, "nonexistent").Return(usecase.ErrUserNotFound).Once()
-
-		req := httptest.NewRequest(http.MethodPost, "/users/nonexistent/restore", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
-		c.SetParamNames("username")
-		c.SetParamValues("nonexistent")
-		c.Set("userEntity", adminUser)
-
-		err := h.RestoreUser(c)
-
-		assert.Error(t, err)
-		mockService.AssertExpectations(t)
-	})
-
-	t.Run("異常系: 削除されていない", func(t *testing.T) {
-		mockService.On("RestoreUser", mock.Anything, adminUser, "activeuser").Return(usecase.ErrUserNotDeleted).Once()
-
-		req := httptest.NewRequest(http.MethodPost, "/users/activeuser/restore", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
-		c.SetParamNames("username")
-		c.SetParamValues("activeuser")
-		c.Set("userEntity", adminUser)
-
-		err := h.RestoreUser(c)
-
-		assert.Error(t, err)
-		mockService.AssertExpectations(t)
-	})
-
-	t.Run("異常系: ADMIN権限がない", func(t *testing.T) {
-		normalUser := &entity.User{ID: 1, AccountTypeID: 1}
-		mockService.On("RestoreUser", mock.Anything, normalUser, "deleteduser").Return(usecase.ErrAdminRequired).Once()
-
-		req := httptest.NewRequest(http.MethodPost, "/users/deleteduser/restore", nil)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
-		c.SetParamNames("username")
-		c.SetParamValues("deleteduser")
-		c.Set("userEntity", normalUser)
-
-		err := h.RestoreUser(c)
 
 		assert.ErrorIs(t, err, apierror.ErrForbidden)
 		mockService.AssertExpectations(t)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -95,7 +95,7 @@ type Handlers struct {
 
 // NewRouter はルートが設定された新しいEchoインスタンスを作成します
 // echoLogWriterはnilの場合があります（ログ設定失敗時）
-func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *masterdata.Cache, staticMasterCache *masterdata.StaticCache, firebaseTokenVerifier usecase.TokenVerifier, echoLogWriter io.Writer) *echo.Echo {
+func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *masterdata.Cache, staticMasterCache *masterdata.StaticCache, firebaseTokenVerifier usecase.TokenVerifier, firebaseUserDeleter usecase.FirebaseUserDeleter, echoLogWriter io.Writer) *echo.Echo {
 	e := echo.New()
 	e.Validator = NewCustomValidator()
 
@@ -153,10 +153,10 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	tm := transaction.NewTransactionManager(db)
 	sessionIssuer := usecase.NewSessionIssuer(db, sessionRepo, cfg.JWTSecret, cfg.Auth.JWTExpirationHour, cfg.Auth.SessionExpirationHour)
 	authUsecase := usecase.NewAuthUsecase(db, userRepo, sessionRepo, sessionIssuer, cfg.PwPepper, masterCache)
-	userCredentialUsecase := usecase.NewUserCredentialUsecase(db, tm, userRepo, playerRecordRepo, sessionRepo, apiTokenRepo, recoveryCodeRepo, cfg.PwPepper, masterCache)
+	userCredentialUsecase := usecase.NewUserCredentialUsecaseWithFirebaseDeleter(db, tm, userRepo, playerRecordRepo, sessionRepo, apiTokenRepo, recoveryCodeRepo, firebaseUserDeleter, cfg.PwPepper, masterCache)
 	recoveryUsecase := usecase.NewRecoveryUsecase(db, tm, userRepo, recoveryCodeRepo, cfg.PwPepper)
 	apiTokenUsecase := usecase.NewAPITokenService(db, apiTokenRepo, userRepo)
-	userUsecase := usecase.NewUserService(db, userRepo, playerRepo, playerRecordRepo, worldsendRecordRepo, songRepo, worldsendChartRepo, masterCache)
+	userUsecase := usecase.NewUserServiceWithFirebaseDeleter(db, userRepo, playerRepo, playerRecordRepo, worldsendRecordRepo, songRepo, worldsendChartRepo, masterCache, firebaseUserDeleter)
 	playerDataUsecase := usecase.NewPlayerDataService(tm, userRepo, playerRepo, playerRecordRepo, worldsendRecordRepo, honorRepo, playerDataRepo, masterCache)
 	songUsecase := usecase.NewSongService(songRepo, masterCache, tm, db)
 	chartStatsMasterProvider := masterdata.NewChartStatsMasterProviderAdapter(staticMasterCache)
@@ -297,7 +297,6 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.A
 	{
 		usersGroup.GET("/", handlers.AdminUser.GetAllUsers, requireAdmin)
 		usersGroup.DELETE("/:username", handlers.User.DeleteUser, requireAdmin)
-		usersGroup.POST("/:username/restore", handlers.User.RestoreUser, requireAdmin)
 	}
 
 	// api.chunisupport.net/internal/songs

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -27,7 +27,7 @@ type Server struct {
 }
 
 // NewServer は新しいServerインスタンスを作成します
-func NewServer(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *masterdata.Cache, staticMasterCache *masterdata.StaticCache, firebaseTokenVerifier usecase.TokenVerifier) *Server {
+func NewServer(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *masterdata.Cache, staticMasterCache *masterdata.StaticCache, firebaseTokenVerifier usecase.TokenVerifier, firebaseUserDeleter usecase.FirebaseUserDeleter) *Server {
 	// Echoのロガーを設定
 	var echoLogWriter io.WriteCloser
 	echoLogWriterResult, err := SetupEchoLogger(cfg)
@@ -38,7 +38,7 @@ func NewServer(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	}
 
 	return &Server{
-		echo:              NewRouter(db, staticDB, cfg, masterCache, staticMasterCache, firebaseTokenVerifier, echoLogWriter),
+		echo:              NewRouter(db, staticDB, cfg, masterCache, staticMasterCache, firebaseTokenVerifier, firebaseUserDeleter, echoLogWriter),
 		db:                db,
 		staticDB:          staticDB,
 		cfg:               cfg,

--- a/internal/domain/repository/user_repository.go
+++ b/internal/domain/repository/user_repository.go
@@ -25,6 +25,8 @@ type UserRepository interface {
 	FindByFirebaseUID(ctx context.Context, exec Executor, uid string) (*entity.User, error)
 	// LinkFirebaseUID は現在値が一致する場合のみ Firebase UID を更新します。
 	LinkFirebaseUID(ctx context.Context, exec Executor, userID int, currentUID *string, newUID string, updatedAt time.Time) error
+	// DeleteByID はユーザーを物理削除します。
+	DeleteByID(ctx context.Context, exec Executor, id int) error
 	// Save はユーザーを集約単位で保存します。IDが存在する場合は更新、存在しない場合は作成します。
 	Save(ctx context.Context, exec Executor, user *entity.User) error
 }

--- a/internal/dto/api_internal/user_list_dto.go
+++ b/internal/dto/api_internal/user_list_dto.go
@@ -3,7 +3,7 @@ package api_internal
 import "time"
 
 // AdminUserListResponse はADMIN用のユーザー一覧APIのレスポンスです。
-// プライベートなユーザーや削除済みユーザーも含まれます。
+// プライベートなユーザーも含まれます。
 type AdminUserListResponse struct {
 	UserName       string    `json:"username"`
 	AccountType    string    `json:"account_type"`
@@ -14,5 +14,4 @@ type AdminUserListResponse struct {
 	OverPowerValue *float64  `json:"overpower_value"`
 	IsSuspicious   bool      `json:"is_suspicious"`
 	IsPrivate      bool      `json:"is_private"`
-	IsDeleted      bool      `json:"is_deleted"`
 }

--- a/internal/infra/firebaseauth/token_verifier_factory.go
+++ b/internal/infra/firebaseauth/token_verifier_factory.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	firebase "firebase.google.com/go/v4"
+	firebaseauthsdk "firebase.google.com/go/v4/auth"
 	"google.golang.org/api/option"
 
 	"github.com/chunisupport/chunisupport-api/internal/usecase"
@@ -24,4 +25,28 @@ func NewTokenVerifierFromCredentialsFile(ctx context.Context, credentialsFile st
 	}
 
 	return NewTokenVerifierFromApp(ctx, app)
+}
+
+// NewAuthClientFromCredentialsFile はサービスアカウントJSONから auth.Client を生成します。
+func NewAuthClientFromCredentialsFile(ctx context.Context, credentialsFile string) (*firebaseauthsdk.Client, error) {
+	credentialsFile = strings.TrimSpace(credentialsFile)
+	if credentialsFile == "" {
+		return nil, fmt.Errorf("firebase credentials file is empty")
+	}
+
+	app, err := firebase.NewApp(ctx, nil, option.WithCredentialsFile(credentialsFile))
+	if err != nil {
+		return nil, err
+	}
+
+	return app.Auth(ctx)
+}
+
+// NewFirebaseUserDeleterFromCredentialsFile はサービスアカウントJSONから FirebaseUserDeleter を生成します。
+func NewFirebaseUserDeleterFromCredentialsFile(ctx context.Context, credentialsFile string) (usecase.FirebaseUserDeleter, error) {
+	client, err := NewAuthClientFromCredentialsFile(ctx, credentialsFile)
+	if err != nil {
+		return nil, err
+	}
+	return NewFirebaseUserDeleter(client), nil
 }

--- a/internal/infra/firebaseauth/user_deleter.go
+++ b/internal/infra/firebaseauth/user_deleter.go
@@ -1,0 +1,32 @@
+package firebaseauth
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	firebaseauthsdk "firebase.google.com/go/v4/auth"
+
+	"github.com/chunisupport/chunisupport-api/internal/usecase"
+)
+
+type firebaseUserDeleter struct {
+	client *firebaseauthsdk.Client
+}
+
+// NewFirebaseUserDeleter は Firebase Admin SDK の auth.Client を使う FirebaseUserDeleter を生成します。
+func NewFirebaseUserDeleter(client *firebaseauthsdk.Client) usecase.FirebaseUserDeleter {
+	return &firebaseUserDeleter{client: client}
+}
+
+func (d *firebaseUserDeleter) DeleteUser(ctx context.Context, uid string) error {
+	if d.client == nil {
+		return errors.New("firebase auth client is nil")
+	}
+	trimmedUID := strings.TrimSpace(uid)
+	if trimmedUID == "" {
+		return errors.New("firebase uid is empty")
+	}
+
+	return d.client.DeleteUser(ctx, trimmedUID)
+}

--- a/internal/infra/models/user_model.go
+++ b/internal/infra/models/user_model.go
@@ -21,7 +21,6 @@ type UserModel struct {
 	PlayerID      *int      `db:"player_id"`
 	AccountTypeID int       `db:"account_type_id"`
 	IsSuspicious  bool      `db:"is_suspicious"`
-	IsDeleted     bool      `db:"is_deleted"`
 	IsPrivate     bool      `db:"is_private"`
 }
 
@@ -55,7 +54,6 @@ func (m *UserModel) ToEntity() (*entity.User, error) {
 		PlayerID:      m.PlayerID,
 		AccountTypeID: m.AccountTypeID,
 		IsSuspicious:  m.IsSuspicious,
-		IsDeleted:     m.IsDeleted,
 		IsPrivate:     m.IsPrivate,
 	}, nil
 }
@@ -72,7 +70,6 @@ func FromUserEntity(e *entity.User) *UserModel {
 		PlayerID:      e.PlayerID,
 		AccountTypeID: e.AccountTypeID,
 		IsSuspicious:  e.IsSuspicious,
-		IsDeleted:     e.IsDeleted,
 		IsPrivate:     e.IsPrivate,
 	}
 }

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -29,7 +29,7 @@ func NewUserRepository(db *sqlx.DB) repository.UserRepository {
 // FindByID はIDでユーザーを検索します。
 func (r *userRepository) FindByID(ctx context.Context, exec repository.Executor, id int) (*entity.User, error) {
 	var userModel models.UserModel
-	query := `SELECT id, username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_deleted, is_private FROM users WHERE id = ?`
+	query := `SELECT id, username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_private FROM users WHERE id = ?`
 	err := exec.GetContext(ctx, &userModel, query, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -43,7 +43,7 @@ func (r *userRepository) FindByID(ctx context.Context, exec repository.Executor,
 // FindByIDForUpdate はIDでユーザーを検索し、更新用に行ロックします。
 func (r *userRepository) FindByIDForUpdate(ctx context.Context, exec repository.Executor, id int) (*entity.User, error) {
 	var userModel models.UserModel
-	query := `SELECT id, username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_deleted, is_private FROM users WHERE id = ? FOR UPDATE`
+	query := `SELECT id, username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_private FROM users WHERE id = ? FOR UPDATE`
 	err := exec.GetContext(ctx, &userModel, query, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -57,7 +57,7 @@ func (r *userRepository) FindByIDForUpdate(ctx context.Context, exec repository.
 // FindByUsername はユーザー名でユーザーを検索します。
 func (r *userRepository) FindByUsername(ctx context.Context, exec repository.Executor, username string) (*entity.User, error) {
 	var userModel models.UserModel
-	query := `SELECT id, username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_deleted, is_private FROM users WHERE username = ?`
+	query := `SELECT id, username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_private FROM users WHERE username = ?`
 	err := exec.GetContext(ctx, &userModel, query, username)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -71,7 +71,7 @@ func (r *userRepository) FindByUsername(ctx context.Context, exec repository.Exe
 // FindByFirebaseUID はFirebase UIDでユーザーを検索します。
 func (r *userRepository) FindByFirebaseUID(ctx context.Context, exec repository.Executor, uid string) (*entity.User, error) {
 	var userModel models.UserModel
-	query := `SELECT id, username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_deleted, is_private FROM users WHERE firebase_uid = ?`
+	query := `SELECT id, username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_private FROM users WHERE firebase_uid = ?`
 	err := exec.GetContext(ctx, &userModel, query, uid)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -111,8 +111,7 @@ func (r *userRepository) FindAllWithPlayer(ctx context.Context, exec repository.
 			p.overpower_value AS player_overpower_value
 		FROM users u
 		LEFT JOIN players p ON u.player_id = p.id
-		WHERE u.is_deleted = FALSE
-		AND u.is_private = FALSE
+		WHERE u.is_private = FALSE
 		AND u.player_id IS NOT NULL
 	`
 	args := []any{}
@@ -194,7 +193,6 @@ func (r *userRepository) FindAllWithPlayerForAdmin(ctx context.Context, exec rep
 			u.updated_at AS user_updated_at,
 			u.is_suspicious AS user_is_suspicious,
 			u.is_private AS user_is_private,
-			u.is_deleted AS user_is_deleted,
 			p.id AS player_id,
 			p.player_name,
 			p.official_player_rating AS player_official_rating,
@@ -233,7 +231,6 @@ func (r *userRepository) FindAllWithPlayerForAdmin(ctx context.Context, exec rep
 			UserUpdatedAt     time.Time `db:"user_updated_at"`
 			UserIsSuspicious  *bool     `db:"user_is_suspicious"`
 			UserIsPrivate     *bool     `db:"user_is_private"`
-			UserIsDeleted     *bool     `db:"user_is_deleted"`
 		}
 		if err := rows.StructScan(&row); err != nil {
 			return nil, fmt.Errorf("scan error: %w", err)
@@ -255,7 +252,6 @@ func (r *userRepository) FindAllWithPlayerForAdmin(ctx context.Context, exec rep
 				PlayerID:      row.UserPlayerID,
 				IsSuspicious:  row.UserIsSuspicious != nil && *row.UserIsSuspicious,
 				IsPrivate:     row.UserIsPrivate != nil && *row.UserIsPrivate,
-				IsDeleted:     row.UserIsDeleted != nil && *row.UserIsDeleted,
 			},
 		}
 
@@ -289,8 +285,8 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 
 	if user.ID == 0 {
 		// 新規作成
-		query := `INSERT INTO users (username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_deleted, is_private) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-		result, err := exec.ExecContext(ctx, query, userModel.Username, userModel.FirebaseUID, userModel.PasswordHash, userModel.CreatedAt, userModel.UpdatedAt, userModel.PlayerID, userModel.AccountTypeID, userModel.IsSuspicious, userModel.IsDeleted, userModel.IsPrivate)
+		query := `INSERT INTO users (username, firebase_uid, password_hash, created_at, updated_at, player_id, account_type_id, is_suspicious, is_private) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		result, err := exec.ExecContext(ctx, query, userModel.Username, userModel.FirebaseUID, userModel.PasswordHash, userModel.CreatedAt, userModel.UpdatedAt, userModel.PlayerID, userModel.AccountTypeID, userModel.IsSuspicious, userModel.IsPrivate)
 		if err != nil {
 			err = wrapFirebaseUIDDuplicateError(err)
 			err = wrapUsernameDuplicateError(err)
@@ -306,8 +302,8 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 
 	// 更新。部分取得エンティティで取りこぼし得る不変項目は更新前提としてのみ扱います。
 	whereClause, whereArgs := userFirebaseUIDWhereClause(userModel.FirebaseUID)
-	query := fmt.Sprintf("UPDATE users SET password_hash = ?, player_id = ?, is_suspicious = ?, is_deleted = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND %s", whereClause)
-	args := []any{userModel.PasswordHash, userModel.PlayerID, userModel.IsSuspicious, userModel.IsDeleted, userModel.IsPrivate, userModel.UpdatedAt, userModel.ID, userModel.Username, userModel.AccountTypeID}
+	query := fmt.Sprintf("UPDATE users SET password_hash = ?, player_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND %s", whereClause)
+	args := []any{userModel.PasswordHash, userModel.PlayerID, userModel.IsSuspicious, userModel.IsPrivate, userModel.UpdatedAt, userModel.ID, userModel.Username, userModel.AccountTypeID}
 	args = append(args, whereArgs...)
 
 	result, err := exec.ExecContext(ctx, query, args...)
@@ -316,6 +312,24 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 	}
 
 	return r.validateSingleUserUpdate(ctx, exec, userModel.ID, result)
+}
+
+// DeleteByID はユーザーを物理削除します。
+func (r *userRepository) DeleteByID(ctx context.Context, exec repository.Executor, id int) error {
+	result, err := exec.ExecContext(ctx, `DELETE FROM users WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return repository.ErrUserNotFound
+	}
+
+	return nil
 }
 
 func userFirebaseUIDWhereClause(firebaseUID *string) (string, []any) {

--- a/internal/infra/repository/user_repository_save_test.go
+++ b/internal/infra/repository/user_repository_save_test.go
@@ -22,8 +22,8 @@ func TestUserRepositorySaveProtectsFirebaseUIDFromPartialEntity(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := db.Exec(`
-		INSERT INTO users (id, username, firebase_uid, password_hash, account_type_id, is_deleted, is_private, is_suspicious)
-		VALUES (1, 'user01', 'linked-uid', 'hash-1', 1, 0, 0, 0)
+		INSERT INTO users (id, username, firebase_uid, password_hash, account_type_id, is_private, is_suspicious)
+		VALUES (1, 'user01', 'linked-uid', 'hash-1', 1, 0, 0)
 	`)
 	require.NoError(t, err)
 
@@ -58,8 +58,8 @@ func TestUserRepositorySaveUpdatesMutableFieldsWhenFirebaseUIDMatches(t *testing
 	existingUID := "linked-uid"
 
 	_, err := db.Exec(`
-		INSERT INTO users (id, username, firebase_uid, password_hash, account_type_id, is_deleted, is_private, is_suspicious)
-		VALUES (1, 'user01', 'linked-uid', 'hash-1', 1, 0, 0, 0)
+		INSERT INTO users (id, username, firebase_uid, password_hash, account_type_id, is_private, is_suspicious)
+		VALUES (1, 'user01', 'linked-uid', 'hash-1', 1, 0, 0)
 	`)
 	require.NoError(t, err)
 
@@ -99,8 +99,8 @@ func TestUserRepositorySaveProtectsAccountTypeIDFromPartialEntity(t *testing.T) 
 	ctx := context.Background()
 
 	_, err := db.Exec(`
-		INSERT INTO users (id, username, firebase_uid, password_hash, account_type_id, is_deleted, is_private, is_suspicious)
-		VALUES (1, 'user01', NULL, 'hash-1', 1, 0, 0, 0)
+		INSERT INTO users (id, username, firebase_uid, password_hash, account_type_id, is_private, is_suspicious)
+		VALUES (1, 'user01', NULL, 'hash-1', 1, 0, 0)
 	`)
 	require.NoError(t, err)
 
@@ -224,8 +224,8 @@ func TestUserRepositoryLinkFirebaseUID(t *testing.T) {
 
 			if tt.wantErr != domainrepo.ErrUserNotFound {
 				_, err := db.Exec(`
-					INSERT INTO users (id, username, firebase_uid, password_hash, account_type_id, is_deleted, is_private, is_suspicious)
-					VALUES (?, 'user01', ?, 'hash-1', 1, 0, 0, 0)
+					INSERT INTO users (id, username, firebase_uid, password_hash, account_type_id, is_private, is_suspicious)
+					VALUES (?, 'user01', ?, 'hash-1', 1, 0, 0)
 				`, 1, tt.initialUID)
 				require.NoError(t, err)
 			}
@@ -278,7 +278,6 @@ func setupUserRepositoryTestDB(t *testing.T) *sqlx.DB {
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			account_type_id INTEGER NOT NULL DEFAULT 1,
 			player_id INTEGER,
-			is_deleted INTEGER NOT NULL DEFAULT 0,
 			is_private INTEGER NOT NULL DEFAULT 0,
 			is_suspicious INTEGER NOT NULL DEFAULT 0
 		);

--- a/internal/usecase/api_token_usecase_impl_test.go
+++ b/internal/usecase/api_token_usecase_impl_test.go
@@ -94,6 +94,10 @@ func (s *tokenStubUserRepository) FindByFirebaseUID(_ context.Context, _ reposit
 	return nil, errors.New("not implemented")
 }
 
+func (s *tokenStubUserRepository) DeleteByID(_ context.Context, _ repository.Executor, _ int) error {
+	return errors.New("not implemented")
+}
+
 func TestAPITokenService_Generate(t *testing.T) {
 	tokenRepo := &stubAPITokenRepository{}
 	userRepo := &tokenStubUserRepository{}

--- a/internal/usecase/auth_usecase_test_helper_test.go
+++ b/internal/usecase/auth_usecase_test_helper_test.go
@@ -95,6 +95,11 @@ func (m *MockUserRepository) FindByFirebaseUID(ctx context.Context, exec reposit
 	return nil, args.Error(1)
 }
 
+func (m *MockUserRepository) DeleteByID(ctx context.Context, exec repository.Executor, id int) error {
+	args := m.Called(ctx, exec, id)
+	return args.Error(0)
+}
+
 // MockSessionRepository はSessionRepositoryのモックです。
 type MockSessionRepository struct {
 	mock.Mock

--- a/internal/usecase/firebase_user_deleter.go
+++ b/internal/usecase/firebase_user_deleter.go
@@ -1,0 +1,14 @@
+package usecase
+
+import "context"
+
+// FirebaseUserDeleter は Firebase ユーザーの物理削除を抽象化します。
+type FirebaseUserDeleter interface {
+	DeleteUser(ctx context.Context, uid string) error
+}
+
+type noopFirebaseUserDeleter struct{}
+
+func (noopFirebaseUserDeleter) DeleteUser(_ context.Context, _ string) error {
+	return nil
+}

--- a/internal/usecase/user_credential_errors.go
+++ b/internal/usecase/user_credential_errors.go
@@ -11,5 +11,4 @@ var (
 	ErrOperationFailed    = errors.New("operation failed")
 	ErrInternalError      = errors.New("internal error")
 	ErrUserAlreadyDeleted = errors.New("user already deleted")
-	ErrUserNotDeleted     = errors.New("user not deleted")
 )

--- a/internal/usecase/user_credential_usecase.go
+++ b/internal/usecase/user_credential_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
@@ -28,6 +29,7 @@ type userCredentialUsecaseImpl struct {
 	sessionRepo      repository.SessionRepository
 	apiTokenRepo     repository.APITokenRepository
 	recoveryCodeRepo repository.RecoveryCodeRepository
+	firebaseDeleter  FirebaseUserDeleter
 	pepper           string
 	masterCache      AccountTypeProvider
 }
@@ -76,9 +78,34 @@ func NewUserCredentialUsecase(
 		sessionRepo:      sessionRepo,
 		apiTokenRepo:     apiTokenRepo,
 		recoveryCodeRepo: recoveryCodeRepo,
+		firebaseDeleter:  noopFirebaseUserDeleter{},
 		pepper:           pepper,
 		masterCache:      masterCache,
 	}
+}
+
+// NewUserCredentialUsecaseWithFirebaseDeleter は Firebase 削除連携付きの UserCredentialUsecase を生成します。
+func NewUserCredentialUsecaseWithFirebaseDeleter(
+	db repository.Executor,
+	tm TransactionManager,
+	userRepo repository.UserRepository,
+	playerRecordRepo repository.PlayerRecordRepository,
+	sessionRepo repository.SessionRepository,
+	apiTokenRepo repository.APITokenRepository,
+	recoveryCodeRepo repository.RecoveryCodeRepository,
+	firebaseDeleter FirebaseUserDeleter,
+	pepper string,
+	masterCache AccountTypeProvider,
+) UserCredentialUsecase {
+	usecase := NewUserCredentialUsecase(db, tm, userRepo, playerRecordRepo, sessionRepo, apiTokenRepo, recoveryCodeRepo, pepper, masterCache)
+	impl, ok := usecase.(*userCredentialUsecaseImpl)
+	if !ok {
+		return usecase
+	}
+	if firebaseDeleter != nil {
+		impl.firebaseDeleter = firebaseDeleter
+	}
+	return impl
 }
 
 func (s *userCredentialUsecaseImpl) GetUser(ctx context.Context, id int) (*api_internal.UserDTO, error) {
@@ -142,7 +169,11 @@ func (s *userCredentialUsecaseImpl) ChangePassword(ctx context.Context, userID i
 }
 
 func (s *userCredentialUsecaseImpl) DeleteOwnAccount(ctx context.Context, userID int) error {
-	return s.tm.Transactional(ctx, func(tx repository.Executor) error {
+	var deletedUserID int
+	var deletedUsername string
+	var deletedFirebaseUID string
+
+	if err := s.tm.Transactional(ctx, func(tx repository.Executor) error {
 		user, err := s.userRepo.FindByIDForUpdate(ctx, tx, userID)
 		if err != nil {
 			if errors.Is(err, repository.ErrUserNotFound) {
@@ -150,21 +181,22 @@ func (s *userCredentialUsecaseImpl) DeleteOwnAccount(ctx context.Context, userID
 			}
 			return err
 		}
-		if !user.IsActive() {
-			return ErrUserAlreadyDeleted
+		deletedUserID = user.ID
+		deletedUsername = user.Username.String()
+		if user.FirebaseUID != nil {
+			deletedFirebaseUID = *user.FirebaseUID
 		}
 
-		user.Delete()
-		if err := s.userRepo.Save(ctx, tx, user); err != nil {
-			return err
-		}
-		if err := s.sessionRepo.DeleteByUserID(ctx, tx, userID); err != nil {
-			return err
-		}
-		if err := s.apiTokenRepo.DeleteByUserID(ctx, tx, userID); err != nil {
-			return err
-		}
+		return s.userRepo.DeleteByID(ctx, tx, userID)
+	}); err != nil {
+		return err
+	}
 
-		return s.recoveryCodeRepo.DeleteByUserID(ctx, tx, userID)
-	})
+	if deletedFirebaseUID != "" {
+		if err := s.firebaseDeleter.DeleteUser(ctx, deletedFirebaseUID); err != nil {
+			slog.Error("failed to delete firebase user after account deletion", "user_id", deletedUserID, "username", deletedUsername, "firebase_uid", deletedFirebaseUID, "error", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/usecase/user_security_usecase_test.go
+++ b/internal/usecase/user_security_usecase_test.go
@@ -186,61 +186,34 @@ func TestUserSecurityUsecase_DeleteUser(t *testing.T) {
 
 	t.Run("アカウント削除に成功する", func(t *testing.T) {
 		mockUserRepo := new(MockUserRepository)
-		mockSessionRepo := new(MockSessionRepository)
-		mockAPITokenRepo := &stubAPITokenRepository{}
-		mockRecoveryRepo := new(MockRecoveryCodeRepository)
 		tm := &mockTransactionManager{}
 		userCredentialUsecase := newTestUserCredentialUsecaseWithDeleteDependencies(
-			tm, mockUserRepo, nil, mockSessionRepo, mockAPITokenRepo, mockRecoveryRepo, "test-pepper",
+			tm, mockUserRepo, nil, new(MockSessionRepository), &stubAPITokenRepository{}, new(MockRecoveryCodeRepository), "test-pepper",
 		)
 
 		user := &entity.User{ID: 1, Username: un}
 		mockUserRepo.On("FindByIDForUpdate", mock.Anything, mock.Anything, 1).Return(user, nil).Once()
-		mockUserRepo.On("Save", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-		mockSessionRepo.On("DeleteByUserID", mock.Anything, mock.Anything, 1).Return(nil).Once()
-		mockRecoveryRepo.On("DeleteByUserID", mock.Anything, mock.Anything, 1).Return(nil).Once()
+		mockUserRepo.On("DeleteByID", mock.Anything, mock.Anything, 1).Return(nil).Once()
 
 		err := userCredentialUsecase.DeleteOwnAccount(context.Background(), 1)
 		assert.NoError(t, err)
 		mockUserRepo.AssertExpectations(t)
-		mockSessionRepo.AssertExpectations(t)
-		mockRecoveryRepo.AssertExpectations(t)
-		assert.Equal(t, 1, mockAPITokenRepo.deletedUserID)
 	})
 
-	t.Run("保存時にDBエラーが発生した場合はエラーを返す", func(t *testing.T) {
+	t.Run("物理削除時にDBエラーが発生した場合はエラーを返す", func(t *testing.T) {
 		mockUserRepo := new(MockUserRepository)
-		mockSessionRepo := new(MockSessionRepository)
-		mockRecoveryRepo := new(MockRecoveryCodeRepository)
 		tm := &mockTransactionManager{}
 		userCredentialUsecase := newTestUserCredentialUsecaseWithDeleteDependencies(
-			tm, mockUserRepo, nil, mockSessionRepo, &stubAPITokenRepository{}, mockRecoveryRepo, "test-pepper",
+			tm, mockUserRepo, nil, new(MockSessionRepository), &stubAPITokenRepository{}, new(MockRecoveryCodeRepository), "test-pepper",
 		)
 
 		user := &entity.User{ID: 2, Username: un}
 		mockUserRepo.On("FindByIDForUpdate", mock.Anything, mock.Anything, 2).Return(user, nil).Once()
-		mockUserRepo.On("Save", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("db error")).Once()
+		mockUserRepo.On("DeleteByID", mock.Anything, mock.Anything, 2).Return(errors.New("db error")).Once()
 
 		err := userCredentialUsecase.DeleteOwnAccount(context.Background(), 2)
 		assert.Error(t, err)
 		assert.Equal(t, "db error", err.Error())
-		mockUserRepo.AssertExpectations(t)
-	})
-
-	t.Run("既に削除済みのユーザーはErrUserAlreadyDeletedを返す", func(t *testing.T) {
-		mockUserRepo := new(MockUserRepository)
-		mockSessionRepo := new(MockSessionRepository)
-		mockRecoveryRepo := new(MockRecoveryCodeRepository)
-		tm := &mockTransactionManager{}
-		userCredentialUsecase := newTestUserCredentialUsecaseWithDeleteDependencies(
-			tm, mockUserRepo, nil, mockSessionRepo, &stubAPITokenRepository{}, mockRecoveryRepo, "test-pepper",
-		)
-
-		deletedUser := &entity.User{ID: 3, Username: un, IsDeleted: true}
-		mockUserRepo.On("FindByIDForUpdate", mock.Anything, mock.Anything, 3).Return(deletedUser, nil).Once()
-
-		err := userCredentialUsecase.DeleteOwnAccount(context.Background(), 3)
-		assert.ErrorIs(t, err, ErrUserAlreadyDeleted)
 		mockUserRepo.AssertExpectations(t)
 	})
 }

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -32,9 +32,6 @@ type UserUsecase interface {
 	// GetAllUsersForAdmin はADMIN用にすべてのユーザー一覧を取得します。
 	GetAllUsersForAdmin(ctx context.Context, page int, limit int, name string) ([]api_internal.AdminUserListResponse, error)
 
-	// DeleteUser はユーザーを論理削除します。
+	// DeleteUser はユーザーを物理削除します。
 	DeleteUser(ctx context.Context, requester *entity.User, username string) error
-
-	// RestoreUser はユーザーを復元します。
-	RestoreUser(ctx context.Context, requester *entity.User, username string) error
 }

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -25,6 +25,7 @@ type userUsecase struct {
 	worldsendChartRepo  repository.WorldsendChartRepository
 	recordCompletionSvc *service.RecordCompletionService
 	masterProvider      userMasterProvider
+	firebaseDeleter     FirebaseUserDeleter
 }
 
 type userMasterProvider interface {
@@ -50,7 +51,21 @@ func NewUserService(db repository.Executor, userRepo repository.UserRepository, 
 		worldsendChartRepo:  worldsendChartRepo,
 		recordCompletionSvc: service.NewRecordCompletionService(),
 		masterProvider:      masterProvider,
+		firebaseDeleter:     noopFirebaseUserDeleter{},
 	}
+}
+
+// NewUserServiceWithFirebaseDeleter は Firebase 削除連携付きの UserUsecase を生成します。
+func NewUserServiceWithFirebaseDeleter(db repository.Executor, userRepo repository.UserRepository, playerRepo repository.PlayerRepository, playerRecordRepo repository.PlayerRecordRepository, worldsendRecordRepo repository.WorldsendRecordRepository, songRepo repository.SongRepository, worldsendChartRepo repository.WorldsendChartRepository, masterProvider userMasterProvider, firebaseDeleter FirebaseUserDeleter) UserUsecase {
+	usecase := NewUserService(db, userRepo, playerRepo, playerRecordRepo, worldsendRecordRepo, songRepo, worldsendChartRepo, masterProvider)
+	impl, ok := usecase.(*userUsecase)
+	if !ok {
+		return usecase
+	}
+	if firebaseDeleter != nil {
+		impl.firebaseDeleter = firebaseDeleter
+	}
+	return impl
 }
 
 // GetUserProfileWithRecords はユーザー名をキーにプロファイルとレコードを一括取得します。
@@ -189,7 +204,6 @@ func (s *userUsecase) GetAllUsersForAdmin(ctx context.Context, page int, limit i
 			UpdatedAt:    u.User.UpdatedAt,
 			IsSuspicious: u.User.IsSuspicious,
 			IsPrivate:    u.User.IsPrivate,
-			IsDeleted:    u.User.IsDeleted,
 		}
 		if u.Player != nil {
 			playerName := u.Player.Name.String()
@@ -203,7 +217,7 @@ func (s *userUsecase) GetAllUsersForAdmin(ctx context.Context, page int, limit i
 	return responses, nil
 }
 
-// DeleteUser はユーザーを論理削除します。
+// DeleteUser はユーザーを物理削除します。
 // 防御的深度: ハンドラ層のミドルウェアに加え、ユースケース層でもADMIN権限を検証します。
 func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, username string) error {
 	// 認可チェック: ADMIN権限が必要
@@ -221,53 +235,26 @@ func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, us
 		return err
 	}
 
-	// 2. 既に削除済みかチェック
-	if user.IsDeleted {
-		return ErrUserAlreadyDeleted
+	firebaseUID := ""
+	if user.FirebaseUID != nil {
+		firebaseUID = *user.FirebaseUID
 	}
 
-	// 3. 論理削除を実行
-	user.Delete()
-	if err := s.userRepo.Save(ctx, s.db, user); err != nil {
-		slog.Error("failed to delete user", "user_id", user.ID, "error", err)
-		return err
-	}
-
-	slog.Info("user deleted successfully", "username", username, "user_id", user.ID)
-	return nil
-}
-
-// RestoreUser はユーザーを復活させます。
-// 防御的深度: ハンドラ層のミドルウェアに加え、ユースケース層でもADMIN権限を検証します。
-func (s *userUsecase) RestoreUser(ctx context.Context, requester *entity.User, username string) error {
-	// 認可チェック: ADMIN権限が必要
-	if requester == nil || !info.HasRole(requester.AccountTypeID, info.AccountTypeAdmin) {
-		return ErrAdminRequired
-	}
-
-	// 1. ユーザーを取得
-	user, err := s.userRepo.FindByUsername(ctx, s.db, username)
-	if err != nil {
+	if err := s.userRepo.DeleteByID(ctx, s.db, user.ID); err != nil {
 		if errors.Is(err, repository.ErrUserNotFound) {
 			return ErrUserNotFound
 		}
-		slog.Error("failed to find user by username", "username", username, "error", err)
+		slog.Error("failed to delete user from database", "user_id", user.ID, "username", username, "error", err)
 		return err
 	}
 
-	// 2. 削除されていない場合はエラー
-	if !user.IsDeleted {
-		return ErrUserNotDeleted
+	if firebaseUID != "" {
+		if err := s.firebaseDeleter.DeleteUser(ctx, firebaseUID); err != nil {
+			slog.Error("failed to delete firebase user after account deletion", "user_id", user.ID, "username", username, "firebase_uid", firebaseUID, "error", err)
+		}
 	}
 
-	// 3. 復活を実行
-	user.Restore()
-	if err := s.userRepo.Save(ctx, s.db, user); err != nil {
-		slog.Error("failed to restore user", "user_id", user.ID, "error", err)
-		return err
-	}
-
-	slog.Info("user restored successfully", "username", username, "user_id", user.ID)
+	slog.Info("user deleted successfully", "username", username, "user_id", user.ID)
 	return nil
 }
 

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -220,9 +220,8 @@ func (s *userUsecase) GetAllUsersForAdmin(ctx context.Context, page int, limit i
 // DeleteUser はユーザーを物理削除します。
 // 防御的深度: ハンドラ層のミドルウェアに加え、ユースケース層でもADMIN権限を検証します。
 func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, username string) error {
-	// 認可チェック: ADMIN権限が必要
-	if requester == nil || !info.HasRole(requester.AccountTypeID, info.AccountTypeAdmin) {
-		return ErrAdminRequired
+	if err := s.ensureDeleteUserPermission(requester); err != nil {
+		return err
 	}
 
 	// 1. ユーザーを取得
@@ -240,11 +239,7 @@ func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, us
 		firebaseUID = *user.FirebaseUID
 	}
 
-	if err := s.userRepo.DeleteByID(ctx, s.db, user.ID); err != nil {
-		if errors.Is(err, repository.ErrUserNotFound) {
-			return ErrUserNotFound
-		}
-		slog.Error("failed to delete user from database", "user_id", user.ID, "username", username, "error", err)
+	if err := s.performPhysicalUserDeletion(ctx, user.ID, username); err != nil {
 		return err
 	}
 
@@ -255,6 +250,24 @@ func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, us
 	}
 
 	slog.Info("user deleted successfully", "username", username, "user_id", user.ID)
+	return nil
+}
+
+func (s *userUsecase) ensureDeleteUserPermission(requester *entity.User) error {
+	if requester == nil || !info.HasRole(requester.AccountTypeID, info.AccountTypeAdmin) {
+		return ErrAdminRequired
+	}
+	return nil
+}
+
+func (s *userUsecase) performPhysicalUserDeletion(ctx context.Context, userID int, username string) error {
+	if err := s.userRepo.DeleteByID(ctx, s.db, userID); err != nil {
+		if errors.Is(err, repository.ErrUserNotFound) {
+			return ErrUserNotFound
+		}
+		slog.Error("failed to delete user from database", "user_id", userID, "username", username, "error", err)
+		return err
+	}
 	return nil
 }
 

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -27,6 +27,7 @@ type stubUserRepository struct {
 	err             error
 	saveErr         error
 	savedUser       *entity.User
+	deletedUserID   int
 }
 
 func (s *stubUserRepository) FindByID(ctx context.Context, exec repository.Executor, id int) (*entity.User, error) {
@@ -72,6 +73,14 @@ func (s *stubUserRepository) LinkFirebaseUID(ctx context.Context, exec repositor
 
 func (s *stubUserRepository) FindByFirebaseUID(_ context.Context, _ repository.Executor, _ string) (*entity.User, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (s *stubUserRepository) DeleteByID(ctx context.Context, exec repository.Executor, id int) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.deletedUserID = id
+	return nil
 }
 
 type stubPlayerRecordRepository struct {
@@ -748,9 +757,8 @@ func intPointer(v int) *int {
 func TestUserService_DeleteUser_Success(t *testing.T) {
 	un, _ := username.NewUserName("testuser")
 	user := &entity.User{
-		ID:        1,
-		Username:  un,
-		IsDeleted: false,
+		ID:       1,
+		Username: un,
 	}
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{user: user}
@@ -758,10 +766,7 @@ func TestUserService_DeleteUser_Success(t *testing.T) {
 
 	err := service.DeleteUser(context.Background(), adminRequester, "testuser")
 	require.NoError(t, err)
-
-	// Saveに渡されたエンティティの状態を検証
-	require.NotNil(t, repo.savedUser, "expected user to be saved")
-	assert.True(t, repo.savedUser.IsDeleted, "expected user to be marked as deleted")
+	assert.Equal(t, 1, repo.deletedUserID)
 }
 
 func TestUserService_DeleteUser_UserNotFound(t *testing.T) {
@@ -771,21 +776,6 @@ func TestUserService_DeleteUser_UserNotFound(t *testing.T) {
 
 	err := service.DeleteUser(context.Background(), adminRequester, "missing")
 	require.ErrorIs(t, err, ErrUserNotFound)
-}
-
-func TestUserService_DeleteUser_AlreadyDeleted(t *testing.T) {
-	un, _ := username.NewUserName("deleteduser")
-	user := &entity.User{
-		ID:        1,
-		Username:  un,
-		IsDeleted: true,
-	}
-	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
-	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
-
-	err := service.DeleteUser(context.Background(), adminRequester, "deleteduser")
-	require.ErrorIs(t, err, ErrUserAlreadyDeleted)
 }
 
 func TestUserService_DeleteUser_AdminRequired(t *testing.T) {
@@ -808,71 +798,5 @@ func TestUserService_DeleteUser_NilRequester(t *testing.T) {
 	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
 
 	err := service.DeleteUser(context.Background(), nil, "testuser")
-	require.ErrorIs(t, err, ErrAdminRequired)
-}
-
-func TestUserService_RestoreUser_Success(t *testing.T) {
-	un, _ := username.NewUserName("deleteduser")
-	user := &entity.User{
-		ID:        1,
-		Username:  un,
-		IsDeleted: true,
-	}
-	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
-	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
-
-	err := service.RestoreUser(context.Background(), adminRequester, "deleteduser")
-	require.NoError(t, err)
-
-	// Saveに渡されたエンティティの状態を検証
-	require.NotNil(t, repo.savedUser, "expected user to be saved")
-	assert.False(t, repo.savedUser.IsDeleted, "expected user to be restored (not deleted)")
-}
-
-func TestUserService_RestoreUser_UserNotFound(t *testing.T) {
-	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
-	repo := &stubUserRepository{err: repository.ErrUserNotFound}
-	service := NewUserService(nil, repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
-
-	err := service.RestoreUser(context.Background(), adminRequester, "missing")
-	require.ErrorIs(t, err, ErrUserNotFound)
-}
-
-func TestUserService_RestoreUser_NotDeleted(t *testing.T) {
-	un, _ := username.NewUserName("activeuser")
-	user := &entity.User{
-		ID:        1,
-		Username:  un,
-		IsDeleted: false,
-	}
-	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
-	repo := &stubUserRepository{user: user}
-	service := NewUserService(nil, repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
-
-	err := service.RestoreUser(context.Background(), adminRequester, "activeuser")
-	require.ErrorIs(t, err, ErrUserNotDeleted)
-}
-
-func TestUserService_RestoreUser_AdminRequired(t *testing.T) {
-	normalUser := &entity.User{ID: 1, AccountTypeID: 1}
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
-
-	err := service.RestoreUser(context.Background(), normalUser, "deleteduser")
-	require.ErrorIs(t, err, ErrAdminRequired)
-}
-
-func TestUserService_RestoreUser_UnknownRoleRejected(t *testing.T) {
-	unknownRoleUser := &entity.User{ID: 1, AccountTypeID: 4}
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
-
-	err := service.RestoreUser(context.Background(), unknownRoleUser, "deleteduser")
-	require.ErrorIs(t, err, ErrAdminRequired)
-}
-
-func TestUserService_RestoreUser_NilRequester(t *testing.T) {
-	service := NewUserService(nil, &stubUserRepository{}, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
-
-	err := service.RestoreUser(context.Background(), nil, "deleteduser")
 	require.ErrorIs(t, err, ErrAdminRequired)
 }

--- a/main.go
+++ b/main.go
@@ -100,9 +100,14 @@ func main() {
 		slog.Error("Failed to initialize firebase token verifier", "error", err)
 		return
 	}
+	firebaseUserDeleter, err := app.SetupFirebaseUserDeleter(ctx, cfg)
+	if err != nil {
+		slog.Error("Failed to initialize firebase user deleter", "error", err)
+		return
+	}
 
 	// サーバーの作成と起動
-	server := app.NewServer(database, staticDatabase, cfg, masterCache, staticMasterCache, firebaseTokenVerifier)
+	server := app.NewServer(database, staticDatabase, cfg, masterCache, staticMasterCache, firebaseTokenVerifier, firebaseUserDeleter)
 	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/main.go
+++ b/main.go
@@ -95,14 +95,9 @@ func main() {
 
 	slog.Info("Static master data preloaded")
 
-	firebaseTokenVerifier, err := app.SetupFirebaseTokenVerifier(ctx, cfg)
+	firebaseTokenVerifier, firebaseUserDeleter, err := app.SetupFirebaseAuthServices(ctx, cfg)
 	if err != nil {
-		slog.Error("Failed to initialize firebase token verifier", "error", err)
-		return
-	}
-	firebaseUserDeleter, err := app.SetupFirebaseUserDeleter(ctx, cfg)
-	if err != nil {
-		slog.Error("Failed to initialize firebase user deleter", "error", err)
+		slog.Error("Failed to initialize firebase services", "error", err)
 		return
 	}
 


### PR DESCRIPTION
### Motivation

- Convert user deletion from logical (`is_deleted`) to physical removal and remove restore semantics for clarity and data cleanup.
- Ensure related data and external Firebase accounts are cleaned up on account deletion to avoid orphaned records and external stale users.
- Reflect the behavior change in API docs and admin responses to remove `is_deleted` exposure.

### Description

- API docs updated (`docs/API.md`) to describe physical deletion semantics, remove references to logical delete/restore, and remove `is_deleted` from admin list schemas and examples. 
- User handling updated: `UserHandler` and router no longer expose restore endpoint and deletion handler now expects physical delete behavior. 
- Usecase and credential services changed to perform physical deletion via new `DeleteByID` repository method and to attempt Firebase user deletion via a new `FirebaseUserDeleter` abstraction, with logging on Firebase failures. 
- Repository/model/DB access updated to remove `is_deleted` usage from queries and models and to add `DeleteByID` implementation; DTOs adjusted to drop `IsDeleted`. 
- Firebase integration added: `firebaseauth` now provides `NewFirebaseUserDeleterFromCredentialsFile` and a concrete `firebaseUserDeleter` implementation, plus app wiring functions `SetupFirebaseUserDeleter`, router/server wiring, and `main` initialization. 
- Tests updated to reflect new physical-delete behavior and new interfaces, including repository and usecase tests; removed restore-related tests and expectations.

### Testing

- Ran unit tests with `go test ./...` after changes, and all unit tests passed.
- Updated handler/repository/usecase tests to reflect physical deletion behavior and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d372f68e54832da5595873a22a86b5)