### PR TITLE
feat: Firebase認証を用いた初回登録機能を実装

### DIFF
--- a/_report/firebase_auth_complete_migration_plan_20260412.md
+++ b/_report/firebase_auth_complete_migration_plan_20260412.md
@@ -1,0 +1,496 @@
+# Firebase Auth 完全移行計画書
+
+作成日: 2026-04-12
+
+## 目的
+
+認証方式を Firebase Authentication へ一本化する。
+
+今回のゴールは次の 3 点である。
+
+- 内部 API のユーザー認証を Firebase ID トークン検証へ移行する
+- `users.password_hash` を削除する
+- `sessions` テーブルと独自セッション管理を削除する
+
+後方互換性は考慮しない。  
+既存の Cookie / JWT / パスワード認証を前提にしたクライアントは破壊的に切り替える。
+
+## 前提とスコープ
+
+### 本計画で「Firebase Auth に移譲するもの」
+
+- `/internal` 配下のユーザー認証
+- ユーザー本人確認
+- ログイン状態の継続判定
+- 退会時の再認証
+
+### 本計画で維持するもの
+
+- `/v1` および `/compat/chunirec/2.0` の API トークン認証
+
+理由:
+
+- 現在の API トークンは「外部 API 利用者向けのアプリ内トークン」であり、ブラウザのログインセッションとは役割が異なる
+- ユーザーの対話的認証を Firebase に寄せることと、機械利用向け API トークンを残すことは両立する
+
+したがって、本計画の「すべての認証が Firebase Auth に移譲される」は、内部 API のユーザー認証について達成するものと定義する。
+
+## 現状整理
+
+### 現在の認証方式
+
+現状は単一方式ではなく、次の 3 系統が混在している。
+
+| 用途 | 現状の方式 | 主な実装 |
+| --- | --- | --- |
+| 内部 API (`/internal`) | Cookie + 独自 JWT + `sessions` テーブル | `internal/app/middleware/auth_middleware.go`, `internal/usecase/auth_usecase_impl.go`, `internal/usecase/session_issuer.go` |
+| Firebase ログイン入口 | Firebase ID トークンを受け取って独自セッションへ変換 | `internal/usecase/firebase_login_usecase.go`, `internal/usecase/firebase_register_usecase.go` |
+| 外部 API (`/v1`, `/compat/chunirec/2.0`) | `Authorization: Bearer <api_token>` | `internal/app/middleware/api_token_middleware.go`, `internal/usecase/api_token_usecase_impl.go` |
+
+### 現在の内部 API 認証フロー
+
+1. `/internal/auth/login` または `/internal/auth/firebase/login` を呼ぶ
+2. バックエンドが独自 JWT を発行する
+3. 同時に `sessions` テーブルへセッションを保存する
+4. 以後の `/internal` は `token` Cookie を読む
+5. JWT 内の `session_id` と `sessions` テーブルを照合して本人確認する
+
+つまり、Firebase は現状では認証基盤ではなく「ログイン入口のひとつ」に留まっている。
+
+### 現在の DB 状態
+
+`users` テーブル:
+
+- `firebase_uid` は nullable かつ unique
+- `password_hash` は NOT NULL
+- Firebase 専用ユーザーは実装上 `password_hash == ""` を許容している
+- 現在は全ユーザーの `firebase_uid` が埋まっている
+- Google 連携していなかったユーザーについても、存在しないメールアドレスとパスワードで Firebase Auth 側ユーザーを作成済みである
+
+`sessions` テーブル:
+
+- 内部 API の継続認証の正本
+- `auth_middleware.go` が Cookie 内 JWT と組み合わせて使用
+
+`user_recovery_codes` テーブル:
+
+- パスワード再設定用
+- パスワード認証を残す前提の機能
+
+### 現在の主要エンドポイント
+
+内部認証関連:
+
+- `POST /internal/auth/register`
+- `POST /internal/auth/login`
+- `POST /internal/auth/firebase/login`
+- `POST /internal/auth/firebase/register`
+- `POST /internal/auth/logout`
+- `POST /internal/auth/recovery-codes`
+- `GET /internal/me/sessions`
+- `DELETE /internal/me/sessions`
+- `PUT /internal/me/password`
+- `POST /internal/me/firebase/link`
+
+### コード上の確定事項
+
+- `FirebaseIDTokenMiddleware` は既に存在し、`Authorization: Bearer <Firebase ID Token>` を読める
+- しかし実ルートでは未採用
+- `/internal` の本番導線は `JWTMiddleware` に依存している
+- `session_issuer.go` は `sessions` テーブル保存と JWT 発行を同時に担っている
+- `auth_handler.go` / `firebase_handler.go` はどちらも `token` Cookie を返す
+- `profile_handler.go` の退会処理は、削除後に Cookie セッション失効を試みる
+- `user_model.go` / `user_repository_impl.go` は `password_hash` カラム前提
+- `recovery_usecase.go` は `PW_PEPPER` と `password_hash` に依存している
+
+## 目標アーキテクチャ
+
+### 認証の正本
+
+内部 API の認証正本を Firebase ID トークンに置き換える。
+
+新しい流れは次のとおり。
+
+1. クライアントが Firebase SDK でログインする
+2. クライアントが Firebase ID トークンを取得する
+3. 内部 API 呼び出し時に `Authorization: Bearer <Firebase ID Token>` を付与する
+4. バックエンドは Firebase Admin SDK でトークンを検証する
+5. `firebase_uid` でアプリ内ユーザーを解決する
+
+### 認証状態の持ち方
+
+- バックエンドは独自 JWT を発行しない
+- `sessions` テーブルは持たない
+- `token` Cookie は廃止する
+- セッション数管理 API も廃止する
+
+### ユーザー識別子
+
+アプリ内ユーザーの認証上の主キーは `users.firebase_uid` とする。
+
+推奨:
+
+- `firebase_uid` を `NOT NULL UNIQUE` にする
+- Firebase 未連携ユーザーを残さない
+
+この方針を採ると、全ユーザーが Firebase Auth を前提とする設計へ揃う。
+
+## 破壊的変更の方針
+
+### 廃止するもの
+
+- `POST /internal/auth/register`
+- `POST /internal/auth/login`
+- `POST /internal/auth/firebase/login`
+- `POST /internal/auth/logout`
+- `POST /internal/auth/recovery-codes`
+- `GET /internal/me/sessions`
+- `DELETE /internal/me/sessions`
+- `PUT /internal/me/password`
+- `POST /internal/me/recovery-codes`
+- `POST /internal/me/firebase/link`
+
+補足:
+
+- `POST /internal/auth/firebase/register` は現行の「Firebase ID トークンでユーザー作成して Cookie 発行」という役割を失う
+- 完全移行後は「初回ログイン時のユーザー作成 API」へ再設計するか、自動プロビジョニングへ置き換える
+
+### 新設または再設計するもの
+
+- Firebase Bearer 認証前提の `/internal` 共通認証
+- 初回ユーザー作成フロー
+- 退会 API の再認証仕様
+
+### 推奨する新しいオンボーディング方式
+
+後方互換を捨てるなら、最も単純なのは次のどちらかである。
+
+#### 案 A: 初回アクセス時自動プロビジョニング
+
+- Firebase ID トークンが有効
+- 対応する `firebase_uid` のユーザーが存在しない
+- その場合は最小情報でユーザーを自動作成する
+- その後に username 設定 API を踏ませる
+
+#### 案 B: 明示的な初回登録 API
+
+- `POST /internal/auth/signup`
+- 認証は Bearer Firebase ID トークン必須
+- リクエストで `username` を受け、`firebase_uid` でユーザーを作成する
+
+本プロジェクトでは、既存に username 必須文化があるため、案 B を推奨する。  
+ただし初回未登録ユーザーの取り扱いを明確にしたいなら、案 A も実装は可能である。
+
+## 移行後 API の想定
+
+### 認証
+
+- `/internal` の認証必須エンドポイントは原則すべて `Authorization: Bearer <Firebase ID Token>` を必須にする
+- Cookie 認証エンドポイントは削除する
+
+### 残す候補
+
+- `POST /internal/auth/signup`
+  - Bearer Firebase ID トークン必須
+  - 未作成の `firebase_uid` に対してローカルユーザーを作成する
+
+### 退会
+
+- `DELETE /internal/me`
+  - Bearer Firebase ID トークン必須
+  - Firebase 側で recent sign-in を満たした直後のトークンを要求する
+  - アプリ DB のユーザー削除後、Firebase Auth 側ユーザー削除も試行する
+
+### 不要になるエンドポイント
+
+- パスワードログイン系
+- Cookie ログアウト系
+- セッション数管理系
+- パスワード再設定 / リカバリーコード系
+- Firebase 連携系
+
+理由:
+
+- すべてのアクティブユーザーが Firebase 前提なら、「連携」という概念そのものが不要になる
+
+## DB 変更計画
+
+### 最終形
+
+`users` テーブル:
+
+- `firebase_uid` は `NOT NULL UNIQUE`
+- `password_hash` を削除
+
+削除するテーブル:
+
+- `sessions`
+- `user_recovery_codes`
+
+維持するテーブル:
+
+- `api_tokens`
+
+補足:
+
+- 外部 API (`/v1`, `/compat/chunirec/2.0`) を維持するため、`api_tokens` は削除しない
+
+### マイグレーション方針
+
+#### Step 1. スキーマ変更
+
+推奨順:
+
+1. 既存 `sessions` を全削除する
+2. 既存 `user_recovery_codes` を全削除する
+3. `users.firebase_uid` を `NOT NULL` に変更する
+4. `users.password_hash` を削除する
+5. `sessions` テーブルを削除する
+6. `user_recovery_codes` テーブルを削除する
+7. `cleanup_expired_sessions` イベントを削除する
+
+補足:
+
+- `sessions` と `user_recovery_codes` は互換維持不要のため、事前に強制全削除で問題ない
+- これらは移行対象データではなく、不要データとして扱う
+
+#### Step 2. ドキュメントと ER 図更新
+
+更新対象:
+
+- `docs/API.md`
+- `docs/configuration.md`
+- `docs/er_diagram.puml`
+- `migration/MIGRATION.md`
+- `docs/recovery_code_spec.md`（廃止またはアーカイブ）
+
+## アプリケーション変更計画
+
+### 1. ルーター
+
+`internal/app/router.go` で実施すること:
+
+- `JWTMiddleware` / `OptionalJWTMiddleware` の適用をやめる
+- 認証必須の `/internal` グループへ `FirebaseIDTokenMiddleware` を適用する
+- Cookie 前提エンドポイントを削除する
+- `AuthHandler` / `SessionHandler` / `RecoveryHandler` への依存を削減または除去する
+
+### 2. ミドルウェア
+
+残す:
+
+- `firebase_auth_middleware.go`
+- `bearer_token.go`
+- `api_token_middleware.go`
+
+削除対象:
+
+- `auth_middleware.go`
+
+### 3. ユースケース
+
+削除対象:
+
+- `auth_usecase_impl.go`
+- `session_issuer.go`
+- `session_usecase_impl.go`
+- パスワード変更・リカバリーコード依存部分
+
+再設計対象:
+
+- `firebase_register_usecase.go`
+  - Cookie セッション発行をやめる
+  - 初回ユーザー作成専用へ変更する
+- `firebase_auth_usecase.go`
+  - `/internal` の標準認証として利用する
+- `user_credential_usecase.go`
+  - `sessionRepo` / `recoveryCodeRepo` / `pepper` 依存の整理
+
+### 4. ハンドラー
+
+削除対象:
+
+- `auth_handler.go`
+- `session_handler.go`
+- パスワード変更 / リカバリーコード発行 / Cookie 失効処理
+
+再設計対象:
+
+- `firebase_handler.go`
+  - ログイン Cookie 発行ではなく、必要最小限の signup 系 API へ縮小
+- `profile_handler.go`
+  - 退会時の Cookie 削除を除去
+  - Firebase Bearer 認証前提へ簡素化
+
+### 5. ドメインとリポジトリ
+
+`entity.User`:
+
+- `PasswordHash` を削除する
+- `ChangePassword` を削除する
+- `NewUser` / `NewFirebaseUser` を統合し、Firebase UID 必須の生成へ寄せる
+
+`models.UserModel`:
+
+- `PasswordHash` フィールドを削除する
+- `ToEntity()` の空ハッシュ分岐を削除する
+
+`user_repository_impl.go`:
+
+- `SELECT` / `INSERT` / `UPDATE` から `password_hash` を除去する
+- `firebase_uid` を前提にした CRUD へ寄せる
+
+## 設定変更計画
+
+削除候補:
+
+- `JWT_SECRET`
+- `PW_PEPPER`
+- `auth.jwt_expiration_hour`
+- `auth.session_expiration_hour`
+- `auth.cookie_secure`
+- `auth.cookie_same_site`
+
+維持:
+
+- `FIREBASE_CREDENTIALS_FILE`
+
+確認事項:
+
+- `PW_PEPPER` はパスワード関連実装を全廃するなら不要
+- Cookie 設定も `token` Cookie 廃止と同時に不要
+
+## 推奨フェーズ
+
+### フェーズ 1: 現状確認と切替条件確定
+
+実施内容:
+
+- `firebase_uid IS NULL` が 0 件であることを最終確認する
+- `sessions` / `user_recovery_codes` の削除前件数を把握する
+- 完全移行日を決める
+
+完了条件:
+
+- 全ユーザーが Firebase 化済みであることが確認できている
+
+### フェーズ 2: 内部 API を Firebase Bearer 認証へ切替
+
+実施内容:
+
+- `/internal` の認証ミドルウェアを `FirebaseIDTokenMiddleware` へ統一する
+- フロントエンドの API 呼び出しを Bearer ID トークン前提へ変更する
+- Cookie 発行 / Cookie 読み取りコードを削除する
+
+完了条件:
+
+- `/internal` の認証必須 API がすべて Firebase ID トークンで通る
+- `token` Cookie を使うコードが消えている
+
+### フェーズ 3: 認証系 API を整理
+
+実施内容:
+
+- パスワードログイン・リカバリーコード・セッション管理 API を削除する
+- 必要なら `POST /internal/auth/signup` を追加する
+
+完了条件:
+
+- 独自ログイン導線が消えている
+- 初回ユーザー作成導線が確定している
+
+### フェーズ 4: ドメイン・DB の不要物を削除
+
+実施内容:
+
+- `PasswordHash` 関連コード削除
+- `Session` 関連コード削除
+- `RecoveryCode` 関連コード削除
+- マイグレーション適用
+
+完了条件:
+
+- `users.password_hash` が消えている
+- `sessions` テーブルが消えている
+- `user_recovery_codes` テーブルが消えている
+
+### フェーズ 5: ドキュメント更新
+
+実施内容:
+
+- API 仕様の全面更新
+- 設定値の全面更新
+- 廃止エンドポイント明記
+
+完了条件:
+
+- 実装と `docs/API.md` が一致している
+
+## リスクと対策
+
+### リスク 1: 退会時の recent sign-in 条件不足
+
+影響:
+
+- クライアントではログイン済みでも、Firebase 側ユーザー削除が拒否される
+
+対策:
+
+- クライアントで reauthenticate を必須にする
+- 退会 API は Firebase Bearer 認証必須にし、必要なら recent sign-in 不足を専用エラーへ変換する
+
+### リスク 2: ID トークン期限切れ時の UX 変化
+
+影響:
+
+- Cookie のような長期セッション前提の UI が崩れる
+
+対策:
+
+- クライアント側で Firebase SDK による ID トークン再取得を標準化する
+- サーバー側は短命トークン前提でシンプルに扱う
+
+## テスト観点
+
+### 必須テスト
+
+- Firebase ID トークン付きで `/internal/me` が通る
+- Firebase ID トークンなしで `/internal/me` が 401 になる
+- Cookie を送っても認証されない
+- 未登録 `firebase_uid` の signup が成功する
+- 既存 `firebase_uid` で重複 signup が拒否される
+- 退会でアプリユーザー削除と Firebase 側削除試行が行われる
+- `/v1` と `/compat/chunirec/2.0` は既存 API トークンで引き続き通る
+
+### 削除対象テスト
+
+- JWT Cookie 認証テスト
+- セッション数テスト
+- パスワードログインテスト
+- リカバリーコードテスト
+
+## 実施順の推奨
+
+1. `firebase_uid IS NULL` が 0 件であることを確認する
+2. `sessions` と `user_recovery_codes` の全削除を実施する
+3. `/internal` の標準認証を Firebase Bearer に切り替える
+4. フロントエンドを Firebase SDK + Bearer 送信へ切り替える
+5. Cookie / JWT / session 系 API と実装を削除する
+6. `password_hash` と recovery code 系実装を削除する
+7. DB マイグレーションで `users.password_hash` / `sessions` / `user_recovery_codes` を削除する
+8. ドキュメントを更新する
+
+## まとめ
+
+現状の Firebase 対応は「独自認証の入口に Firebase を追加した状態」であり、完全移譲ではない。  
+完全移譲を達成するには、Firebase ログイン API を増やすのではなく、内部 API の認証正本そのものを Firebase ID トークンへ置き換える必要がある。
+
+後方互換性を捨てる前提なら、目指すべき最終形は明確である。
+
+- `/internal` は Bearer Firebase ID トークンで認証する
+- 独自 JWT と Cookie を廃止する
+- `sessions` テーブルを削除する
+- `users.password_hash` を削除する
+- リカバリーコード系も原則廃止する
+
+この順で進めれば、認証の責務は Firebase 側へ寄り、アプリ側は `firebase_uid` に紐づくドメインデータ管理へ集中できる。

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 このドキュメントは `chunisupport-api` が提供する内部API(`/internal` プレフィックス)、公開API(`/v1` プレフィックス)、chunirec互換API(`/compat/chunirec/2.0` プレフィックス)の仕様をまとめたものです。
 
-**最終更新日**: 2026年04月05日
+**最終更新日**: 2026年04月12日
 
 ## ベースURLと環境
 
@@ -26,9 +26,11 @@
 
 ### 内部API (`/internal`)
 
-- ログイン成功時に `token` という名前の HTTPOnly Cookie を発行します。
-- 認証必須エンドポイントでは Cookie を検証し、ユーザー情報をリクエストコンテキストに格納します。
-- Cookie 任意のエンドポイントでは、未認証時にレートリミットが適用されます。
+- 認証必須エンドポイントでは `Authorization: Bearer <Firebase ID Token>` を送信します。
+- 認証必須エンドポイントでは Firebase ID トークンを検証し、ユーザー情報をリクエストコンテキストに格納します。
+- Bearer 任意のエンドポイントでは、未認証時にレートリミットが適用されます。
+- `token` Cookie や独自セッションは使用しません。
+- `POST /internal/auth/login`、`POST /internal/auth/logout`、`GET /internal/me/sessions` などのCookie/セッション前提APIは廃止されています。
 
 ### 公開API (`/v1`, `/compat/chunirec/2.0`)
 
@@ -97,53 +99,43 @@
 | ---- | -------- | ---- | ---- |
 | `/` | GET | 不要 | 監視向けにアプリケーション名を固定で返します |
 | `/health` | GET | APIトークン(ADMIN) | DB接続を含むヘルスチェック |
-| `/internal/auth/register` | POST | 不要 | ユーザー登録 |
-| `/internal/auth/login` | POST | 不要 | ログインしてCookieを発行 |
-| `/internal/auth/firebase/login` | POST | 不要 | Firebase IDトークンでログインしてCookieを発行 |
-| `/internal/auth/firebase/register` | POST | 不要 | Firebase IDトークンで新規ユーザー登録してCookieを発行 |
-| `/internal/auth/logout` | POST | Cookie | セッション失効 |
-| `/internal/auth/recovery-codes` | POST | 不要 | リカバリーコードでパスワード再設定 |
-| `/internal/auth/api-tokens` | POST | Cookie | APIトークン発行 |
-| `/internal/auth/api-tokens` | DELETE | Cookie | APIトークン削除 |
-| `/internal/me` | GET | Cookie | 自身のユーザー情報 |
-| `/internal/me/privacy` | PUT | Cookie | 非公開設定更新 |
-| `/internal/me/password` | PUT | Cookie | パスワード変更 |
-| `/internal/me/recovery-codes` | POST | Cookie | リカバリーコード発行 |
-| `/internal/me` | DELETE | Cookie | アカウント物理削除 |
-| `/internal/me/register-data` | POST | Cookie | CHUNITHMプレイヤーデータ登録 |
-| `/internal/me/player-data` | DELETE | Cookie | プレイヤー連携を解除し、プレイヤー関連レコードを削除 |
+| `/internal/auth/signup` | POST | Firebase Bearer | Firebase IDトークンで初回ユーザー登録 |
+| `/internal/auth/api-tokens` | POST | Firebase Bearer | APIトークン発行 |
+| `/internal/auth/api-tokens` | DELETE | Firebase Bearer | APIトークン削除 |
+| `/internal/me` | GET | Firebase Bearer | 自身のユーザー情報 |
+| `/internal/me/privacy` | PUT | Firebase Bearer | 非公開設定更新 |
+| `/internal/me` | DELETE | Firebase Bearer | アカウント物理削除 |
+| `/internal/me/register-data` | POST | Firebase Bearer | CHUNITHMプレイヤーデータ登録 |
+| `/internal/me/player-data` | DELETE | Firebase Bearer | プレイヤー連携を解除し、プレイヤー関連レコードを削除 |
 | `/internal/player-data/temp` | POST | なし | 未ログインでプレイヤーデータを一時受付（gzip JSON） |
-| `/internal/player-data/commit` | POST | Cookie | 一時受付したプレイヤーデータを確定保存 |
-| `/internal/me/firebase/link` | POST | Cookie | Firebase UID を現在のユーザーへ連携 |
-| `/internal/me/sessions` | GET | Cookie | 有効なセッション数を取得 |
-| `/internal/me/sessions` | DELETE | Cookie | 現在のセッション以外をすべてログアウト |
-| `/internal/me/goals` | GET | Cookie | 目標一覧を取得 |
-| `/internal/me/goals` | POST | Cookie | 目標を作成 |
-| `/internal/me/goals/:id` | PUT | Cookie | 目標を更新 |
-| `/internal/me/goals/:id` | DELETE | Cookie | 目標を削除 |
-| `/internal/users/` | GET | Cookie (ADMIN+) | 全ユーザー一覧取得（プライベート・プレイヤー未紐付けを含む） |
-| `/internal/users/:username/updated-at` | GET | Cookie (任意) | レコード更新日時のみ取得 |
-| `/internal/users/:username/profile` | GET | Cookie (任意) | ユーザー名とプレイヤー情報のみ取得 |
-| `/internal/users/:username` | GET | Cookie (任意) | プロファイルとレコードを一括取得 |
-| `/internal/users/:username` | DELETE | Cookie (ADMIN+) | ユーザーの物理削除 |
-| `/internal/songs/updated-at` | GET | Cookie (任意) | 楽曲情報キャッシュ用の最終更新日時のみ取得 |
-| `/internal/songs` | GET | Cookie (任意) | WORLD'S END以外の楽曲一覧取得 |
-| `/internal/songs/:displayid` | GET | Cookie (任意) | 楽曲詳細取得 |
-| `/internal/songs/:displayid/stats/:difficulty` | GET | Cookie (任意) | 難易度別楽曲統計取得 |
-| `/internal/songs` | PUT | Cookie (EDITOR+) | 楽曲情報と譜面情報の一括更新 |
-| `/internal/songs/:displayid` | DELETE | Cookie (EDITOR+) | 楽曲の論理削除 |
-| `/internal/songs/:displayid/restore` | POST | Cookie (EDITOR+) | 楽曲の復活 |
-| `/internal/songs/worldsend` | GET | Cookie (任意) | WORLD'S END楽曲一覧取得 |
-| `/internal/songs/worldsend/:displayid` | GET | Cookie (任意) | WORLD'S END楽曲詳細取得 |
-| `/internal/songs/worldsend` | PUT | Cookie (EDITOR+) | WORLD'S END楽曲情報と譜面情報の一括更新 |
-| `/internal/songs/worldsend/:displayid` | DELETE | Cookie (EDITOR+) | WORLD'S END楽曲の論理削除 |
-| `/internal/songs/worldsend/:displayid/restore` | POST | Cookie (EDITOR+) | WORLD'S END楽曲の復活 |
-| `/internal/editor/songs` | GET | Cookie (EDITOR+) | 編集者向け通常楽曲一覧取得（`is_deleted`, `updated_at`, 譜面の `updated_at` を含む） |
-| `/internal/editor/songs/:displayid` | GET | Cookie (EDITOR+) | 編集者向け通常楽曲詳細取得（`is_deleted`, `updated_at`, 譜面の `updated_at` を含む） |
-| `/internal/editor/songs/worldsend` | GET | Cookie (EDITOR+) | 編集者向けWORLD'S END楽曲一覧取得（`is_deleted`, `updated_at`, 譜面の `updated_at` を含む） |
-| `/internal/editor/songs/worldsend/:displayid` | GET | Cookie (EDITOR+) | 編集者向けWORLD'S END楽曲詳細取得（`is_deleted`, `updated_at`, 譜面の `updated_at` を含む） |
-| `/internal/master` | GET | Cookie | フロントエンド向けマスターデータ取得 |
-| `/internal/master/versions` | GET | Cookie | バージョン一覧取得 |
+| `/internal/player-data/commit` | POST | Firebase Bearer | 一時受付したプレイヤーデータを確定保存 |
+| `/internal/me/goals` | GET | Firebase Bearer | 目標一覧を取得 |
+| `/internal/me/goals` | POST | Firebase Bearer | 目標を作成 |
+| `/internal/me/goals/:id` | PUT | Firebase Bearer | 目標を更新 |
+| `/internal/me/goals/:id` | DELETE | Firebase Bearer | 目標を削除 |
+| `/internal/users/` | GET | Firebase Bearer (ADMIN+) | 全ユーザー一覧取得（プライベート・プレイヤー未紐付けを含む） |
+| `/internal/users/:username/updated-at` | GET | Firebase Bearer (任意) | レコード更新日時のみ取得 |
+| `/internal/users/:username/profile` | GET | Firebase Bearer (任意) | ユーザー名とプレイヤー情報のみ取得 |
+| `/internal/users/:username` | GET | Firebase Bearer (任意) | プロファイルとレコードを一括取得 |
+| `/internal/users/:username` | DELETE | Firebase Bearer (ADMIN+) | ユーザーの物理削除 |
+| `/internal/songs/updated-at` | GET | Firebase Bearer (任意) | 楽曲情報キャッシュ用の最終更新日時のみ取得 |
+| `/internal/songs` | GET | Firebase Bearer (任意) | WORLD'S END以外の楽曲一覧取得 |
+| `/internal/songs/:displayid` | GET | Firebase Bearer (任意) | 楽曲詳細取得 |
+| `/internal/songs/:displayid/stats/:difficulty` | GET | Firebase Bearer (任意) | 難易度別楽曲統計取得 |
+| `/internal/songs` | PUT | Firebase Bearer (EDITOR+) | 楽曲情報と譜面情報の一括更新 |
+| `/internal/songs/:displayid` | DELETE | Firebase Bearer (EDITOR+) | 楽曲の論理削除 |
+| `/internal/songs/:displayid/restore` | POST | Firebase Bearer (EDITOR+) | 楽曲の復活 |
+| `/internal/songs/worldsend` | GET | Firebase Bearer (任意) | WORLD'S END楽曲一覧取得 |
+| `/internal/songs/worldsend/:displayid` | GET | Firebase Bearer (任意) | WORLD'S END楽曲詳細取得 |
+| `/internal/songs/worldsend` | PUT | Firebase Bearer (EDITOR+) | WORLD'S END楽曲情報と譜面情報の一括更新 |
+| `/internal/songs/worldsend/:displayid` | DELETE | Firebase Bearer (EDITOR+) | WORLD'S END楽曲の論理削除 |
+| `/internal/songs/worldsend/:displayid/restore` | POST | Firebase Bearer (EDITOR+) | WORLD'S END楽曲の復活 |
+| `/internal/editor/songs` | GET | Firebase Bearer (EDITOR+) | 編集者向け通常楽曲一覧取得（`is_deleted`, `updated_at`, 譜面の `updated_at` を含む） |
+| `/internal/editor/songs/:displayid` | GET | Firebase Bearer (EDITOR+) | 編集者向け通常楽曲詳細取得（`is_deleted`, `updated_at`, 譜面の `updated_at` を含む） |
+| `/internal/editor/songs/worldsend` | GET | Firebase Bearer (EDITOR+) | 編集者向けWORLD'S END楽曲一覧取得（`is_deleted`, `updated_at`, 譜面の `updated_at` を含む） |
+| `/internal/editor/songs/worldsend/:displayid` | GET | Firebase Bearer (EDITOR+) | 編集者向けWORLD'S END楽曲詳細取得（`is_deleted`, `updated_at`, 譜面の `updated_at` を含む） |
+| `/internal/master` | GET | Firebase Bearer | フロントエンド向けマスターデータ取得 |
+| `/internal/master/versions` | GET | Firebase Bearer | バージョン一覧取得 |
 | `/v1/songs` | GET | APIトークン | 全楽曲一覧取得（WORLD'S END除く） |
 | `/v1/songs/:displayid` | GET | APIトークン | 楽曲詳細取得 |
 | `/v1/songs/:displayid/stats/:difficulty` | GET | APIトークン | 難易度別楽曲統計取得 |
@@ -184,30 +176,29 @@
 
 ## 認証エンドポイント
 
-### POST `/internal/auth/register`
-- **認証**: 不要
+### POST `/internal/auth/signup`
+- **認証**: Firebase Bearer 必須
+- **リクエストヘッダー**: `Authorization: Bearer <Firebase ID Token>`
 - **リクエストボディ**:
 
 ```json
 {
-  "username": "sample_user",
-  "password": "strongpassword"
+  "username": "sampleuser"
 }
 ```
 
 | フィールド | 型 | 必須 | バリデーション |
 | ---------- | -- | ---- | -------------- |
 | `username` | string | ✓ | 5〜50文字、小文字英数字のみ |
-| `password` | string | ✓ | 8〜128文字 |
 
-- **レスポンス**: 201 Created。`UserDTO` を返します。登録成功時は自動的にログイン状態となり、`token` Cookie が設定されます。
-- **レスポンスヘッダー**: `Set-Cookie: token=<JWT>; Path=/; HttpOnly; ...`
-- **セッション数制限**: ユーザーあたりのセッション数は10件に制限されており、新しいセッションを作成すると最も古いセッションから自動的に削除されます。
+- **レスポンス**: 201 Created。`UserDTO` を返します。
 
 ```json
 {
-  "username": "sample_user",
-  "player": null
+  "username": "sampleuser",
+  "account_type": "PLAYER",
+  "is_private": false,
+  "last_score_update": null
 }
 ```
 
@@ -217,118 +208,14 @@
   - 400 Bad Request (`username_too_short`): ユーザー名が5文字未満
   - 400 Bad Request (`username_too_long`): ユーザー名が50文字超過
   - 400 Bad Request (`username_invalid_char`): ユーザー名に使用できない文字が含まれている（小文字英数字のみ可）
-  - 400 Bad Request (`password_too_short`): パスワードが8文字未満
-  - 400 Bad Request (`password_too_long`): パスワードが128文字超過
   - 400 Bad Request (`registration_failed`): ユーザー登録失敗（詳細隠蔽）
-  - 500 Internal Server Error (`internal_error`): 予期しないサーバーエラー
-
-### POST `/internal/auth/login`
-- **認証**: 不要
-- **リクエストボディ**:
-
-```json
-{
-  "username": "sample_user",
-  "password": "strongpassword"
-}
-```
-
-| フィールド | 型 | 必須 | バリデーション |
-| ---------- | -- | ---- | -------------- |
-| `username` | string | ✓ | 5〜50文字、小文字英数字のみ |
-| `password` | string | ✓ | 8〜128文字 |
-
-- **レスポンス**: 200 OK。ボディは空で、`token` Cookie が設定されます。
-- **レスポンスヘッダー**: `Set-Cookie: token=<JWT>; Path=/; HttpOnly; ...`
-- **セッション数制限**: ユーザーあたりのセッション数は10件に制限されており、新しいセッションを作成すると最も古いセッションから自動的に削除されます。
-- **主なエラー**:
-  - 400 Bad Request (`bad_request`): リクエスト形式不正（JSONパースエラー）
-  - 401 Unauthorized (`invalid_credentials`): ユーザー名またはパスワードが不正
-
-### POST `/internal/auth/firebase/login`
-- **認証**: 不要
-- **リクエストボディ**:
-
-```json
-{
-  "id_token": "<Firebase ID Token>"
-}
-```
-
-| フィールド | 型 | 必須 | バリデーション |
-| ---------- | -- | ---- | -------------- |
-| `id_token` | string | ✓ | 必須 |
-
-- **レスポンス**: 204 No Content。ボディは空で、`token` Cookie が設定されます。
-- **レスポンスヘッダー**: `Set-Cookie: token=<JWT>; Path=/; HttpOnly; ...`
-- **セッション数制限**: ユーザーあたりのセッション数は10件に制限されており、新しいセッションを作成すると最も古いセッションから自動的に削除されます。
-- **主なエラー**:
-  - 400 Bad Request (`bad_request`): リクエスト形式不正（JSONパースエラー）
-  - 401 Unauthorized (`invalid_token`): Firebase IDトークンが不正、失効済み、またはユーザーに未連携
-  - 500 Internal Server Error (`internal_error`): 予期しないサーバーエラー
-
-### POST `/internal/auth/firebase/register`
-- **認証**: 不要
-- **リクエストボディ**:
-
-```json
-{
-  "id_token": "<Firebase ID Token>",
-  "username": "<username>"
-}
-```
-
-| フィールド | 型 | 必須 | バリデーション |
-| ---------- | -- | ---- | -------------- |
-| `id_token` | string | ✓ | 必須 |
-| `username` | string | ✓ | 5〜50文字、小文字英数字のみ |
-
-- **レスポンス**: 201 Created。ボディは空で、`token` Cookie が設定されます。
-- **レスポンスヘッダー**: `Set-Cookie: token=<JWT>; Path=/; HttpOnly; ...`
-- **セッション数制限**: ユーザーあたりのセッション数は10件に制限されており、超過時は最古のセッションから自動的に削除されます。
-- **主なエラー**:
-  - 400 Bad Request (`bad_request`): リクエスト形式不正（JSONパースエラー）
+  - 401 Unauthorized (`missing_token`): Bearerトークン未指定
   - 401 Unauthorized (`invalid_token`): Firebase IDトークンが不正または失効済み
-  - 400 Bad Request (`registration_failed`): username 重複などによりユーザー登録失敗（詳細隠蔽）
   - 409 Conflict (`firebase_uid_already_linked`): Firebase UID が既存ユーザーに連携済み
-  - 422 Unprocessable Entity (`validation_failed`): usernameバリデーション失敗
-  - 500 Internal Server Error (`internal_error`): 予期しないサーバーエラー
-
-### POST `/internal/auth/logout`
-- **認証**: Cookie 必須
-- **レスポンス**: 200 OK。ボディは空です。
-- Cookieは即時失効 (`Max-Age=-1`)。
-- **主なエラー**:
-  - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
-
-### POST `/internal/auth/recovery-codes`
-- **認証**: 不要
-- **レートリミット**: 1分あたり5回/IP
-- **リクエストボディ**:
-
-```json
-{
-  "recovery_code": "A1B2-C3D4-E5F6",
-  "new_password": "new-password"
-}
-```
-
-| フィールド | 型 | 必須 | バリデーション |
-| ---------- | -- | ---- | -------------- |
-| `recovery_code` | string | ✓ | `XXXX-XXXX-XXXX` 形式の英数字 |
-| `new_password` | string | ✓ | 8〜128文字 |
-
-- **レスポンス**: 200 OK。ボディは空です。
-- **主なエラー**:
-  - 400 Bad Request (`bad_request`): `recovery_code` の形式不正
-  - 400 Bad Request (`password_too_short`): パスワードが8文字未満
-  - 400 Bad Request (`password_too_long`): パスワードが128文字超過
-  - 400 Bad Request (`invalid_password`): パスワードが無効（詳細隠蔽）
-  - 401 Unauthorized (`invalid_recovery_credentials`): コード不正/使用済み/ユーザー不在（詳細隠蔽）
   - 500 Internal Server Error (`internal_error`): 予期しないサーバーエラー
 
 ### POST `/internal/auth/api-tokens`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **レスポンス**: 200 OK
 
 ```json
@@ -338,7 +225,7 @@
 トークンはレスポンスでのみ平文が取得できます。
 
 ### DELETE `/internal/auth/api-tokens`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **レスポンス**: 204 No Content
 - 自分のAPIトークンを削除します。トークンが存在しない場合でも204を返します。
 - **主なエラー**:
@@ -349,7 +236,7 @@
 ## `/internal/me` グループ
 
 ### GET `/internal/me`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **レスポンス**: `UserDTO`
 
 ```json
@@ -373,7 +260,7 @@
 - 最終スコア更新日時の取得に失敗した場合、このエンドポイントは成功レスポンスを返さずエラーを返します。
 
 ### PUT `/internal/me/privacy`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **リクエストボディ**:
 
 ```json
@@ -392,53 +279,11 @@
   - 400 Bad Request (`bad_request`): リクエスト形式不正
   - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
 
-### PUT `/internal/me/password`
-- **認証**: Cookie 必須
-- **リクエストボディ**:
-
-```json
-{
-  "current_password": "oldpassword123",
-  "new_password": "newpassword123"
-}
-```
-
-| フィールド | 型 | 必須 | バリデーション |
-| ---------- | -- | ---- | -------------- |
-| `current_password` | string | ✓ | 8〜128文字 |
-| `new_password` | string | ✓ | 8〜128文字 |
-
-- **レスポンス**: 200 OK。ボディは空です。
-- **主なエラー**:
-  - 400 Bad Request (`bad_request`): リクエスト形式不正（JSONパースエラー）
-  - 400 Bad Request (`password_too_short`): 新しいパスワードが8文字未満
-  - 400 Bad Request (`password_too_long`): 新しいパスワードが128文字超過
-  - 400 Bad Request (`invalid_password`): パスワードが無効（詳細隠蔽）
-  - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
-  - 401 Unauthorized (`invalid_credentials`): 現在のパスワードが不正
-
-### POST `/internal/me/recovery-codes`
-- **認証**: Cookie 必須
-- **リクエストボディ**: なし
-- **レスポンス**: 200 OK。リカバリーコード一覧を返却します。
-
-```json
-{
-  "recovery_codes": [
-    "A1B2-C3D4-E5F6",
-    "G7H8-I9J0-K1L2"
-  ]
-}
-```
-
-- **主なエラー**:
-  - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
-
 ### DELETE `/internal/me`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **レスポンス**: 200 OK。ボディは空です。
 
-ユーザーを物理削除します。ユーザーに紐づく `players` / `player_records` / `player_worldsend_records` / `player_honors` / `sessions` / `api_tokens` / `user_recovery_codes` も外部キー制約により削除されます。Firebase UID が連携されている場合は Firebase ユーザー削除も試行します（失敗時はサーバーログに記録し、APIレスポンスは成功を維持します）。
+ユーザーを物理削除します。ユーザーに紐づく `players` / `player_records` / `player_worldsend_records` / `player_honors` / `sessions` / `api_tokens` / `user_recovery_codes` も外部キー制約により削除されます。Firebase UID が連携されている場合は Firebase ユーザー削除も試行します（失敗時はサーバーログに記録し、APIレスポンスは成功を維持します）。現時点では Firebase の recent sign-in を使った再認証は未実装です。
 
 - **主なエラー**:
   - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
@@ -446,7 +291,7 @@
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー（DB削除失敗など）
 
 ### DELETE `/internal/me/player-data`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **レスポンス**: 204 No Content（ボディなし）
 
 ユーザーアカウントは残したまま、`users.player_id` を `NULL` にし、紐づく `players` および `player_records`/`player_worldsend_records`/`player_honors` を物理削除します。削除はトランザクション内で実行され、連携済みでない状態でも冪等に成功します。
@@ -454,70 +299,8 @@
 - **主なエラー**:
   - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
 
-### POST `/internal/me/firebase/link`
-- **認証**: Cookie 必須
-- **リクエストボディ**:
-
-```json
-{
-  "id_token": "<Firebase ID Token>"
-}
-```
-
-| フィールド | 型 | 必須 | バリデーション |
-| ---------- | -- | ---- | -------------- |
-| `id_token` | string | ✓ | 必須 |
-
-- **レスポンス**: 204 No Content。
-- **挙動**:
-  - 同一ユーザーに同じ Firebase UID を再連携した場合は、冪等に成功します。
-  - 同一ユーザーに別の Firebase UID を連携しようとした場合は、`409 Conflict` (`firebase_uid_already_linked`) を返します（初回連携のみ許可）。
-  - 他ユーザーに既に連携されている Firebase UID は連携できません。
-
-- **主なエラー**:
-  - 400 Bad Request (`bad_request`): リクエスト形式不正（JSONパースエラー）
-  - 401 Unauthorized (`invalid_token`): Firebase IDトークンが不正または失効済み
-  - 401 Unauthorized (`unauthorized`): 削除済みユーザー
-  - 409 Conflict (`firebase_uid_already_linked`): Firebase UID が他ユーザーに連携済み
-  - 500 Internal Server Error (`internal_error`): 予期しないサーバーエラー
-
-### GET `/internal/me/sessions`
-- **認証**: Cookie 必須
-- **説明**: 現在有効なセッション数を取得します。
-- **セッション数制限**: ユーザーあたりのセッション数は10件に制限されています。新規ログインで上限を超えた場合、最も古いセッションから自動的に削除されます。
-- **レスポンス**: 200 OK
-
-#### レスポンス例
-
-```json
-{
-  "count": 3
-}
-```
-
-#### レスポンススキーマ
-
-| フィールド | 型 | 説明 |
-| ---------- | -- | ---- |
-| `count` | number | 有効なセッション数（期限切れを除く） |
-
-- **主なエラー**:
-  - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
-  - 500 Internal Server Error (`internal_error`): DB処理失敗
-
-### DELETE `/internal/me/sessions`
-- **認証**: Cookie 必須
-- **説明**: 現在のセッション以外をすべてログアウトします（他の端末からログアウト）。
-- **レスポンス**: 204 No Content（ボディなし）
-
-現在使用中のセッションは削除されないため、このリクエストを実行した端末はログイン状態のままとなります。他の端末では次回リクエスト時に401エラーが返され、再ログインが必要になります。
-
-- **主なエラー**:
-  - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
-  - 500 Internal Server Error (`internal_error`): DB処理失敗
-
 ### POST `/internal/me/register-data`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **コンテンツタイプ**: 
   - デフォルト（クエリパラメータなし）: `application/octet-stream` または `text/plain`（base64+gzip形式）
   - `?format=json`: `application/json`（デバッグ用、通常は使用しない）
@@ -767,7 +550,7 @@ curl -X POST \
 
 - **主なエラー**:
   - 400 Bad Request (`bad_request` / `resource_not_found` / `app_version_unsupported`): JSON構文不備・楽曲マスタ未登録・非対応バージョンなど
-  - 401 Unauthorized (`missing_token` / `invalid_token`): Cookie欠如
+  - 401 Unauthorized (`missing_token` / `invalid_token`): Bearerトークン欠如または無効
   - 409 Conflict (`conflict`): 別ユーザーのプレイヤーデータと競合
   - 413 Request Entity Too Large (`payload_too_large`): ボディサイズ5MB超過
   - 422 Unprocessable Entity (`validation_failed`): バリデーションエラー（スコア範囲外など）
@@ -1053,7 +836,7 @@ curl -X POST \
 ## `/internal/users` グループ
 
 ### GET `/internal/users/`
-- **認証**: Cookie 必須（ADMIN権限必須）
+- **認証**: Firebase Bearer 必須（ADMIN権限必須）
 - **説明**: ADMIN専用のエンドポイントです。プライベートアカウント、プレイヤー未紐付けアカウントを含む全ユーザーの一覧を取得します。
 - **クエリパラメータ**:
     - `page` (任意): ページ番号 (デフォルト: 1)
@@ -1112,7 +895,7 @@ curl -X POST \
 ---
 
 ### GET `/internal/users/:username`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしは1分10回/IP
 - **パスパラメータ**: `username` - 対象ユーザーのユーザー名
 - **クエリパラメータ**:
@@ -1185,7 +968,7 @@ curl -X POST \
 ---
 
 ### GET `/internal/users/:username/updated-at`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしで1分間10回/IP
 - **パスパラメータ**: `username` - 対象ユーザーのユーザー名
 - **レスポンス**: プレイヤーデータの `updated_at` のみを返します。非公開設定のユーザーは本人以外 404 を返します。
@@ -1205,7 +988,7 @@ curl -X POST \
 | `updated_at` | string | プレイヤーデータの最終更新日時 (ISO8601) |
 
 ### GET `/internal/users/:username/profile`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしで1分間10回/IP
 - **パスパラメータ**: `username` - 対象ユーザーのユーザー名
 - **レスポンス**: ユーザー名とプレイヤー情報のみを返します。非公開設定のユーザーは本人以外 404 を返します。
@@ -1246,7 +1029,7 @@ curl -X POST \
 | `player` | object | プレイヤー情報。スキーマは `PlayerDTO` と同一 |
 
 ### GET `/internal/songs/updated-at`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしで1分間10回/IP
 - **レスポンス**: `songs`, `charts`, `worldsend_charts` の `updated_at` の最大値のみを返します。楽曲情報キャッシュの更新判定に使用できます。
 
@@ -1319,7 +1102,7 @@ curl -X POST \
   - 404 Not Found (`user_not_found`): ユーザーが見つからない（非公開/プレイヤー未紐付含む）
 
 ### DELETE `/internal/users/:username`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: ADMIN 権限が必要
 - **パスパラメータ**: `username` - 削除対象ユーザーのユーザー名
 - **レスポンス**: 204 No Content
@@ -1327,7 +1110,7 @@ curl -X POST \
 **説明**: 指定されたユーザー名のユーザーを物理削除します。関連データ（プレイヤー・レコード・セッション・APIトークン・リカバリーコード）も外部キー制約により削除されます。Firebase UID が連携されている場合は Firebase ユーザー削除も試行します（失敗時はサーバーログに記録し、APIレスポンスは成功を維持します）。
 
 - **主なエラー**:
-  - 401 Unauthorized (`unauthorized`): Cookie欠如または無効
+  - 401 Unauthorized (`unauthorized`): Bearerトークン欠如または無効
   - 403 Forbidden (`forbidden`): ADMIN権限が不足
   - 404 Not Found (`user_not_found`): ユーザーが存在しない
   - 400 Bad Request (`operation_failed`): 操作失敗（詳細隠蔽）
@@ -1337,7 +1120,7 @@ curl -X POST \
 ## `/internal/songs` グループ
 
 ### GET `/internal/songs`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしは1分10回/IP
 - **概要**: WORLD'S END以外の全楽曲を譜面情報付きで取得します。デフォルトでは削除済み楽曲は除外されます。
 - **クエリパラメータ**:
@@ -1414,7 +1197,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### GET `/internal/songs/:displayid`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしは1分10回/IP
 - **パスパラメータ**: `displayid` - 楽曲の表示用ID
 - **概要**: 指定されたDisplayIDの楽曲を譜面情報付きで取得します。削除済み楽曲も取得可能です。
@@ -1454,7 +1237,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): 楽曲が存在しない、またはサーバー内部エラー
 
 ### GET `/internal/songs/:displayid/stats/:difficulty`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしは1分10回/IP
 - **パスパラメータ**: 
   - `displayid` - 楽曲の表示用ID
@@ -1547,7 +1330,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### PUT `/internal/songs`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **概要**: 通常楽曲（WORLD'S ENDを除く）の楽曲情報と譜面情報を一括更新します。既存データの修正専用で、新規追加・削除は行いません。
 - **リクエスト**: JSON配列
@@ -1613,7 +1396,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): 楽曲・譜面・マスタ不整合などのサーバー内部エラー
 
 ### DELETE `/internal/songs/:displayid`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **パスパラメータ**: `displayid` - 楽曲の表示用ID
 - **概要**: 指定されたDisplayIDの楽曲を論理削除します。物理削除ではなく、`is_deleted` フラグを `true` に設定します。
@@ -1625,7 +1408,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): 楽曲が存在しない、またはサーバー内部エラー
 
 ### POST `/internal/songs/:displayid/restore`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **パスパラメータ**: `displayid` - 楽曲の表示用ID
 - **概要**: 指定されたDisplayIDの削除済み楽曲を復活させます。`is_deleted` フラグを `false` に設定します。
@@ -1637,7 +1420,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): 楽曲が存在しない、またはサーバー内部エラー
 
 ### GET `/internal/songs/worldsend`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしは1分10回/IP
 - **クエリパラメータ**: 
   - `include_deleted` (bool, optional): `true` を指定すると削除済み楽曲も含めて取得。ただし、EDITOR 権限が必要です。権限がない場合は自動的に `false` として処理されます。デフォルト: `false`
@@ -1696,7 +1479,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### GET `/internal/songs/worldsend/:displayid`
-- **認証**: Cookie (任意)
+- **認証**: Firebase Bearer (任意)
 - **レートリミット**: 認証なしは1分10回/IP
 - **パスパラメータ**: `displayid` - 楽曲の表示用ID
 - **概要**: 指定された DisplayID の WORLD'S END 楽曲を譜面情報付きで取得します。削除済み楽曲も取得可能です。
@@ -1728,7 +1511,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### PUT `/internal/songs/worldsend`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **概要**: WORLD'S END 楽曲および譜面情報を一括更新します。既存データの修正専用で、新規追加・削除は行いません。
 - **リクエスト**: JSON配列
@@ -1796,7 +1579,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): 楽曲・譜面・マスタ不整合などのサーバー内部エラー
 
 ### DELETE `/internal/songs/worldsend/:displayid`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **パスパラメータ**: `displayid` - 楽曲の表示用ID
 - **概要**: 指定された DisplayID の WORLD'S END 楽曲を論理削除します。物理削除ではなく、`is_deleted` フラグを `true` に設定します。
@@ -1809,7 +1592,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### POST `/internal/songs/worldsend/:displayid/restore`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **パスパラメータ**: `displayid` - 楽曲の表示用ID
 - **概要**: 指定された DisplayID の削除済み WORLD'S END 楽曲を復活させます。`is_deleted` フラグを `false` に設定します。
@@ -1826,7 +1609,7 @@ curl -X POST \
 ## `/internal/editor/songs` グループ
 
 ### GET `/internal/editor/songs`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **概要**: 編集者向けに、WORLD'S END以外の全楽曲を削除済みも含めて取得します。
 - **レスポンス**: 200 OK
@@ -1865,7 +1648,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### GET `/internal/editor/songs/:displayid`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **パスパラメータ**: `displayid` - 楽曲の表示用ID
 - **概要**: 編集者向けに、指定されたDisplayIDの通常楽曲を取得します。削除済みも取得対象です。
@@ -1878,7 +1661,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### GET `/internal/editor/songs/worldsend`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **概要**: 編集者向けに、全 WORLD'S END 楽曲を削除済みも含めて取得します。
 - **レスポンス**: 200 OK
@@ -1917,7 +1700,7 @@ curl -X POST \
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### GET `/internal/editor/songs/worldsend/:displayid`
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **権限**: EDITOR または ADMIN 権限が必要
 - **パスパラメータ**: `displayid` - 楽曲の表示用ID
 - **概要**: 編集者向けに、指定されたDisplayIDの WORLD'S END 楽曲を取得します。削除済みも取得対象です。
@@ -1935,7 +1718,7 @@ curl -X POST \
 
 ### GET `/internal/master`
 
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **概要**: フロントエンド向けにマスタデータ（ジャンル、難易度、アカウント種別、バージョン、レーティング帯、成果種別、クラスエンブレム、クリアランプ、コンボランプ、フルチェインランプ、スロット、称号タイプ）を返却します。
 - `achievement_types` は目標APIの `achievement_type` を表示・入力補助するための辞書として利用します。
 - **レスポンス**: 200 OK
@@ -2075,7 +1858,7 @@ curl -X POST \
 
 ### GET `/internal/master/versions`
 
-- **認証**: Cookie 必須
+- **認証**: Firebase Bearer 必須
 - **概要**: `/internal/master` の `versions` を単独で取得します。フロントエンドが内部マスタ全体に依存せず、バージョン一覧だけを段階的に分離取得するためのエンドポイントです。
 - **レスポンス**: 200 OK。レスポンス形式は後述の `GET /v1/master/versions` と同一です。
 
@@ -2773,7 +2556,7 @@ interface SkippedRecord {
 
 このエンドポイントでは、保存済み本文を `PlayerDataPayload` として解釈し、通常の `/internal/me/register-data` と同じ登録処理を実行します。ただし、一時データは登録処理の開始前に `uploadToken` 単位で消費されます。したがって、登録処理中にエラーになった場合でも同じ `uploadToken` では再試行できず、再アップロードが必要です。
 
-- **認証**: 必須（Cookie）
+- **認証**: 必須（Firebase Bearer）
 - **リクエスト**:
 
 ```json

--- a/internal/app/handler/api_internal/auth_handler.go
+++ b/internal/app/handler/api_internal/auth_handler.go
@@ -28,7 +28,7 @@ func NewAuthHandler(authUsecase usecase.AuthUsecase, cookieSecure bool, cookieSa
 
 // authRequest は認証リクエストのボディの構造です。
 type authRequest struct {
-	Username string `json:"username" validate:"required,username"`
+	Username string `json:"username" validate:"username"`
 	Password string `json:"password" validate:"required,min=8,max=128"` // #nosec G117 API入力仕様として必要
 }
 

--- a/internal/app/handler/api_internal/firebase_handler.go
+++ b/internal/app/handler/api_internal/firebase_handler.go
@@ -14,7 +14,7 @@ type firebaseRequest struct {
 
 type firebaseRegisterRequest struct {
 	IDToken  string `json:"id_token" validate:"required"`
-	Username string `json:"username" validate:"required,username"`
+	Username string `json:"username" validate:"username"`
 }
 
 // FirebaseHandler は Firebase ログイン・連携・登録リクエストを処理します。

--- a/internal/app/handler/api_internal/profile_handler.go
+++ b/internal/app/handler/api_internal/profile_handler.go
@@ -5,26 +5,19 @@ import (
 	"net/http"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
-	"github.com/chunisupport/chunisupport-api/internal/auth"
 	"github.com/chunisupport/chunisupport-api/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
 // ProfileHandler は認証済みユーザーのプロフィール関連リクエストを処理します。
 type ProfileHandler struct {
-	authUsecase           usecase.AuthUsecase
 	userCredentialUsecase usecase.UserCredentialUsecase
-	cookieSecure          bool
-	cookieSameSite        http.SameSite
 }
 
 // NewProfileHandler は新しいProfileHandlerを生成します。
-func NewProfileHandler(authUsecase usecase.AuthUsecase, userCredentialUsecase usecase.UserCredentialUsecase, cookieSecure bool, cookieSameSite http.SameSite) *ProfileHandler {
+func NewProfileHandler(userCredentialUsecase usecase.UserCredentialUsecase) *ProfileHandler {
 	return &ProfileHandler{
-		authUsecase:           authUsecase,
 		userCredentialUsecase: userCredentialUsecase,
-		cookieSecure:          cookieSecure,
-		cookieSameSite:        cookieSameSite,
 	}
 }
 
@@ -102,19 +95,11 @@ func (h *ProfileHandler) DeleteAccount(c echo.Context) error {
 		return err
 	}
 
+	// TODO: Firebase の recent sign-in を使った再認証を追加する。
 	if err := h.userCredentialUsecase.DeleteOwnAccount(c.Request().Context(), user.ID); err != nil {
 		slog.Error("Failed to delete user", "user_id", user.ID, "error", err)
 		return apierror.FromUsecaseError(err)
 	}
-
-	if claims, ok := c.Get("user").(*auth.Claims); ok && claims != nil {
-		if err := h.authUsecase.Logout(c.Request().Context(), claims.SessionID); err != nil {
-			slog.Error("Failed to invalidate session after deletion", "session_id", claims.SessionID, "error", err)
-			return apierror.ErrInternalError.WithInternal(err)
-		}
-	}
-
-	c.SetCookie(newAuthCookie(h.cookieSecure, h.cookieSameSite, "", -1))
 
 	return c.NoContent(http.StatusOK)
 }

--- a/internal/app/handler/api_internal/profile_handler_mock_test.go
+++ b/internal/app/handler/api_internal/profile_handler_mock_test.go
@@ -2,7 +2,6 @@ package api_internal_test
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/handler/api_internal"
 	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
@@ -37,11 +36,10 @@ func (m *mockUserCredentialUsecase) DeleteOwnAccount(ctx context.Context, userID
 	return args.Error(0)
 }
 
-func newProfileHandlerWithMocks(secureCookie bool, sameSite http.SameSite) (*api_internal.ProfileHandler, *mockAuthUsecase, *mockUserCredentialUsecase) {
-	authMock := new(mockAuthUsecase)
+func newProfileHandlerWithMocks() (*api_internal.ProfileHandler, *mockUserCredentialUsecase) {
 	userCredentialMock := new(mockUserCredentialUsecase)
 
-	h := api_internal.NewProfileHandler(authMock, userCredentialMock, secureCookie, sameSite)
+	h := api_internal.NewProfileHandler(userCredentialMock)
 
-	return h, authMock, userCredentialMock
+	return h, userCredentialMock
 }

--- a/internal/app/handler/api_internal/profile_handler_test.go
+++ b/internal/app/handler/api_internal/profile_handler_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
-	"github.com/chunisupport/chunisupport-api/internal/auth"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
 	"github.com/labstack/echo/v4"
@@ -17,7 +16,7 @@ import (
 
 func TestProfileHandler_Me(t *testing.T) {
 	e := newTestEcho()
-	h, _, userCredentialMock := newProfileHandlerWithMocks(false, http.SameSiteLaxMode)
+	h, userCredentialMock := newProfileHandlerWithMocks()
 
 	t.Run("正常系: 自分のユーザー情報を取得できる", func(t *testing.T) {
 		// Given
@@ -43,7 +42,7 @@ func TestProfileHandler_Me(t *testing.T) {
 
 func TestProfileHandler_UpdatePrivacy(t *testing.T) {
 	e := newTestEcho()
-	h, _, userCredentialMock := newProfileHandlerWithMocks(false, http.SameSiteLaxMode)
+	h, userCredentialMock := newProfileHandlerWithMocks()
 
 	t.Run("公開設定更新時にユースケースを呼び出して成功レスポンスを返す", func(t *testing.T) {
 		// Given
@@ -69,20 +68,17 @@ func TestProfileHandler_UpdatePrivacy(t *testing.T) {
 
 func TestProfileHandler_DeleteAccount(t *testing.T) {
 	e := newTestEcho()
-	h, authMock, userCredentialMock := newProfileHandlerWithMocks(false, http.SameSiteLaxMode)
+	h, userCredentialMock := newProfileHandlerWithMocks()
 
-	t.Run("アカウント削除時にセッション無効化とCookie削除を行う", func(t *testing.T) {
+	t.Run("アカウント削除時にユーザー削除のみを行う", func(t *testing.T) {
 		// Given
 		user := &entity.User{ID: 20}
-		claims := &auth.Claims{SessionID: "session-1"}
 		userCredentialMock.On("DeleteOwnAccount", mock.Anything, 20).Return(nil).Once()
-		authMock.On("Logout", mock.Anything, "session-1").Return(nil).Once()
 
 		req := httptest.NewRequest(http.MethodDelete, "/internal/me", nil)
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 		c.Set("userEntity", user)
-		c.Set("user", claims)
 
 		// When
 		err := h.DeleteAccount(c)
@@ -90,13 +86,8 @@ func TestProfileHandler_DeleteAccount(t *testing.T) {
 		// Then
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
-		cookies := rec.Result().Cookies()
-		if assert.NotEmpty(t, cookies) {
-			assert.Equal(t, "token", cookies[0].Name)
-			assert.Equal(t, -1, cookies[0].MaxAge)
-		}
+		assert.Empty(t, rec.Result().Cookies())
 		userCredentialMock.AssertExpectations(t)
-		authMock.AssertExpectations(t)
 	})
 
 	t.Run("ユーザー未設定時は認証エラー", func(t *testing.T) {
@@ -115,7 +106,7 @@ func TestProfileHandler_DeleteAccount(t *testing.T) {
 
 func TestProfileHandler_ChangePassword(t *testing.T) {
 	e := newTestEcho()
-	h, _, userCredentialMock := newProfileHandlerWithMocks(false, http.SameSiteLaxMode)
+	h, userCredentialMock := newProfileHandlerWithMocks()
 
 	t.Run("正常系: パスワード変更", func(t *testing.T) {
 		// Given

--- a/internal/app/handler/api_internal/signup_handler.go
+++ b/internal/app/handler/api_internal/signup_handler.go
@@ -10,7 +10,7 @@ import (
 )
 
 type signupRequest struct {
-	Username string `json:"username" validate:"required,username"`
+	Username string `json:"username" validate:"username"`
 }
 
 // SignupHandler は Firebase Bearer トークンを用いた初回登録を処理します。

--- a/internal/app/handler/api_internal/signup_handler.go
+++ b/internal/app/handler/api_internal/signup_handler.go
@@ -2,9 +2,9 @@ package api_internal
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
+	"github.com/chunisupport/chunisupport-api/internal/app/httpheader"
 	"github.com/chunisupport/chunisupport-api/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -33,7 +33,7 @@ func (h *SignupHandler) Signup(c echo.Context) error {
 		return err
 	}
 
-	idToken := extractSignupBearerToken(c)
+	idToken := httpheader.ExtractBearerToken(c.Request().Header)
 	if idToken == "" {
 		return apierror.ErrMissingToken
 	}
@@ -44,23 +44,4 @@ func (h *SignupHandler) Signup(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusCreated, user)
-}
-
-func extractSignupBearerToken(c echo.Context) string {
-	authHeader := c.Request().Header.Get(echo.HeaderAuthorization)
-	if authHeader == "" {
-		return ""
-	}
-
-	scheme, token, found := strings.Cut(authHeader, " ")
-	if !found || !strings.EqualFold(strings.TrimSpace(scheme), "Bearer") {
-		return ""
-	}
-
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return ""
-	}
-
-	return token
 }

--- a/internal/app/handler/api_internal/signup_handler.go
+++ b/internal/app/handler/api_internal/signup_handler.go
@@ -1,0 +1,66 @@
+package api_internal
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
+	"github.com/chunisupport/chunisupport-api/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type signupRequest struct {
+	Username string `json:"username" validate:"required,username"`
+}
+
+// SignupHandler は Firebase Bearer トークンを用いた初回登録を処理します。
+type SignupHandler struct {
+	signupUsecase usecase.SignupUsecase
+}
+
+// NewSignupHandler は SignupHandler を生成します。
+func NewSignupHandler(signupUsecase usecase.SignupUsecase) *SignupHandler {
+	return &SignupHandler{signupUsecase: signupUsecase}
+}
+
+// Signup は Bearer の Firebase ID トークンでアプリ内ユーザーを作成します。
+func (h *SignupHandler) Signup(c echo.Context) error {
+	req := new(signupRequest)
+	if err := c.Bind(req); err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	idToken := extractSignupBearerToken(c)
+	if idToken == "" {
+		return apierror.ErrMissingToken
+	}
+
+	user, err := h.signupUsecase.Signup(c.Request().Context(), idToken, req.Username)
+	if err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+
+	return c.JSON(http.StatusCreated, user)
+}
+
+func extractSignupBearerToken(c echo.Context) string {
+	authHeader := c.Request().Header.Get(echo.HeaderAuthorization)
+	if authHeader == "" {
+		return ""
+	}
+
+	scheme, token, found := strings.Cut(authHeader, " ")
+	if !found || !strings.EqualFold(strings.TrimSpace(scheme), "Bearer") {
+		return ""
+	}
+
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+
+	return token
+}

--- a/internal/app/handler/api_internal/signup_handler_test.go
+++ b/internal/app/handler/api_internal/signup_handler_test.go
@@ -1,0 +1,101 @@
+package api_internal_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chunisupport/chunisupport-api/internal/app"
+	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
+	"github.com/chunisupport/chunisupport-api/internal/app/handler/api_internal"
+	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
+	"github.com/chunisupport/chunisupport-api/internal/usecase"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSignupUsecase struct {
+	mock.Mock
+}
+
+func (m *mockSignupUsecase) Signup(ctx context.Context, idToken string, username string) (*dto_internal.UserDTO, error) {
+	args := m.Called(ctx, idToken, username)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*dto_internal.UserDTO), args.Error(1)
+}
+
+func TestSignupHandler_Signup(t *testing.T) {
+	e := echo.New()
+	e.Validator = app.NewCustomValidator()
+
+	t.Run("正常系: Bearerトークンで初回登録できる", func(t *testing.T) {
+		signupUsecase := new(mockSignupUsecase)
+		h := api_internal.NewSignupHandler(signupUsecase)
+		signupUsecase.On("Signup", mock.Anything, "firebase-id-token", "newuser").Return(&dto_internal.UserDTO{
+			Username:    "newuser",
+			AccountType: "PLAYER",
+		}, nil).Once()
+
+		body := `{"username":"newuser"}`
+		req := httptest.NewRequest(http.MethodPost, "/internal/auth/signup", bytes.NewBufferString(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer firebase-id-token")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := h.Signup(c)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Contains(t, rec.Body.String(), "newuser")
+		signupUsecase.AssertExpectations(t)
+	})
+
+	t.Run("異常系: Authorizationヘッダがない場合は401を返す", func(t *testing.T) {
+		signupUsecase := new(mockSignupUsecase)
+		h := api_internal.NewSignupHandler(signupUsecase)
+		body := `{"username":"newuser"}`
+		req := httptest.NewRequest(http.MethodPost, "/internal/auth/signup", bytes.NewBufferString(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := h.Signup(c)
+
+		require.Error(t, err)
+		apiErr, ok := err.(*apierror.APIError)
+		require.True(t, ok)
+		assert.Equal(t, http.StatusUnauthorized, apiErr.HTTPStatus)
+		assert.Equal(t, apierror.CodeMissingToken, apiErr.Code)
+		signupUsecase.AssertNotCalled(t, "Signup", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("異常系: 無効トークンは401を返す", func(t *testing.T) {
+		signupUsecase := new(mockSignupUsecase)
+		h := api_internal.NewSignupHandler(signupUsecase)
+		signupUsecase.On("Signup", mock.Anything, "invalid-token", "newuser").Return(nil, usecase.ErrInvalidIDToken).Once()
+
+		body := `{"username":"newuser"}`
+		req := httptest.NewRequest(http.MethodPost, "/internal/auth/signup", bytes.NewBufferString(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer invalid-token")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := h.Signup(c)
+
+		require.Error(t, err)
+		apiErr, ok := err.(*apierror.APIError)
+		require.True(t, ok)
+		assert.Equal(t, http.StatusUnauthorized, apiErr.HTTPStatus)
+		assert.Equal(t, apierror.CodeInvalidToken, apiErr.Code)
+		signupUsecase.AssertExpectations(t)
+	})
+}

--- a/internal/app/httpheader/bearer_token.go
+++ b/internal/app/httpheader/bearer_token.go
@@ -1,0 +1,28 @@
+package httpheader
+
+import (
+	"net/http"
+	"strings"
+)
+
+const authorizationHeader = "Authorization"
+
+// ExtractBearerToken は Authorization ヘッダから Bearer トークンを取り出します。
+func ExtractBearerToken(header http.Header) string {
+	authHeader := header.Get(authorizationHeader)
+	if authHeader == "" {
+		return ""
+	}
+
+	scheme, token, found := strings.Cut(authHeader, " ")
+	if !found || !strings.EqualFold(strings.TrimSpace(scheme), "Bearer") {
+		return ""
+	}
+
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+
+	return token
+}

--- a/internal/app/httpheader/bearer_token_test.go
+++ b/internal/app/httpheader/bearer_token_test.go
@@ -1,0 +1,70 @@
+package httpheader
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractBearerToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     string
+		expected   string
+		headerName string
+	}{
+		{
+			name:       "Bearerトークンを抽出できる",
+			headerName: authorizationHeader,
+			header:     "Bearer firebase-token",
+			expected:   "firebase-token",
+		},
+		{
+			name:       "schemeの大文字小文字は区別しない",
+			headerName: authorizationHeader,
+			header:     "bearer firebase-token",
+			expected:   "firebase-token",
+		},
+		{
+			name:       "トークン前後の空白を除去する",
+			headerName: authorizationHeader,
+			header:     "Bearer   firebase-token   ",
+			expected:   "firebase-token",
+		},
+		{
+			name:       "Authorizationヘッダがない場合は空文字を返す",
+			headerName: authorizationHeader,
+			header:     "",
+			expected:   "",
+		},
+		{
+			name:       "Bearer以外のschemeは拒否する",
+			headerName: authorizationHeader,
+			header:     "Basic firebase-token",
+			expected:   "",
+		},
+		{
+			name:       "トークンが空なら空文字を返す",
+			headerName: authorizationHeader,
+			header:     "Bearer    ",
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			header := make(http.Header)
+			if tt.header != "" {
+				header.Set(tt.headerName, tt.header)
+			}
+
+			// When
+			got := ExtractBearerToken(header)
+
+			// Then
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/app/middleware/bearer_token.go
+++ b/internal/app/middleware/bearer_token.go
@@ -1,26 +1,11 @@
 package middleware
 
 import (
-	"strings"
+	"github.com/chunisupport/chunisupport-api/internal/app/httpheader"
 
 	"github.com/labstack/echo/v4"
 )
 
 func extractBearerToken(c echo.Context) string {
-	authHeader := c.Request().Header.Get(echo.HeaderAuthorization)
-	if authHeader == "" {
-		return ""
-	}
-
-	scheme, token, found := strings.Cut(authHeader, " ")
-	if !found || !strings.EqualFold(strings.TrimSpace(scheme), "Bearer") {
-		return ""
-	}
-
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return ""
-	}
-
-	return token
+	return httpheader.ExtractBearerToken(c.Request().Header)
 }

--- a/internal/app/middleware/firebase_auth_middleware.go
+++ b/internal/app/middleware/firebase_auth_middleware.go
@@ -12,6 +12,7 @@ import (
 // FirebaseAuthenticator はFirebase IDトークンからユーザーを解決する最小インターフェースです。
 type FirebaseAuthenticator interface {
 	Authenticate(ctx context.Context, idToken string) (*entity.User, error)
+	AuthenticateOptional(ctx context.Context, idToken string) (*entity.User, error)
 }
 
 // FirebaseIDTokenMiddleware はBearerのFirebase IDトークン認証を行います。
@@ -52,15 +53,14 @@ func OptionalFirebaseIDTokenMiddleware(authenticator FirebaseAuthenticator) echo
 				return apierror.ErrInternalError.WithInternal(errors.New("firebase authenticator is nil"))
 			}
 
-			user, err := authenticator.Authenticate(c.Request().Context(), idToken)
+			user, err := authenticator.AuthenticateOptional(c.Request().Context(), idToken)
 			if err != nil {
 				return apierror.FromUsecaseError(err)
 			}
-			if user == nil {
-				return apierror.ErrInternalError.WithInternal(errors.New("firebase authenticator returned nil user"))
+			if user != nil {
+				c.Set("userEntity", user)
 			}
 
-			c.Set("userEntity", user)
 			return next(c)
 		}
 	}

--- a/internal/app/middleware/firebase_auth_middleware.go
+++ b/internal/app/middleware/firebase_auth_middleware.go
@@ -39,3 +39,29 @@ func FirebaseIDTokenMiddleware(authenticator FirebaseAuthenticator) echo.Middlew
 		}
 	}
 }
+
+// OptionalFirebaseIDTokenMiddleware はBearerのFirebase IDトークンがある場合のみ認証を行います。
+func OptionalFirebaseIDTokenMiddleware(authenticator FirebaseAuthenticator) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			idToken := extractBearerToken(c)
+			if idToken == "" {
+				return next(c)
+			}
+			if authenticator == nil {
+				return apierror.ErrInternalError.WithInternal(errors.New("firebase authenticator is nil"))
+			}
+
+			user, err := authenticator.Authenticate(c.Request().Context(), idToken)
+			if err != nil {
+				return apierror.FromUsecaseError(err)
+			}
+			if user == nil {
+				return apierror.ErrInternalError.WithInternal(errors.New("firebase authenticator returned nil user"))
+			}
+
+			c.Set("userEntity", user)
+			return next(c)
+		}
+	}
+}

--- a/internal/app/middleware/firebase_auth_middleware_test.go
+++ b/internal/app/middleware/firebase_auth_middleware_test.go
@@ -237,4 +237,81 @@ func TestFirebaseIDTokenMiddleware(t *testing.T) {
 	})
 }
 
+func TestOptionalFirebaseIDTokenMiddleware(t *testing.T) {
+	e := echo.New()
+
+	t.Run("Authorizationヘッダがない場合は匿名で次のハンドラーを実行する", func(t *testing.T) {
+		mockAuthenticator := new(mockFirebaseAuthenticator)
+		middlewareFunc := middleware.OptionalFirebaseIDTokenMiddleware(mockAuthenticator)
+		req := httptest.NewRequest(http.MethodGet, "/internal/songs", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		handlerCalled := false
+		handler := middlewareFunc(func(c echo.Context) error {
+			handlerCalled = true
+			assert.Nil(t, c.Get("userEntity"))
+			return c.NoContent(http.StatusOK)
+		})
+
+		err := handler(c)
+
+		require.NoError(t, err)
+		assert.True(t, handlerCalled)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		mockAuthenticator.AssertNotCalled(t, "Authenticate", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Bearerトークンが有効な場合はuserEntityを設定して次のハンドラーを実行する", func(t *testing.T) {
+		mockAuthenticator := new(mockFirebaseAuthenticator)
+		middlewareFunc := middleware.OptionalFirebaseIDTokenMiddleware(mockAuthenticator)
+		req := httptest.NewRequest(http.MethodGet, "/internal/songs", nil)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer firebase-token")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		user := &entity.User{ID: 1}
+		mockAuthenticator.On("Authenticate", mock.Anything, "firebase-token").Return(user, nil).Once()
+
+		handlerCalled := false
+		handler := middlewareFunc(func(c echo.Context) error {
+			handlerCalled = true
+			storedUser, ok := c.Get("userEntity").(*entity.User)
+			require.True(t, ok)
+			assert.Same(t, user, storedUser)
+			return c.NoContent(http.StatusOK)
+		})
+
+		err := handler(c)
+
+		require.NoError(t, err)
+		assert.True(t, handlerCalled)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		mockAuthenticator.AssertExpectations(t)
+	})
+
+	t.Run("不正なトークンの場合は401を返す", func(t *testing.T) {
+		mockAuthenticator := new(mockFirebaseAuthenticator)
+		middlewareFunc := middleware.OptionalFirebaseIDTokenMiddleware(mockAuthenticator)
+		req := httptest.NewRequest(http.MethodGet, "/internal/songs", nil)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer invalid-token")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		mockAuthenticator.On("Authenticate", mock.Anything, "invalid-token").Return(nil, usecase.ErrInvalidIDToken).Once()
+
+		handler := middlewareFunc(func(c echo.Context) error {
+			return c.NoContent(http.StatusOK)
+		})
+
+		err := handler(c)
+
+		apiErr, ok := err.(*apierror.APIError)
+		require.True(t, ok)
+		assert.Equal(t, http.StatusUnauthorized, apiErr.HTTPStatus)
+		assert.Equal(t, apierror.CodeInvalidToken, apiErr.Code)
+		mockAuthenticator.AssertExpectations(t)
+	})
+}
+
 var _ middleware.FirebaseAuthenticator = (*mockFirebaseAuthenticator)(nil)

--- a/internal/app/middleware/firebase_auth_middleware_test.go
+++ b/internal/app/middleware/firebase_auth_middleware_test.go
@@ -30,6 +30,15 @@ func (m *mockFirebaseAuthenticator) Authenticate(ctx context.Context, idToken st
 	return nil, args.Error(1)
 }
 
+func (m *mockFirebaseAuthenticator) AuthenticateOptional(ctx context.Context, idToken string) (*entity.User, error) {
+	args := m.Called(ctx, idToken)
+	if user, ok := args.Get(0).(*entity.User); ok {
+		return user, args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
 func TestFirebaseIDTokenMiddleware(t *testing.T) {
 	e := echo.New()
 
@@ -271,7 +280,7 @@ func TestOptionalFirebaseIDTokenMiddleware(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		user := &entity.User{ID: 1}
-		mockAuthenticator.On("Authenticate", mock.Anything, "firebase-token").Return(user, nil).Once()
+		mockAuthenticator.On("AuthenticateOptional", mock.Anything, "firebase-token").Return(user, nil).Once()
 
 		handlerCalled := false
 		handler := middlewareFunc(func(c echo.Context) error {
@@ -279,6 +288,31 @@ func TestOptionalFirebaseIDTokenMiddleware(t *testing.T) {
 			storedUser, ok := c.Get("userEntity").(*entity.User)
 			require.True(t, ok)
 			assert.Same(t, user, storedUser)
+			return c.NoContent(http.StatusOK)
+		})
+
+		err := handler(c)
+
+		require.NoError(t, err)
+		assert.True(t, handlerCalled)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		mockAuthenticator.AssertExpectations(t)
+	})
+
+	t.Run("有効なトークンだが未登録ユーザーなら匿名で次のハンドラーを実行する", func(t *testing.T) {
+		mockAuthenticator := new(mockFirebaseAuthenticator)
+		middlewareFunc := middleware.OptionalFirebaseIDTokenMiddleware(mockAuthenticator)
+		req := httptest.NewRequest(http.MethodGet, "/internal/songs", nil)
+		req.Header.Set(echo.HeaderAuthorization, "Bearer unregistered-token")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		mockAuthenticator.On("AuthenticateOptional", mock.Anything, "unregistered-token").Return(nil, nil).Once()
+
+		handlerCalled := false
+		handler := middlewareFunc(func(c echo.Context) error {
+			handlerCalled = true
+			assert.Nil(t, c.Get("userEntity"))
 			return c.NoContent(http.StatusOK)
 		})
 
@@ -298,7 +332,7 @@ func TestOptionalFirebaseIDTokenMiddleware(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
-		mockAuthenticator.On("Authenticate", mock.Anything, "invalid-token").Return(nil, usecase.ErrInvalidIDToken).Once()
+		mockAuthenticator.On("AuthenticateOptional", mock.Anything, "invalid-token").Return(nil, usecase.ErrInvalidIDToken).Once()
 
 		handler := middlewareFunc(func(c echo.Context) error {
 			return c.NoContent(http.StatusOK)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -75,6 +75,7 @@ func (cv *CustomValidator) Validate(i any) error {
 type Handlers struct {
 	Auth                *api_internal.AuthHandler
 	Firebase            *api_internal.FirebaseHandler
+	Signup              *api_internal.SignupHandler
 	Recovery            *api_internal.RecoveryHandler
 	Profile             *api_internal.ProfileHandler
 	User                *api_internal.UserHandler
@@ -157,12 +158,14 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	firebaseLinkUsecase := usecase.NewFirebaseLinkUsecase(tm, userRepo, firebaseTokenVerifier)
 	firebaseLoginUsecase := usecase.NewFirebaseLoginUsecase(firebaseAuthUsecase, sessionIssuer)
 	firebaseRegisterUsecase := usecase.NewFirebaseRegisterUsecase(tm, userRepo, firebaseTokenVerifier, sessionIssuer)
+	signupUsecase := usecase.NewSignupUsecase(tm, userRepo, firebaseTokenVerifier, masterCache)
 	firebaseHandler := api_internal.NewFirebaseHandler(firebaseLinkUsecase, firebaseLoginUsecase, firebaseRegisterUsecase, cfg.Auth.CookieSecure, sameSite)
 	handlers := &Handlers{
 		Auth:                api_internal.NewAuthHandler(authUsecase, cfg.Auth.CookieSecure, sameSite),
 		Firebase:            firebaseHandler,
+		Signup:              api_internal.NewSignupHandler(signupUsecase),
 		Recovery:            api_internal.NewRecoveryHandler(recoveryUsecase),
-		Profile:             api_internal.NewProfileHandler(authUsecase, userCredentialUsecase, cfg.Auth.CookieSecure, sameSite),
+		Profile:             api_internal.NewProfileHandler(userCredentialUsecase),
 		User:                api_internal.NewUserHandler(userUsecase),
 		AdminUser:           api_internal.NewAdminUserHandler(userUsecase),
 		Song:                api_internal.NewSongHandler(songUsecase, chartStatsUsecase, masterCache, staticMasterCache),
@@ -197,19 +200,19 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	e.GET("/health", handleHealth(db), middleware.APITokenMiddleware(apiTokenUsecase), middleware.RequireRole(info.AccountTypeAdmin))
 
 	// ルートの登録
-	registerRoutes(e, handlers, authUsecase, apiTokenUsecase, cfg.JWTSecret, cfg)
+	registerRoutes(e, handlers, firebaseAuthUsecase, apiTokenUsecase, cfg)
 
 	return e
 }
 
 // registerRoutes はすべてのルートを登録します
-func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.Authenticator, apiTokenUsecase usecase.APITokenUsecase, secret string, cfg config.Config) {
+func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator middleware.FirebaseAuthenticator, apiTokenUsecase usecase.APITokenUsecase, cfg config.Config) {
 	// api.chunisupport.net/internal
 	internal := e.Group("/internal")
 
-	// JWT認証ミドルウェア
-	jwtAuth := middleware.JWTMiddleware(secret, authenticator)
-	optionalJWTAuth := middleware.OptionalJWTMiddleware(secret, authenticator)
+	// Firebase認証ミドルウェア
+	firebaseAuth := middleware.FirebaseIDTokenMiddleware(firebaseAuthenticator)
+	optionalFirebaseAuth := middleware.OptionalFirebaseIDTokenMiddleware(firebaseAuthenticator)
 	anonymousRateLimit := middleware.AnonymousIPRateLimitMiddleware(middleware.RateLimitConfig{
 		Requests: info.InternalPublicRateLimitRequests,
 		Window:   info.InternalPublicRateLimitWindow,
@@ -224,52 +227,27 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.A
 	// api.chunisupport.net/internal/auth
 	authGroup := internal.Group("/auth")
 	{
-		// ログイン: 1分間に10回まで
-		authGroup.POST("/login", handlers.Auth.Login, middleware.IPRateLimitMiddleware(middleware.RateLimitConfig{
-			Requests: info.LoginRateLimitRequests,
-			Window:   info.LoginRateLimitWindow,
-		}))
-		authGroup.POST("/firebase/login", handlers.Firebase.Login, middleware.IPRateLimitMiddleware(middleware.RateLimitConfig{
-			Requests: info.LoginRateLimitRequests,
-			Window:   info.LoginRateLimitWindow,
-		}))
-		// Firebase経由の新規登録: 1分間に5回まで
-		authGroup.POST("/firebase/register", handlers.Firebase.Register, middleware.IPRateLimitMiddleware(middleware.RateLimitConfig{
+		// Firebase経由の初回登録: 1分間に5回まで
+		authGroup.POST("/signup", handlers.Signup.Signup, middleware.IPRateLimitMiddleware(middleware.RateLimitConfig{
 			Requests: info.RegisterRateLimitRequests,
 			Window:   info.RegisterRateLimitWindow,
 		}))
-		authGroup.POST("/logout", handlers.Auth.Logout, jwtAuth)
-		// 登録: 1分間に5回まで
-		authGroup.POST("/register", handlers.Auth.Register, middleware.IPRateLimitMiddleware(middleware.RateLimitConfig{
-			Requests: info.RegisterRateLimitRequests,
-			Window:   info.RegisterRateLimitWindow,
-		}))
-		authGroup.POST("/recovery-codes", handlers.Recovery.RecoverPassword, middleware.IPRateLimitMiddleware(middleware.RateLimitConfig{
-			Requests: info.RecoveryCodeRateLimitRequests,
-			Window:   info.RecoveryCodeRateLimitWindow,
-		}))
-		authGroup.POST("/api-tokens", handlers.APIToken.Generate, jwtAuth)
-		authGroup.DELETE("/api-tokens", handlers.APIToken.Delete, jwtAuth)
+		authGroup.POST("/api-tokens", handlers.APIToken.Generate, firebaseAuth)
+		authGroup.DELETE("/api-tokens", handlers.APIToken.Delete, firebaseAuth)
 	}
 
 	// api.chunisupport.net/internal/me
 	meGroup := internal.Group("/me")
-	meGroup.Use(jwtAuth)
+	meGroup.Use(firebaseAuth)
 	{
 		meGroup.GET("", handlers.Profile.Me)
 		meGroup.PUT("/privacy", handlers.Profile.UpdatePrivacy)
-		meGroup.PUT("/password", handlers.Profile.ChangePassword)
-		meGroup.POST("/recovery-codes", handlers.Recovery.IssueRecoveryCodes)
 		meGroup.DELETE("", handlers.Profile.DeleteAccount)
 		meGroup.POST("/register-data", handlers.Me.RegisterData, middleware.UserRateLimitMiddleware(middleware.RateLimitConfig{
 			Requests: info.RegisterDataRateLimitRequests,
 			Window:   info.RegisterDataRateLimitWindow,
 		}))
 		meGroup.DELETE("/player-data", handlers.Me.DeletePlayerData)
-		meGroup.POST("/firebase/link", handlers.Firebase.Link)
-		// セッション管理
-		meGroup.GET("/sessions", handlers.Session.GetSessionCount)
-		meGroup.DELETE("/sessions", handlers.Session.LogoutOtherSessions)
 		meGroup.GET("/goals", handlers.Goal.List)
 		meGroup.POST("/goals", handlers.Goal.Create)
 		meGroup.PUT("/goals/:id", handlers.Goal.Update)
@@ -285,14 +263,14 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.A
 		Requests: info.TempDataRateLimitPerMin,
 		Window:   info.TempDataRateLimitWindow,
 	}))
-	temporaryPlayerDataGroup.POST("/commit", handlers.TemporaryPlayerData.CommitTemporaryData, jwtAuth, middleware.UserRateLimitMiddleware(middleware.RateLimitConfig{
+	temporaryPlayerDataGroup.POST("/commit", handlers.TemporaryPlayerData.CommitTemporaryData, firebaseAuth, middleware.UserRateLimitMiddleware(middleware.RateLimitConfig{
 		Requests: info.RegisterDataRateLimitRequests,
 		Window:   info.RegisterDataRateLimitWindow,
 	}))
 
 	// api.chunisupport.net/internal/users
 	publicUsersGroup := internal.Group("/users")
-	publicUsersGroup.Use(optionalJWTAuth, anonymousRateLimit)
+	publicUsersGroup.Use(optionalFirebaseAuth, anonymousRateLimit)
 	{
 		publicUsersGroup.GET("/:username/updated-at", handlers.User.GetUserUpdatedAt)
 		publicUsersGroup.GET("/:username/profile", handlers.User.GetUserProfile)
@@ -300,7 +278,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.A
 	}
 
 	usersGroup := internal.Group("/users")
-	usersGroup.Use(jwtAuth)
+	usersGroup.Use(firebaseAuth)
 	{
 		usersGroup.GET("/", handlers.AdminUser.GetAllUsers, requireAdmin)
 		usersGroup.DELETE("/:username", handlers.User.DeleteUser, requireAdmin)
@@ -308,7 +286,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.A
 
 	// api.chunisupport.net/internal/songs
 	publicSongsGroup := internal.Group("/songs")
-	publicSongsGroup.Use(optionalJWTAuth, anonymousRateLimit)
+	publicSongsGroup.Use(optionalFirebaseAuth, anonymousRateLimit)
 	{
 		publicSongsGroup.GET("/updated-at", handlers.Song.GetSongsUpdatedAt)
 		publicSongsGroup.GET("", handlers.Song.GetSongs)
@@ -324,7 +302,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.A
 	}
 
 	songsGroup := internal.Group("/songs")
-	songsGroup.Use(jwtAuth)
+	songsGroup.Use(firebaseAuth)
 	{
 		songsGroup.PUT("", handlers.Song.UpdateSongs, requireEditor)
 		songsGroup.DELETE("/:displayid", handlers.Song.DeleteSong, requireEditor)
@@ -340,7 +318,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.A
 	}
 
 	editorSongsGroup := internal.Group("/editor/songs")
-	editorSongsGroup.Use(jwtAuth, requireEditor)
+	editorSongsGroup.Use(firebaseAuth, requireEditor)
 	{
 		editorSongsGroup.GET("", handlers.Song.GetEditorSongs)
 		editorSongsGroup.GET("/:displayid", handlers.Song.GetEditorSong)
@@ -350,7 +328,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, authenticator middleware.A
 
 	// api.chunisupport.net/internal/master
 	masterGroup := internal.Group("/master")
-	masterGroup.Use(jwtAuth)
+	masterGroup.Use(firebaseAuth)
 	{
 		masterGroup.GET("", handlers.MasterData.GetMasterData)
 	}

--- a/internal/usecase/auth_usecase_test_helper_test.go
+++ b/internal/usecase/auth_usecase_test_helper_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/info"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -13,9 +14,9 @@ import (
 func newMockMasterCache() AccountTypeProvider {
 	return &stubAccountTypeProvider{
 		nameByID: map[int]string{
-			1: "PLAYER",
-			2: "EDITOR",
-			3: "ADMIN",
+			info.AccountTypePlayer: "PLAYER",
+			info.AccountTypeEditor: "EDITOR",
+			info.AccountTypeAdmin:  "ADMIN",
 		},
 	}
 }

--- a/internal/usecase/firebase_auth_usecase.go
+++ b/internal/usecase/firebase_auth_usecase.go
@@ -20,6 +20,8 @@ type TokenVerifier interface {
 type FirebaseAuthUsecase interface {
 	// Authenticate はFirebase IDトークンを検証し、紐づく有効ユーザーを返します。
 	Authenticate(ctx context.Context, idToken string) (*entity.User, error)
+	// AuthenticateOptional はFirebase IDトークンを検証し、未登録ユーザーなら匿名扱いにします。
+	AuthenticateOptional(ctx context.Context, idToken string) (*entity.User, error)
 }
 
 type firebaseAuthUsecase struct {
@@ -39,6 +41,15 @@ func NewFirebaseAuthUsecase(db repository.Executor, userRepo repository.UserRepo
 
 // Authenticate はFirebase IDトークンを検証し、紐づくユーザーを返します。
 func (u *firebaseAuthUsecase) Authenticate(ctx context.Context, idToken string) (*entity.User, error) {
+	return u.authenticate(ctx, idToken, false)
+}
+
+// AuthenticateOptional はFirebase IDトークンを検証し、未登録ユーザーなら匿名扱いにします。
+func (u *firebaseAuthUsecase) AuthenticateOptional(ctx context.Context, idToken string) (*entity.User, error) {
+	return u.authenticate(ctx, idToken, true)
+}
+
+func (u *firebaseAuthUsecase) authenticate(ctx context.Context, idToken string, allowMissingUser bool) (*entity.User, error) {
 	idToken = strings.TrimSpace(idToken)
 	if idToken == "" {
 		return nil, ErrInvalidIDToken
@@ -68,6 +79,10 @@ func (u *firebaseAuthUsecase) Authenticate(ctx context.Context, idToken string) 
 	user, err := u.userRepo.FindByFirebaseUID(ctx, u.db, uid)
 	if err != nil {
 		if errors.Is(err, repository.ErrUserNotFound) {
+			if allowMissingUser {
+				return nil, nil
+			}
+
 			return nil, ErrInvalidIDToken
 		}
 

--- a/internal/usecase/firebase_auth_usecase_test.go
+++ b/internal/usecase/firebase_auth_usecase_test.go
@@ -177,6 +177,75 @@ func TestFirebaseAuthUsecase_Authenticate(t *testing.T) {
 	}
 }
 
+func TestFirebaseAuthUsecase_AuthenticateOptional(t *testing.T) {
+	tests := []struct {
+		name        string
+		idToken     string
+		setup       func(verifier *mockTokenVerifier, userRepo *MockUserRepository)
+		wantUser    *entity.User
+		wantNilUser bool
+		wantErr     error
+	}{
+		{
+			name:    "有効なIDトークンでユーザーが存在すればユーザーを返す",
+			idToken: "valid-token",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				user := &entity.User{ID: 10}
+				verifier.On("VerifyIDToken", mock.Anything, "valid-token").Return("firebase-uid", nil).Once()
+				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(user, nil).Once()
+			},
+			wantUser: &entity.User{ID: 10},
+		},
+		{
+			name:    "有効なIDトークンでも未登録ユーザーなら匿名扱いにする",
+			idToken: "missing-user-token",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				verifier.On("VerifyIDToken", mock.Anything, "missing-user-token").Return("firebase-uid", nil).Once()
+				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
+			},
+			wantNilUser: true,
+		},
+		{
+			name:    "不正なIDトークンならErrInvalidIDTokenを返す",
+			idToken: "invalid-token",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				verifier.On("VerifyIDToken", mock.Anything, "invalid-token").Return("", errors.Join(ErrInvalidIDToken, errors.New("verify failed"))).Once()
+			},
+			wantErr: ErrInvalidIDToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			verifier := new(mockTokenVerifier)
+			userRepo := new(MockUserRepository)
+			service := NewFirebaseAuthUsecase(nil, userRepo, verifier)
+			tt.setup(verifier, userRepo)
+
+			// When
+			gotUser, err := service.AuthenticateOptional(context.Background(), tt.idToken)
+
+			// Then
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, gotUser)
+			} else if tt.wantNilUser {
+				require.NoError(t, err)
+				assert.Nil(t, gotUser)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, gotUser)
+				assert.Equal(t, tt.wantUser.ID, gotUser.ID)
+			}
+
+			verifier.AssertExpectations(t)
+			userRepo.AssertExpectations(t)
+		})
+	}
+}
+
 func TestFirebaseAuthUsecase_Authenticate_TokenVerifierがnilの場合はErrInternalErrorを返す(t *testing.T) {
 	// Given
 	userRepo := new(MockUserRepository)

--- a/internal/usecase/firebase_login_usecase_test.go
+++ b/internal/usecase/firebase_login_usecase_test.go
@@ -22,6 +22,14 @@ func (m *mockFirebaseAuthUsecase) Authenticate(ctx context.Context, idToken stri
 	return args.Get(0).(*entity.User), args.Error(1)
 }
 
+func (m *mockFirebaseAuthUsecase) AuthenticateOptional(ctx context.Context, idToken string) (*entity.User, error) {
+	args := m.Called(ctx, idToken)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*entity.User), args.Error(1)
+}
+
 type mockSessionIssuer struct {
 	mock.Mock
 }

--- a/internal/usecase/firebase_register_usecase.go
+++ b/internal/usecase/firebase_register_usecase.go
@@ -71,20 +71,6 @@ func (u *firebaseRegisterUsecase) RegisterWithFirebase(ctx context.Context, idTo
 
 	var newUser *entity.User
 	if err := u.tm.Transactional(ctx, func(tx repository.Executor) error {
-		// Firebase UID が既存ユーザーに紐付いていないか確認
-		if _, err := u.userRepo.FindByFirebaseUID(ctx, tx, uid); err == nil {
-			return ErrFirebaseUIDAlreadyLinked
-		} else if !errors.Is(err, repository.ErrUserNotFound) {
-			return err
-		}
-
-		// ユーザー名が使用済みでないか確認
-		if _, err := u.userRepo.FindByUsername(ctx, tx, un.String()); err == nil {
-			return ErrUsernameTaken
-		} else if !errors.Is(err, repository.ErrUserNotFound) {
-			return err
-		}
-
 		newUser = entity.NewFirebaseUser(un, uid, info.AccountTypePlayer)
 		if err := u.userRepo.Save(ctx, tx, newUser); err != nil {
 			if errors.Is(err, repository.ErrDuplicateUsername) {

--- a/internal/usecase/firebase_register_usecase_test.go
+++ b/internal/usecase/firebase_register_usecase_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -28,8 +27,6 @@ func TestFirebaseRegisterUsecase_RegisterWithFirebase(t *testing.T) {
 			username: "newuser",
 			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.On("VerifyIDToken", mock.Anything, "valid-token").Return("firebase-uid", nil).Once()
-				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
-				userRepo.On("FindByUsername", mock.Anything, mock.Anything, "newuser").Return(nil, repository.ErrUserNotFound).Once()
 				userRepo.On("Save", mock.Anything, mock.Anything, mock.AnythingOfType("*entity.User")).Return(nil).Once()
 				sessionIssuer.On("IssueSession", mock.Anything, mock.AnythingOfType("*entity.User")).Return("jwt-token", nil).Once()
 			},
@@ -49,6 +46,7 @@ func TestFirebaseRegisterUsecase_RegisterWithFirebase(t *testing.T) {
 			wantErr: ErrInvalidIDToken,
 			assertAfter: func(t *testing.T, verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.AssertNotCalled(t, "VerifyIDToken", mock.Anything, mock.Anything)
+				userRepo.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -61,7 +59,7 @@ func TestFirebaseRegisterUsecase_RegisterWithFirebase(t *testing.T) {
 			wantErr: ErrInvalidIDToken,
 			assertAfter: func(t *testing.T, verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.AssertExpectations(t)
-				userRepo.AssertNotCalled(t, "FindByFirebaseUID", mock.Anything, mock.Anything, mock.Anything)
+				userRepo.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -70,13 +68,13 @@ func TestFirebaseRegisterUsecase_RegisterWithFirebase(t *testing.T) {
 			username: "newuser",
 			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.On("VerifyIDToken", mock.Anything, "linked-token").Return("existing-uid", nil).Once()
-				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "existing-uid").Return(&entity.User{ID: 99}, nil).Once()
+				userRepo.On("Save", mock.Anything, mock.Anything, mock.AnythingOfType("*entity.User")).Return(repository.ErrFirebaseUIDAlreadyLinked).Once()
 			},
 			wantErr: ErrFirebaseUIDAlreadyLinked,
 			assertAfter: func(t *testing.T, verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.AssertExpectations(t)
 				userRepo.AssertExpectations(t)
-				userRepo.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
+				sessionIssuer.AssertNotCalled(t, "IssueSession", mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -85,14 +83,13 @@ func TestFirebaseRegisterUsecase_RegisterWithFirebase(t *testing.T) {
 			username: "takenuser",
 			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.On("VerifyIDToken", mock.Anything, "valid-token").Return("firebase-uid", nil).Once()
-				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
-				userRepo.On("FindByUsername", mock.Anything, mock.Anything, "takenuser").Return(&entity.User{ID: 10}, nil).Once()
+				userRepo.On("Save", mock.Anything, mock.Anything, mock.AnythingOfType("*entity.User")).Return(repository.ErrDuplicateUsername).Once()
 			},
 			wantErr: ErrUsernameTaken,
 			assertAfter: func(t *testing.T, verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.AssertExpectations(t)
 				userRepo.AssertExpectations(t)
-				userRepo.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
+				sessionIssuer.AssertNotCalled(t, "IssueSession", mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -105,7 +102,7 @@ func TestFirebaseRegisterUsecase_RegisterWithFirebase(t *testing.T) {
 			wantErr: ErrUsernameTooShort,
 			assertAfter: func(t *testing.T, verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.AssertExpectations(t)
-				userRepo.AssertNotCalled(t, "FindByFirebaseUID", mock.Anything, mock.Anything, mock.Anything)
+				userRepo.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		{
@@ -114,8 +111,6 @@ func TestFirebaseRegisterUsecase_RegisterWithFirebase(t *testing.T) {
 			username: "newuser",
 			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository, sessionIssuer *authMockSessionIssuer) {
 				verifier.On("VerifyIDToken", mock.Anything, "valid-token").Return("firebase-uid", nil).Once()
-				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
-				userRepo.On("FindByUsername", mock.Anything, mock.Anything, "newuser").Return(nil, repository.ErrUserNotFound).Once()
 				userRepo.On("Save", mock.Anything, mock.Anything, mock.AnythingOfType("*entity.User")).Return(repository.ErrFirebaseUIDAlreadyLinked).Once()
 			},
 			wantErr: ErrFirebaseUIDAlreadyLinked,
@@ -152,6 +147,9 @@ func TestFirebaseRegisterUsecase_RegisterWithFirebase(t *testing.T) {
 			if tt.assertAfter != nil {
 				tt.assertAfter(t, verifier, userRepo, sessionIssuer)
 			}
+
+			userRepo.AssertNotCalled(t, "FindByFirebaseUID", mock.Anything, mock.Anything, mock.Anything)
+			userRepo.AssertNotCalled(t, "FindByUsername", mock.Anything, mock.Anything, mock.Anything)
 		})
 	}
 }

--- a/internal/usecase/signup_usecase.go
+++ b/internal/usecase/signup_usecase.go
@@ -82,18 +82,6 @@ func (u *signupUsecase) Signup(ctx context.Context, idToken string, usernameStr 
 
 	var newUser *entity.User
 	if err := u.tm.Transactional(ctx, func(tx repository.Executor) error {
-		if _, err := u.userRepo.FindByFirebaseUID(ctx, tx, uid); err == nil {
-			return ErrFirebaseUIDAlreadyLinked
-		} else if !errors.Is(err, repository.ErrUserNotFound) {
-			return err
-		}
-
-		if _, err := u.userRepo.FindByUsername(ctx, tx, un.String()); err == nil {
-			return ErrUsernameTaken
-		} else if !errors.Is(err, repository.ErrUserNotFound) {
-			return err
-		}
-
 		newUser = entity.NewFirebaseUser(un, uid, info.AccountTypePlayer)
 		if err := u.userRepo.Save(ctx, tx, newUser); err != nil {
 			if errors.Is(err, repository.ErrDuplicateUsername) {

--- a/internal/usecase/signup_usecase.go
+++ b/internal/usecase/signup_usecase.go
@@ -1,0 +1,117 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/username"
+	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
+	"github.com/chunisupport/chunisupport-api/internal/info"
+)
+
+// SignupUsecase はFirebase Bearerトークンを用いた初回ユーザー作成を扱います。
+type SignupUsecase interface {
+	// Signup はFirebase IDトークンとユーザー名でアプリ内ユーザーを作成します。
+	Signup(ctx context.Context, idToken string, usernameStr string) (*dto_internal.UserDTO, error)
+}
+
+type signupUsecase struct {
+	tm                  TransactionManager
+	userRepo            repository.UserRepository
+	tokenVerifier       TokenVerifier
+	accountTypeProvider AccountTypeProvider
+}
+
+// NewSignupUsecase は signup 用ユースケースを生成します。
+func NewSignupUsecase(
+	tm TransactionManager,
+	userRepo repository.UserRepository,
+	tokenVerifier TokenVerifier,
+	accountTypeProvider AccountTypeProvider,
+) SignupUsecase {
+	if tm == nil {
+		panic("signupUsecase: TransactionManager is nil")
+	}
+	if userRepo == nil {
+		panic("signupUsecase: UserRepository is nil")
+	}
+	if tokenVerifier == nil {
+		panic("signupUsecase: TokenVerifier is nil")
+	}
+	if accountTypeProvider == nil {
+		panic("signupUsecase: AccountTypeProvider is nil")
+	}
+
+	return &signupUsecase{
+		tm:                  tm,
+		userRepo:            userRepo,
+		tokenVerifier:       tokenVerifier,
+		accountTypeProvider: accountTypeProvider,
+	}
+}
+
+func (u *signupUsecase) Signup(ctx context.Context, idToken string, usernameStr string) (*dto_internal.UserDTO, error) {
+	idToken = strings.TrimSpace(idToken)
+	if idToken == "" {
+		return nil, ErrInvalidIDToken
+	}
+
+	uid, err := u.tokenVerifier.VerifyIDToken(ctx, idToken)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidIDToken):
+			return nil, err
+		case errors.Is(err, ErrInternalError):
+			return nil, err
+		default:
+			return nil, errors.Join(ErrInternalError, err)
+		}
+	}
+	uid = strings.TrimSpace(uid)
+	if uid == "" {
+		return nil, errors.Join(ErrInternalError, errors.New("firebase uid is empty"))
+	}
+
+	un, err := username.NewUserName(usernameStr)
+	if err != nil {
+		return nil, convertUsernameError(err)
+	}
+
+	var newUser *entity.User
+	if err := u.tm.Transactional(ctx, func(tx repository.Executor) error {
+		if _, err := u.userRepo.FindByFirebaseUID(ctx, tx, uid); err == nil {
+			return ErrFirebaseUIDAlreadyLinked
+		} else if !errors.Is(err, repository.ErrUserNotFound) {
+			return err
+		}
+
+		if _, err := u.userRepo.FindByUsername(ctx, tx, un.String()); err == nil {
+			return ErrUsernameTaken
+		} else if !errors.Is(err, repository.ErrUserNotFound) {
+			return err
+		}
+
+		newUser = entity.NewFirebaseUser(un, uid, info.AccountTypePlayer)
+		if err := u.userRepo.Save(ctx, tx, newUser); err != nil {
+			if errors.Is(err, repository.ErrDuplicateUsername) {
+				return ErrUsernameTaken
+			}
+			if errors.Is(err, repository.ErrFirebaseUIDAlreadyLinked) {
+				return ErrFirebaseUIDAlreadyLinked
+			}
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	accountTypeName := u.accountTypeProvider.GetAccountTypeNameByID(newUser.AccountTypeID)
+	return dto_internal.ToUserDTO(newUser, accountTypeName, newUser.IsPrivate, nil), nil
+}
+
+var _ SignupUsecase = (*signupUsecase)(nil)

--- a/internal/usecase/signup_usecase_test.go
+++ b/internal/usecase/signup_usecase_test.go
@@ -28,8 +28,6 @@ func TestSignupUsecase_Signup(t *testing.T) {
 			username: "newuser",
 			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
 				verifier.On("VerifyIDToken", mock.Anything, "valid-token").Return("firebase-uid", nil).Once()
-				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
-				userRepo.On("FindByUsername", mock.Anything, mock.Anything, "newuser").Return(nil, repository.ErrUserNotFound).Once()
 				userRepo.On("Save", mock.Anything, mock.Anything, mock.MatchedBy(func(user *entity.User) bool {
 					user.ID = 99
 					return user.Username.String() == "newuser" && user.FirebaseUID != nil && *user.FirebaseUID == "firebase-uid"
@@ -59,7 +57,7 @@ func TestSignupUsecase_Signup(t *testing.T) {
 			username: "newuser",
 			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
 				verifier.On("VerifyIDToken", mock.Anything, "linked-token").Return("firebase-uid", nil).Once()
-				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(&entity.User{ID: 10}, nil).Once()
+				userRepo.On("Save", mock.Anything, mock.Anything, mock.AnythingOfType("*entity.User")).Return(repository.ErrFirebaseUIDAlreadyLinked).Once()
 			},
 			wantErr: ErrFirebaseUIDAlreadyLinked,
 		},
@@ -69,8 +67,7 @@ func TestSignupUsecase_Signup(t *testing.T) {
 			username: "newuser",
 			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
 				verifier.On("VerifyIDToken", mock.Anything, "valid-token").Return("firebase-uid", nil).Once()
-				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
-				userRepo.On("FindByUsername", mock.Anything, mock.Anything, "newuser").Return(&entity.User{ID: 1}, nil).Once()
+				userRepo.On("Save", mock.Anything, mock.Anything, mock.AnythingOfType("*entity.User")).Return(repository.ErrDuplicateUsername).Once()
 			},
 			wantErr: ErrUsernameTaken,
 		},
@@ -120,6 +117,8 @@ func TestSignupUsecase_Signup(t *testing.T) {
 
 			verifier.AssertExpectations(t)
 			userRepo.AssertExpectations(t)
+			userRepo.AssertNotCalled(t, "FindByFirebaseUID", mock.Anything, mock.Anything, mock.Anything)
+			userRepo.AssertNotCalled(t, "FindByUsername", mock.Anything, mock.Anything, mock.Anything)
 		})
 	}
 }

--- a/internal/usecase/signup_usecase_test.go
+++ b/internal/usecase/signup_usecase_test.go
@@ -1,0 +1,125 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignupUsecase_Signup(t *testing.T) {
+	tests := []struct {
+		name        string
+		idToken     string
+		username    string
+		setup       func(verifier *mockTokenVerifier, userRepo *MockUserRepository)
+		wantUser    string
+		wantErr     error
+		wantErrText string
+	}{
+		{
+			name:     "有効なFirebaseトークンならユーザーを作成してDTOを返す",
+			idToken:  "valid-token",
+			username: "newuser",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				verifier.On("VerifyIDToken", mock.Anything, "valid-token").Return("firebase-uid", nil).Once()
+				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
+				userRepo.On("FindByUsername", mock.Anything, mock.Anything, "newuser").Return(nil, repository.ErrUserNotFound).Once()
+				userRepo.On("Save", mock.Anything, mock.Anything, mock.MatchedBy(func(user *entity.User) bool {
+					user.ID = 99
+					return user.Username.String() == "newuser" && user.FirebaseUID != nil && *user.FirebaseUID == "firebase-uid"
+				})).Return(nil).Once()
+			},
+			wantUser: "newuser",
+		},
+		{
+			name:     "空のIDトークンはErrInvalidIDTokenを返す",
+			idToken:  "  ",
+			username: "newuser",
+			setup:    func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {},
+			wantErr:  ErrInvalidIDToken,
+		},
+		{
+			name:     "無効なIDトークンはErrInvalidIDTokenを返す",
+			idToken:  "invalid-token",
+			username: "newuser",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				verifier.On("VerifyIDToken", mock.Anything, "invalid-token").Return("", errors.Join(ErrInvalidIDToken, errors.New("invalid token"))).Once()
+			},
+			wantErr: ErrInvalidIDToken,
+		},
+		{
+			name:     "Firebase UIDが既存ユーザーに紐付いていればErrFirebaseUIDAlreadyLinkedを返す",
+			idToken:  "linked-token",
+			username: "newuser",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				verifier.On("VerifyIDToken", mock.Anything, "linked-token").Return("firebase-uid", nil).Once()
+				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(&entity.User{ID: 10}, nil).Once()
+			},
+			wantErr: ErrFirebaseUIDAlreadyLinked,
+		},
+		{
+			name:     "ユーザー名が既に使われていればErrUsernameTakenを返す",
+			idToken:  "valid-token",
+			username: "newuser",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				verifier.On("VerifyIDToken", mock.Anything, "valid-token").Return("firebase-uid", nil).Once()
+				userRepo.On("FindByFirebaseUID", mock.Anything, mock.Anything, "firebase-uid").Return(nil, repository.ErrUserNotFound).Once()
+				userRepo.On("FindByUsername", mock.Anything, mock.Anything, "newuser").Return(&entity.User{ID: 1}, nil).Once()
+			},
+			wantErr: ErrUsernameTaken,
+		},
+		{
+			name:     "空のFirebase UIDはErrInternalErrorを返す",
+			idToken:  "empty-uid-token",
+			username: "newuser",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				verifier.On("VerifyIDToken", mock.Anything, "empty-uid-token").Return("   ", nil).Once()
+			},
+			wantErr: ErrInternalError,
+		},
+		{
+			name:     "想定外の検証失敗はErrInternalErrorにまとめる",
+			idToken:  "error-token",
+			username: "newuser",
+			setup: func(verifier *mockTokenVerifier, userRepo *MockUserRepository) {
+				verifier.On("VerifyIDToken", mock.Anything, "error-token").Return("", errors.New("boom")).Once()
+			},
+			wantErr: ErrInternalError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verifier := new(mockTokenVerifier)
+			userRepo := new(MockUserRepository)
+			service := NewSignupUsecase(&mockTransactionManager{}, userRepo, verifier, newMockMasterCache())
+			tt.setup(verifier, userRepo)
+
+			got, err := service.Signup(context.Background(), tt.idToken, tt.username)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, got)
+			} else if tt.wantErrText != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrText)
+				assert.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				assert.Equal(t, tt.wantUser, got.Username)
+				assert.Equal(t, "PLAYER", got.AccountType)
+			}
+
+			verifier.AssertExpectations(t)
+			userRepo.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
feat: SignupHandlerを追加し、Firebase IDトークンによるユーザー作成を処理
feat: SignupUsecaseを追加し、Firebaseトークンを検証してユーザーを作成
test: SignupHandlerおよびSignupUsecaseのテストを追加
docs: Firebase Authへの完全移行計画書を作成

注：不要になったコードの削除、アカウント削除前の再認証などは別途対応します。