### PR TITLE
update: 退会時に全セッション失効・APIトークン削除・リカバリーコード削除を実行

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -429,7 +429,7 @@
 - **認証**: Cookie 必須
 - **レスポンス**: 200 OK。ボディは空です。
 
-ユーザーを物理削除します。ユーザーに紐づく `players` / `player_records` / `player_worldsend_records` / `player_honors` / `sessions` / `api_tokens` / `user_recovery_codes` も外部キー制約により削除されます。Firebase UID が連携されている場合は Firebase ユーザー削除も試行します（失敗時はサーバーログに記録し、APIレスポンスは成功を維持します）。
+ユーザーを物理削除します。退会トランザクション内で、対象ユーザーの **全セッション即時失効**（`sessions` の全削除）、**APIトークン削除**（`api_tokens`）、**リカバリーコード削除**（`user_recovery_codes`）を先に実行した後に `users` を削除します。`players` / `player_records` / `player_worldsend_records` / `player_honors` は外部キー制約により削除されます。Firebase UID が連携されている場合は Firebase ユーザー削除も試行します（失敗時はサーバーログに記録し、APIレスポンスは成功を維持します）。
 
 - **主なエラー**:
   - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要

--- a/internal/usecase/user_credential_usecase.go
+++ b/internal/usecase/user_credential_usecase.go
@@ -187,6 +187,16 @@ func (s *userCredentialUsecaseImpl) DeleteOwnAccount(ctx context.Context, userID
 			deletedFirebaseUID = *user.FirebaseUID
 		}
 
+		if err := s.sessionRepo.DeleteByUserID(ctx, tx, userID); err != nil {
+			return err
+		}
+		if err := s.apiTokenRepo.DeleteByUserID(ctx, tx, userID); err != nil {
+			return err
+		}
+		if err := s.recoveryCodeRepo.DeleteByUserID(ctx, tx, userID); err != nil {
+			return err
+		}
+
 		return s.userRepo.DeleteByID(ctx, tx, userID)
 	}); err != nil {
 		return err

--- a/internal/usecase/user_security_usecase_test.go
+++ b/internal/usecase/user_security_usecase_test.go
@@ -186,35 +186,75 @@ func TestUserSecurityUsecase_DeleteUser(t *testing.T) {
 
 	t.Run("アカウント削除に成功する", func(t *testing.T) {
 		mockUserRepo := new(MockUserRepository)
+		mockSessionRepo := new(MockSessionRepository)
+		mockRecoveryCodeRepo := new(MockRecoveryCodeRepository)
+		apiTokenRepo := &stubAPITokenRepository{}
 		tm := &mockTransactionManager{}
 		userCredentialUsecase := newTestUserCredentialUsecaseWithDeleteDependencies(
-			tm, mockUserRepo, nil, new(MockSessionRepository), &stubAPITokenRepository{}, new(MockRecoveryCodeRepository), "test-pepper",
+			tm, mockUserRepo, nil, mockSessionRepo, apiTokenRepo, mockRecoveryCodeRepo, "test-pepper",
 		)
 
 		user := &entity.User{ID: 1, Username: un}
 		mockUserRepo.On("FindByIDForUpdate", mock.Anything, mock.Anything, 1).Return(user, nil).Once()
+		mockSessionRepo.On("DeleteByUserID", mock.Anything, mock.Anything, 1).Return(nil).Once()
+		mockRecoveryCodeRepo.On("DeleteByUserID", mock.Anything, mock.Anything, 1).Return(nil).Once()
 		mockUserRepo.On("DeleteByID", mock.Anything, mock.Anything, 1).Return(nil).Once()
 
 		err := userCredentialUsecase.DeleteOwnAccount(context.Background(), 1)
 		assert.NoError(t, err)
+		assert.Equal(t, 1, apiTokenRepo.deletedUserID)
 		mockUserRepo.AssertExpectations(t)
+		mockSessionRepo.AssertExpectations(t)
+		mockRecoveryCodeRepo.AssertExpectations(t)
 	})
 
 	t.Run("物理削除時にDBエラーが発生した場合はエラーを返す", func(t *testing.T) {
 		mockUserRepo := new(MockUserRepository)
+		mockSessionRepo := new(MockSessionRepository)
+		mockRecoveryCodeRepo := new(MockRecoveryCodeRepository)
+		apiTokenRepo := &stubAPITokenRepository{}
 		tm := &mockTransactionManager{}
 		userCredentialUsecase := newTestUserCredentialUsecaseWithDeleteDependencies(
-			tm, mockUserRepo, nil, new(MockSessionRepository), &stubAPITokenRepository{}, new(MockRecoveryCodeRepository), "test-pepper",
+			tm, mockUserRepo, nil, mockSessionRepo, apiTokenRepo, mockRecoveryCodeRepo, "test-pepper",
 		)
 
 		user := &entity.User{ID: 2, Username: un}
 		mockUserRepo.On("FindByIDForUpdate", mock.Anything, mock.Anything, 2).Return(user, nil).Once()
+		mockSessionRepo.On("DeleteByUserID", mock.Anything, mock.Anything, 2).Return(nil).Once()
+		mockRecoveryCodeRepo.On("DeleteByUserID", mock.Anything, mock.Anything, 2).Return(nil).Once()
 		mockUserRepo.On("DeleteByID", mock.Anything, mock.Anything, 2).Return(errors.New("db error")).Once()
 
 		err := userCredentialUsecase.DeleteOwnAccount(context.Background(), 2)
 		assert.Error(t, err)
 		assert.Equal(t, "db error", err.Error())
+		assert.Equal(t, 2, apiTokenRepo.deletedUserID)
 		mockUserRepo.AssertExpectations(t)
+		mockSessionRepo.AssertExpectations(t)
+		mockRecoveryCodeRepo.AssertExpectations(t)
+	})
+
+	t.Run("全セッション削除で失敗した場合はエラーを返しユーザー削除しない", func(t *testing.T) {
+		mockUserRepo := new(MockUserRepository)
+		mockSessionRepo := new(MockSessionRepository)
+		mockRecoveryCodeRepo := new(MockRecoveryCodeRepository)
+		apiTokenRepo := &stubAPITokenRepository{}
+		tm := &mockTransactionManager{}
+		userCredentialUsecase := newTestUserCredentialUsecaseWithDeleteDependencies(
+			tm, mockUserRepo, nil, mockSessionRepo, apiTokenRepo, mockRecoveryCodeRepo, "test-pepper",
+		)
+
+		user := &entity.User{ID: 3, Username: un}
+		mockUserRepo.On("FindByIDForUpdate", mock.Anything, mock.Anything, 3).Return(user, nil).Once()
+		mockSessionRepo.On("DeleteByUserID", mock.Anything, mock.Anything, 3).Return(errors.New("session delete error")).Once()
+
+		err := userCredentialUsecase.DeleteOwnAccount(context.Background(), 3)
+		assert.Error(t, err)
+		assert.Equal(t, "session delete error", err.Error())
+		assert.Equal(t, 0, apiTokenRepo.deletedUserID)
+		mockUserRepo.AssertExpectations(t)
+		mockSessionRepo.AssertExpectations(t)
+		mockRecoveryCodeRepo.AssertNotCalled(t, "DeleteByUserID", mock.Anything, mock.Anything, mock.Anything)
+		mockUserRepo.AssertNotCalled(t, "DeleteByID", mock.Anything, mock.Anything, mock.Anything)
 	})
 }
 


### PR DESCRIPTION
### Motivation
- 退会時に認証情報が残り続けるのを防ぐため、ユーザー削除のトランザクション内でセッション・APIトークン・リカバリーコードを即時削除する必要があった。 
- 外部キーのCASCADEに依存するだけでなく、退会フロー内で明示的に無効化処理を行うことで挙動を明確化するため。 

### Description
- `internal/usecase/user_credential_usecase.go` の `DeleteOwnAccount` にて、ユーザー削除前に `sessionRepo.DeleteByUserID` / `apiTokenRepo.DeleteByUserID` / `recoveryCodeRepo.DeleteByUserID` をトランザクション内で実行するよう追加した。 
- `internal/usecase/user_security_usecase_test.go` に退会処理周りのユニットテストを拡充し、正常系・ユーザー削除失敗時・セッション削除失敗時のケースを追加して期待挙動を検証するようにした。 
- `docs/API.md` の `DELETE /internal/me` 説明を実装に合わせて更新し、退会時に「全セッション即時失効」「APIトークン削除」「リカバリーコード削除」を明記した。 

### Testing
- `gofmt -w internal/usecase/user_credential_usecase.go internal/usecase/user_security_usecase_test.go` を実行した（整形）。 
- `go test ./...` を実行し、該当パッケージを含むテストが通過した（テストは複数回実行して成功を確認）。 
- 変更ファイル: `internal/usecase/user_credential_usecase.go`, `internal/usecase/user_security_usecase_test.go`, `docs/API.md`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3d8041a34832d8c8163bd09707526)