### PR TITLE
Remove slot_id and slot_order from full-record change detection

### DIFF
--- a/internal/infra/repository/player_data_repository_impl.go
+++ b/internal/infra/repository/player_data_repository_impl.go
@@ -227,9 +227,7 @@ const (
 	fullRecordChangedCondition = "score <> VALUES(score) OR " +
 		"clear_lamp_id <> VALUES(clear_lamp_id) OR " +
 		"combo_lamp_id <> VALUES(combo_lamp_id) OR " +
-		"full_chain_id <> VALUES(full_chain_id) OR " +
-		"slot_id <> VALUES(slot_id) OR " +
-		"NOT (slot_order <=> VALUES(slot_order))"
+		"full_chain_id <> VALUES(full_chain_id)"
 
 	worldsendRecordChangedCondition = "score <> VALUES(score) OR " +
 		"clear_lamp_id <> VALUES(clear_lamp_id) OR " +

--- a/internal/infra/repository/player_data_repository_impl_test.go
+++ b/internal/infra/repository/player_data_repository_impl_test.go
@@ -212,7 +212,7 @@ func TestSavePlayerData_execがnilならエラーを返す(t *testing.T) {
 
 func TestFullRecordChangedCondition_比較対象カラムを過不足なく含む(t *testing.T) {
 	// Given
-	expected := "score <> VALUES(score) OR clear_lamp_id <> VALUES(clear_lamp_id) OR combo_lamp_id <> VALUES(combo_lamp_id) OR full_chain_id <> VALUES(full_chain_id) OR slot_id <> VALUES(slot_id) OR NOT (slot_order <=> VALUES(slot_order))"
+	expected := "score <> VALUES(score) OR clear_lamp_id <> VALUES(clear_lamp_id) OR combo_lamp_id <> VALUES(combo_lamp_id) OR full_chain_id <> VALUES(full_chain_id)"
 
 	// When
 	got := fullRecordChangedCondition


### PR DESCRIPTION
### Motivation

- Simplify the change detection logic for full player records by excluding slot tracking fields from the comparison so that updates are triggered only by gameplay-related columns.

### Description

- Removed `slot_id` and the `NOT (slot_order <=> VALUES(slot_order))` comparison from the `fullRecordChangedCondition` string constant.
- Left the `worldsendRecordChangedCondition` unchanged so worldsend behavior remains the same.
- Updated the test `TestFullRecordChangedCondition_比較対象カラムを過不足なく含む` to expect the new `fullRecordChangedCondition` value.
- Kept the upsert query template (`fullRecordUpsertQuery`) using the `{{CHANGED_CONDITION}}` placeholder so the updated condition is applied when composing the query.

### Testing

- Ran unit tests including `TestFullRecordChangedCondition_比較対象カラムを過不足なく含む`, `TestWorldsendRecordChangedCondition_比較対象カラムを過不足なく含む`, and `TestFullRecordUpsertQuery_updatedAtの評価が比較対象更新より先に行われる` via `go test ./...` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f609c44458832d9ed3fddf74309a63)