### PR TITLE
Prevent replacing existing Firebase UID; return 409 Conflict on re-link attempts

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -462,7 +462,7 @@
 - **レスポンス**: 204 No Content。
 - **挙動**:
   - 同一ユーザーに同じ Firebase UID を再連携した場合は、冪等に成功します。
-  - 同一ユーザーに別の Firebase UID を連携した場合は、新しい Firebase UID に更新されます。
+  - 同一ユーザーに別の Firebase UID を連携しようとした場合は、`409 Conflict` (`firebase_uid_already_linked`) を返します（初回連携のみ許可）。
   - 他ユーザーに既に連携されている Firebase UID は連携できません。
 
 - **主なエラー**:

--- a/internal/usecase/firebase_link_usecase.go
+++ b/internal/usecase/firebase_link_usecase.go
@@ -76,7 +76,7 @@ func (u *firebaseLinkUsecase) LinkFirebaseUID(ctx context.Context, userID int, i
 		}
 
 		currentFirebaseUID := user.FirebaseUID
-		if currentFirebaseUID != nil && *currentFirebaseUID != uid {
+		if user.HasLinkedFirebase() {
 			return ErrFirebaseUIDAlreadyLinked
 		}
 		user.LinkFirebaseUID(uid)

--- a/internal/usecase/firebase_link_usecase.go
+++ b/internal/usecase/firebase_link_usecase.go
@@ -76,6 +76,9 @@ func (u *firebaseLinkUsecase) LinkFirebaseUID(ctx context.Context, userID int, i
 		}
 
 		currentFirebaseUID := user.FirebaseUID
+		if currentFirebaseUID != nil && *currentFirebaseUID != uid {
+			return ErrFirebaseUIDAlreadyLinked
+		}
 		user.LinkFirebaseUID(uid)
 		if err := u.userRepo.LinkFirebaseUID(ctx, tx, user.ID, currentFirebaseUID, uid, user.UpdatedAt); err != nil {
 			if errors.Is(err, repository.ErrFirebaseUIDAlreadyLinked) {

--- a/internal/usecase/firebase_link_usecase.go
+++ b/internal/usecase/firebase_link_usecase.go
@@ -75,10 +75,10 @@ func (u *firebaseLinkUsecase) LinkFirebaseUID(ctx context.Context, userID int, i
 			return errors.Join(ErrInternalError, errors.New("user repository returned nil user"))
 		}
 
-		currentFirebaseUID := user.FirebaseUID
 		if user.HasLinkedFirebase() {
 			return ErrFirebaseUIDAlreadyLinked
 		}
+		currentFirebaseUID := user.FirebaseUID
 		user.LinkFirebaseUID(uid)
 		if err := u.userRepo.LinkFirebaseUID(ctx, tx, user.ID, currentFirebaseUID, uid, user.UpdatedAt); err != nil {
 			if errors.Is(err, repository.ErrFirebaseUIDAlreadyLinked) {

--- a/internal/usecase/firebase_link_usecase_test.go
+++ b/internal/usecase/firebase_link_usecase_test.go
@@ -53,7 +53,7 @@ func TestFirebaseLinkUsecase_LinkFirebaseUID(t *testing.T) {
 			},
 		},
 		{
-			name:    "自分に別のUIDが既に紐付いていれば新しいUIDへ更新できる",
+			name:    "自分に別のUIDが既に紐付いていれば409相当のエラーを返す",
 			userID:  10,
 			idToken: "replace-user-token",
 			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
@@ -62,11 +62,12 @@ func TestFirebaseLinkUsecase_LinkFirebaseUID(t *testing.T) {
 				verifier.On("VerifyIDToken", mock.Anything, "replace-user-token").Return("new-firebase-uid", nil).Once()
 				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "new-firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
 				userRepo.On("FindByIDForUpdate", mock.Anything, mock.Anything, 10).Return(user, nil).Once()
-				userRepo.On("LinkFirebaseUID", mock.Anything, mock.Anything, 10, &existingUID, "new-firebase-uid", mock.AnythingOfType("time.Time")).Return(nil).Once()
 			},
+			wantErr: ErrFirebaseUIDAlreadyLinked,
 			assertAfter: func(t *testing.T, verifier *mockTokenVerifier, userRepo *MockUserRepository) {
 				verifier.AssertExpectations(t)
 				userRepo.AssertExpectations(t)
+				userRepo.AssertNotCalled(t, "LinkFirebaseUID", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{


### PR DESCRIPTION
### Motivation
- Ensure Firebase UID linking is first-time-only so an existing different Firebase UID cannot be replaced, and reflect that behavior in the API documentation.

### Description
- Update `docs/API.md` to state that attempting to link a different Firebase UID returns `409 Conflict` (`firebase_uid_already_linked`).
- Add a guard in `internal/usecase/firebase_link_usecase.go` that returns `ErrFirebaseUIDAlreadyLinked` when the user already has a different `FirebaseUID` before calling `LinkFirebaseUID`.
- Update `internal/usecase/firebase_link_usecase_test.go` to expect `ErrFirebaseUIDAlreadyLinked` for replacement attempts and to assert that `LinkFirebaseUID` is not invoked in those cases.

### Testing
- Ran the updated unit test `TestFirebaseLinkUsecase_LinkFirebaseUID` which includes cases for idempotent linking, replacement attempts, and conflicts, and it passed.
- Ran package tests for the usecase package with `go test ./internal/usecase` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ceafda20832da32237de84a7fd33)