### PR TITLE
Recalculate player overpower on lock/unlock and extend PlayerLockedSongUsecase dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
       - name: Test
         run: go test ./...
       - name: Install and run govulncheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chunisupport/chunisupport-api
 
-go 1.26.2
+go 1.26.3
 
 require (
 	firebase.google.com/go/v4 v4.19.0

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -136,7 +136,10 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	playerLockedSongRepo := infra.NewPlayerLockedSongRepository()
 	playerLockedSongQueryService := infra.NewPlayerLockedSongQueryService()
 	playerSongIDResolver := infra.NewPlayerSongIDResolver()
-	playerLockedSongUsecase := usecase.NewPlayerLockedSongUsecase(db, tm, userRepo, playerRepo, playerRecordRepo, playerDataRepo, songRepo, playerLockedSongRepo, playerLockedSongQueryService, playerSongIDResolver)
+	playerLockedSongUsecase, err := usecase.NewPlayerLockedSongUsecase(db, tm, userRepo, playerRepo, playerRecordRepo, playerDataRepo, songRepo, playerLockedSongRepo, playerLockedSongQueryService, playerSongIDResolver)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create player locked song usecase: %v", err))
+	}
 	masterDataUsecase := usecase.NewMasterDataUsecase(masterCache, chartStatsMasterProvider)
 
 	// DI - Handlers

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -136,7 +136,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	playerLockedSongRepo := infra.NewPlayerLockedSongRepository()
 	playerLockedSongQueryService := infra.NewPlayerLockedSongQueryService()
 	playerSongIDResolver := infra.NewPlayerSongIDResolver()
-	playerLockedSongUsecase := usecase.NewPlayerLockedSongUsecase(db, userRepo, playerRepo, playerRecordRepo, playerDataRepo, songRepo, playerLockedSongRepo, playerLockedSongQueryService, playerSongIDResolver)
+	playerLockedSongUsecase := usecase.NewPlayerLockedSongUsecase(db, tm, userRepo, playerRepo, playerRecordRepo, playerDataRepo, songRepo, playerLockedSongRepo, playerLockedSongQueryService, playerSongIDResolver)
 	masterDataUsecase := usecase.NewMasterDataUsecase(masterCache, chartStatsMasterProvider)
 
 	// DI - Handlers

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -136,7 +136,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	playerLockedSongRepo := infra.NewPlayerLockedSongRepository()
 	playerLockedSongQueryService := infra.NewPlayerLockedSongQueryService()
 	playerSongIDResolver := infra.NewPlayerSongIDResolver()
-	playerLockedSongUsecase := usecase.NewPlayerLockedSongUsecase(db, userRepo, playerRepo, songRepo, playerLockedSongRepo, playerLockedSongQueryService, playerSongIDResolver)
+	playerLockedSongUsecase := usecase.NewPlayerLockedSongUsecase(db, userRepo, playerRepo, playerRecordRepo, playerDataRepo, songRepo, playerLockedSongRepo, playerLockedSongQueryService, playerSongIDResolver)
 	masterDataUsecase := usecase.NewMasterDataUsecase(masterCache, chartStatsMasterProvider)
 
 	// DI - Handlers

--- a/internal/info/statistics.go
+++ b/internal/info/statistics.go
@@ -3,6 +3,9 @@ package info
 import "strings"
 
 const (
+	// DifficultyNameUltima は内部で扱うULTIMA難易度名です。
+	DifficultyNameUltima = "ULTIMA"
+
 	// StatsDifficultyWorldsend はWORLD'S END譜面を表す難易度名です。
 	// 通常の難易度（BASIC, ADVANCED, EXPERT, MASTER, ULTIMA）と異なり、
 	// WORLD'S ENDは専用のマスタデータが存在しないため、定数として定義しています。
@@ -29,7 +32,7 @@ var difficultyPathToName = map[string]string{
 	string(DifficultyPathAdvanced):  "ADVANCED",
 	string(DifficultyPathExpert):    "EXPERT",
 	string(DifficultyPathMaster):    "MASTER",
-	string(DifficultyPathUltima):    "ULTIMA",
+	string(DifficultyPathUltima):    DifficultyNameUltima,
 	string(DifficultyPathWorldsend): StatsDifficultyWorldsend,
 }
 

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -11,7 +11,11 @@ import (
 	domainservice "github.com/chunisupport/chunisupport-api/internal/domain/service"
 )
 
-var errPlayerLockedSongInputRequired = errors.New("input is required")
+var (
+	errPlayerLockedSongInputRequired = errors.New("input is required")
+	errPlayerLockedSongNilDB         = errors.New("database executor is nil")
+	errPlayerLockedSongNilTM         = errors.New("transaction manager is nil")
+)
 
 type playerLockedSongUsecase struct {
 	db             repository.Executor
@@ -26,8 +30,14 @@ type playerLockedSongUsecase struct {
 	resolver       PlayerSongIDResolver
 }
 
-func NewPlayerLockedSongUsecase(db repository.Executor, tm TransactionManager, userRepo repository.UserRepository, playerRepo repository.PlayerRepository, playerRecRepo repository.PlayerRecordRepository, playerDataRepo repository.PlayerDataRepository, songRepo repository.SongRepository, lockedRepo repository.PlayerLockedSongRepository, queryService PlayerLockedSongQueryService, resolver PlayerSongIDResolver) PlayerLockedSongUsecase {
-	return &playerLockedSongUsecase{db: db, tm: tm, userRepo: userRepo, playerRepo: playerRepo, playerRecRepo: playerRecRepo, playerDataRepo: playerDataRepo, songRepo: songRepo, lockedRepo: lockedRepo, queryService: queryService, resolver: resolver}
+func NewPlayerLockedSongUsecase(db repository.Executor, tm TransactionManager, userRepo repository.UserRepository, playerRepo repository.PlayerRepository, playerRecRepo repository.PlayerRecordRepository, playerDataRepo repository.PlayerDataRepository, songRepo repository.SongRepository, lockedRepo repository.PlayerLockedSongRepository, queryService PlayerLockedSongQueryService, resolver PlayerSongIDResolver) (PlayerLockedSongUsecase, error) {
+	if db == nil {
+		return nil, errPlayerLockedSongNilDB
+	}
+	if tm == nil {
+		return nil, errPlayerLockedSongNilTM
+	}
+	return &playerLockedSongUsecase{db: db, tm: tm, userRepo: userRepo, playerRepo: playerRepo, playerRecRepo: playerRecRepo, playerDataRepo: playerDataRepo, songRepo: songRepo, lockedRepo: lockedRepo, queryService: queryService, resolver: resolver}, nil
 }
 
 func (u *playerLockedSongUsecase) List(ctx context.Context, username string, requester *entity.User) ([]*PlayerLockedSongOutput, error) {
@@ -67,6 +77,9 @@ func (u *playerLockedSongUsecase) Lock(ctx context.Context, userID int, input *P
 	if input == nil {
 		return errPlayerLockedSongInputRequired
 	}
+	if u.tm == nil {
+		return errPlayerLockedSongNilTM
+	}
 	player, err := u.playerRepo.FindByUserID(ctx, u.db, userID)
 	if err != nil {
 		return err
@@ -105,6 +118,9 @@ func (u *playerLockedSongUsecase) Unlock(ctx context.Context, userID int, input 
 	if input == nil {
 		return errPlayerLockedSongInputRequired
 	}
+	if u.tm == nil {
+		return errPlayerLockedSongNilTM
+	}
 	player, err := u.playerRepo.FindByUserID(ctx, u.db, userID)
 	if err != nil {
 		return err
@@ -125,10 +141,6 @@ func (u *playerLockedSongUsecase) Unlock(ctx context.Context, userID int, input 
 		}
 		return u.recalculatePlayerOverpowerWithTx(ctx, tx, player)
 	})
-}
-
-func (u *playerLockedSongUsecase) recalculatePlayerOverpower(ctx context.Context, player *entity.Player) error {
-	return u.recalculatePlayerOverpowerWithTx(ctx, u.db, player)
 }
 
 func (u *playerLockedSongUsecase) recalculatePlayerOverpowerWithTx(ctx context.Context, exec repository.Executor, player *entity.Player) error {

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	domainservice "github.com/chunisupport/chunisupport-api/internal/domain/service"
+	"github.com/chunisupport/chunisupport-api/internal/info"
 )
 
 var (
@@ -165,7 +166,7 @@ func (u *playerLockedSongUsecase) recalculatePlayerOverpowerWithTx(ctx context.C
 		if record == nil || record.Song == nil || record.Chart == nil || record.ChartDifficulty == nil {
 			continue
 		}
-		if _, exists := lockedSet[lockedSongKey(record.Song.ID, record.ChartDifficulty.Name == "ULTIMA")]; exists {
+		if _, exists := lockedSet[lockedSongKey(record.Song.ID, record.ChartDifficulty.Name == info.DifficultyNameUltima)]; exists {
 			continue
 		}
 		overpower := domainservice.CalcSingleOverpower(uint32(record.Score), float64(record.Chart.Const), record.ComboLampID)

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
@@ -13,17 +14,19 @@ import (
 var errPlayerLockedSongInputRequired = errors.New("input is required")
 
 type playerLockedSongUsecase struct {
-	db           repository.Executor
-	userRepo     repository.UserRepository
-	playerRepo   repository.PlayerRepository
-	songRepo     repository.SongRepository
-	lockedRepo   repository.PlayerLockedSongRepository
-	queryService PlayerLockedSongQueryService
-	resolver     PlayerSongIDResolver
+	db             repository.Executor
+	userRepo       repository.UserRepository
+	playerRepo     repository.PlayerRepository
+	playerRecRepo  repository.PlayerRecordRepository
+	playerDataRepo repository.PlayerDataRepository
+	songRepo       repository.SongRepository
+	lockedRepo     repository.PlayerLockedSongRepository
+	queryService   PlayerLockedSongQueryService
+	resolver       PlayerSongIDResolver
 }
 
-func NewPlayerLockedSongUsecase(db repository.Executor, userRepo repository.UserRepository, playerRepo repository.PlayerRepository, songRepo repository.SongRepository, lockedRepo repository.PlayerLockedSongRepository, queryService PlayerLockedSongQueryService, resolver PlayerSongIDResolver) PlayerLockedSongUsecase {
-	return &playerLockedSongUsecase{db: db, userRepo: userRepo, playerRepo: playerRepo, songRepo: songRepo, lockedRepo: lockedRepo, queryService: queryService, resolver: resolver}
+func NewPlayerLockedSongUsecase(db repository.Executor, userRepo repository.UserRepository, playerRepo repository.PlayerRepository, playerRecRepo repository.PlayerRecordRepository, playerDataRepo repository.PlayerDataRepository, songRepo repository.SongRepository, lockedRepo repository.PlayerLockedSongRepository, queryService PlayerLockedSongQueryService, resolver PlayerSongIDResolver) PlayerLockedSongUsecase {
+	return &playerLockedSongUsecase{db: db, userRepo: userRepo, playerRepo: playerRepo, playerRecRepo: playerRecRepo, playerDataRepo: playerDataRepo, songRepo: songRepo, lockedRepo: lockedRepo, queryService: queryService, resolver: resolver}
 }
 
 func (u *playerLockedSongUsecase) List(ctx context.Context, username string, requester *entity.User) ([]*PlayerLockedSongOutput, error) {
@@ -89,7 +92,10 @@ func (u *playerLockedSongUsecase) Lock(ctx context.Context, userID int, input *P
 	if err != nil {
 		return err
 	}
-	return u.lockedRepo.Create(ctx, u.db, lockedSong)
+	if err := u.lockedRepo.Create(ctx, u.db, lockedSong); err != nil {
+		return err
+	}
+	return u.recalculatePlayerOverpower(ctx, player)
 }
 
 func (u *playerLockedSongUsecase) Unlock(ctx context.Context, userID int, input *PlayerLockedSongInput) error {
@@ -110,5 +116,60 @@ func (u *playerLockedSongUsecase) Unlock(ctx context.Context, userID int, input 
 	if songID == nil {
 		return nil
 	}
-	return u.lockedRepo.Delete(ctx, u.db, player.ID, *songID, input.IsUltima)
+	if err := u.lockedRepo.Delete(ctx, u.db, player.ID, *songID, input.IsUltima); err != nil {
+		return err
+	}
+	return u.recalculatePlayerOverpower(ctx, player)
+}
+
+func (u *playerLockedSongUsecase) recalculatePlayerOverpower(ctx context.Context, player *entity.Player) error {
+	if player == nil {
+		return ErrPlayerNotLinked
+	}
+	records, err := u.playerRecRepo.FindByPlayerID(ctx, u.db, player.ID)
+	if err != nil {
+		return err
+	}
+	lockedSongs, err := u.lockedRepo.ListByPlayerID(ctx, u.db, player.ID)
+	if err != nil {
+		return err
+	}
+	lockedSet := make(map[string]struct{}, len(lockedSongs))
+	for _, lockedSong := range lockedSongs {
+		key := lockedSongKey(lockedSong.SongID, lockedSong.IsUltima)
+		lockedSet[key] = struct{}{}
+	}
+	bestBySong := make(map[int]float64, len(records))
+	for _, record := range records {
+		if record == nil || record.Song == nil || record.Chart == nil || record.ChartDifficulty == nil {
+			continue
+		}
+		if _, exists := lockedSet[lockedSongKey(record.Song.ID, record.ChartDifficulty.Name == "ULTIMA")]; exists {
+			continue
+		}
+		overpower := domainservice.CalcSingleOverpower(uint32(record.Score), float64(record.Chart.Const), record.ComboLampID)
+		if current, exists := bestBySong[record.Song.ID]; !exists || overpower > current {
+			bestBySong[record.Song.ID] = overpower
+		}
+	}
+	total := 0.0
+	for _, best := range bestBySong {
+		total += best
+	}
+	value := max(roundFloat(total, 3), 0.0)
+	stats, err := u.playerDataRepo.GetOverpowerTargetStats(ctx, repository.OverpowerTargetFilter{ExcludeWorldsend: true, ExcludeDeleted: true})
+	if err != nil {
+		return err
+	}
+	percent := 0.0
+	if stats.MaxOverpowerTotal > 0 {
+		percent = min(max(roundFloat(total/stats.MaxOverpowerTotal*100, 4), 0.0), 100.0)
+	}
+	player.OverpowerValue = &value
+	player.OverpowerPercent = &percent
+	return u.playerRepo.Save(ctx, u.db, player)
+}
+
+func lockedSongKey(songID int, isUltima bool) string {
+	return fmt.Sprintf("%d:%t", songID, isUltima)
 }

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -15,6 +15,7 @@ var errPlayerLockedSongInputRequired = errors.New("input is required")
 
 type playerLockedSongUsecase struct {
 	db             repository.Executor
+	tm             TransactionManager
 	userRepo       repository.UserRepository
 	playerRepo     repository.PlayerRepository
 	playerRecRepo  repository.PlayerRecordRepository
@@ -25,8 +26,8 @@ type playerLockedSongUsecase struct {
 	resolver       PlayerSongIDResolver
 }
 
-func NewPlayerLockedSongUsecase(db repository.Executor, userRepo repository.UserRepository, playerRepo repository.PlayerRepository, playerRecRepo repository.PlayerRecordRepository, playerDataRepo repository.PlayerDataRepository, songRepo repository.SongRepository, lockedRepo repository.PlayerLockedSongRepository, queryService PlayerLockedSongQueryService, resolver PlayerSongIDResolver) PlayerLockedSongUsecase {
-	return &playerLockedSongUsecase{db: db, userRepo: userRepo, playerRepo: playerRepo, playerRecRepo: playerRecRepo, playerDataRepo: playerDataRepo, songRepo: songRepo, lockedRepo: lockedRepo, queryService: queryService, resolver: resolver}
+func NewPlayerLockedSongUsecase(db repository.Executor, tm TransactionManager, userRepo repository.UserRepository, playerRepo repository.PlayerRepository, playerRecRepo repository.PlayerRecordRepository, playerDataRepo repository.PlayerDataRepository, songRepo repository.SongRepository, lockedRepo repository.PlayerLockedSongRepository, queryService PlayerLockedSongQueryService, resolver PlayerSongIDResolver) PlayerLockedSongUsecase {
+	return &playerLockedSongUsecase{db: db, tm: tm, userRepo: userRepo, playerRepo: playerRepo, playerRecRepo: playerRecRepo, playerDataRepo: playerDataRepo, songRepo: songRepo, lockedRepo: lockedRepo, queryService: queryService, resolver: resolver}
 }
 
 func (u *playerLockedSongUsecase) List(ctx context.Context, username string, requester *entity.User) ([]*PlayerLockedSongOutput, error) {
@@ -92,10 +93,12 @@ func (u *playerLockedSongUsecase) Lock(ctx context.Context, userID int, input *P
 	if err != nil {
 		return err
 	}
-	if err := u.lockedRepo.Create(ctx, u.db, lockedSong); err != nil {
-		return err
-	}
-	return u.recalculatePlayerOverpower(ctx, player)
+	return u.tm.Transactional(ctx, func(tx repository.Executor) error {
+		if err := u.lockedRepo.Create(ctx, tx, lockedSong); err != nil {
+			return err
+		}
+		return u.recalculatePlayerOverpowerWithTx(ctx, tx, player)
+	})
 }
 
 func (u *playerLockedSongUsecase) Unlock(ctx context.Context, userID int, input *PlayerLockedSongInput) error {
@@ -116,21 +119,27 @@ func (u *playerLockedSongUsecase) Unlock(ctx context.Context, userID int, input 
 	if songID == nil {
 		return nil
 	}
-	if err := u.lockedRepo.Delete(ctx, u.db, player.ID, *songID, input.IsUltima); err != nil {
-		return err
-	}
-	return u.recalculatePlayerOverpower(ctx, player)
+	return u.tm.Transactional(ctx, func(tx repository.Executor) error {
+		if err := u.lockedRepo.Delete(ctx, tx, player.ID, *songID, input.IsUltima); err != nil {
+			return err
+		}
+		return u.recalculatePlayerOverpowerWithTx(ctx, tx, player)
+	})
 }
 
 func (u *playerLockedSongUsecase) recalculatePlayerOverpower(ctx context.Context, player *entity.Player) error {
+	return u.recalculatePlayerOverpowerWithTx(ctx, u.db, player)
+}
+
+func (u *playerLockedSongUsecase) recalculatePlayerOverpowerWithTx(ctx context.Context, exec repository.Executor, player *entity.Player) error {
 	if player == nil {
 		return ErrPlayerNotLinked
 	}
-	records, err := u.playerRecRepo.FindByPlayerID(ctx, u.db, player.ID)
+	records, err := u.playerRecRepo.FindByPlayerID(ctx, exec, player.ID)
 	if err != nil {
 		return err
 	}
-	lockedSongs, err := u.lockedRepo.ListByPlayerID(ctx, u.db, player.ID)
+	lockedSongs, err := u.lockedRepo.ListByPlayerID(ctx, exec, player.ID)
 	if err != nil {
 		return err
 	}
@@ -167,7 +176,7 @@ func (u *playerLockedSongUsecase) recalculatePlayerOverpower(ctx context.Context
 	}
 	player.OverpowerValue = &value
 	player.OverpowerPercent = &percent
-	return u.playerRepo.Save(ctx, u.db, player)
+	return u.playerRepo.Save(ctx, exec, player)
 }
 
 func lockedSongKey(songID int, isUltima bool) string {

--- a/internal/usecase/player_locked_song_usecase_impl_test.go
+++ b/internal/usecase/player_locked_song_usecase_impl_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
@@ -16,6 +17,7 @@ import (
 type stubPlayerLockedSongPlayerRepository struct {
 	player    *entity.Player
 	gotUserID int
+	saved     *entity.Player
 }
 
 func (s *stubPlayerLockedSongPlayerRepository) FindByID(ctx context.Context, exec repository.Executor, id int) (*entity.Player, error) {
@@ -40,6 +42,7 @@ func (s *stubPlayerLockedSongPlayerRepository) UpdateCalculatedRatings(ctx conte
 }
 
 func (s *stubPlayerLockedSongPlayerRepository) Save(ctx context.Context, exec repository.Executor, player *entity.Player) error {
+	s.saved = player
 	return nil
 }
 
@@ -49,10 +52,11 @@ func (s *stubPlayerLockedSongPlayerRepository) DeleteByUserID(ctx context.Contex
 
 type spyPlayerLockedSongRepository struct {
 	createCalled bool
+	lockedSongs  []*entity.PlayerLockedSong
 }
 
 func (s *spyPlayerLockedSongRepository) ListByPlayerID(ctx context.Context, exec repository.Executor, playerID int) ([]*entity.PlayerLockedSong, error) {
-	return nil, nil
+	return s.lockedSongs, nil
 }
 
 func (s *spyPlayerLockedSongRepository) Create(ctx context.Context, exec repository.Executor, lockedSong *entity.PlayerLockedSong) error {
@@ -62,6 +66,32 @@ func (s *spyPlayerLockedSongRepository) Create(ctx context.Context, exec reposit
 
 func (s *spyPlayerLockedSongRepository) Delete(ctx context.Context, exec repository.Executor, playerID int, songID int, isUltima bool) error {
 	return nil
+}
+
+type stubPlayerRecordRepositoryForLockedSong struct {
+	records []*entity.PlayerRecord
+}
+
+func (s *stubPlayerRecordRepositoryForLockedSong) FindByPlayerID(ctx context.Context, exec repository.Executor, playerID int) ([]*entity.PlayerRecord, error) {
+	return s.records, nil
+}
+func (s *stubPlayerRecordRepositoryForLockedSong) FindByPlayerIDForRating(ctx context.Context, exec repository.Executor, playerID int) ([]*entity.PlayerRecord, error) {
+	return nil, nil
+}
+func (s *stubPlayerRecordRepositoryForLockedSong) GetLastScoreUpdate(ctx context.Context, exec repository.Executor, playerID int) (*time.Time, error) {
+	return nil, nil
+}
+
+type stubPlayerDataRepositoryForLockedSong struct{}
+
+func (s *stubPlayerDataRepositoryForLockedSong) LoadMasterData(ctx context.Context, officialIdxList []string) (*repository.PlayerDataMaster, error) {
+	return nil, nil
+}
+func (s *stubPlayerDataRepositoryForLockedSong) SavePlayerData(ctx context.Context, exec repository.Executor, input repository.PlayerDataSaveInput) error {
+	return nil
+}
+func (s *stubPlayerDataRepositoryForLockedSong) GetOverpowerTargetStats(ctx context.Context, filter repository.OverpowerTargetFilter) (*repository.OverpowerTargetStats, error) {
+	return &repository.OverpowerTargetStats{MaxOverpowerTotal: 100}, nil
 }
 
 type stubPlayerLockedSongQueryService struct {
@@ -200,9 +230,11 @@ func TestPlayerLockedSongLock(t *testing.T) {
 			songRepo.On("FindByDisplayID", mock.Anything, mock.Anything, "0123456789abcdef").Return(tt.song, nil).Once()
 			lockedRepo := &spyPlayerLockedSongRepository{}
 			u := &playerLockedSongUsecase{
-				playerRepo: &stubPlayerLockedSongPlayerRepository{player: &entity.Player{ID: 10}},
-				songRepo:   songRepo,
-				lockedRepo: lockedRepo,
+				playerRepo:     &stubPlayerLockedSongPlayerRepository{player: &entity.Player{ID: 10}},
+				playerRecRepo:  &stubPlayerRecordRepositoryForLockedSong{records: []*entity.PlayerRecord{}},
+				playerDataRepo: &stubPlayerDataRepositoryForLockedSong{},
+				songRepo:       songRepo,
+				lockedRepo:     lockedRepo,
 			}
 
 			// When

--- a/internal/usecase/player_locked_song_usecase_impl_test.go
+++ b/internal/usecase/player_locked_song_usecase_impl_test.go
@@ -230,6 +230,7 @@ func TestPlayerLockedSongLock(t *testing.T) {
 			songRepo.On("FindByDisplayID", mock.Anything, mock.Anything, "0123456789abcdef").Return(tt.song, nil).Once()
 			lockedRepo := &spyPlayerLockedSongRepository{}
 			u := &playerLockedSongUsecase{
+				tm:             &passthroughTransactionManager{},
 				playerRepo:     &stubPlayerLockedSongPlayerRepository{player: &entity.Player{ID: 10}},
 				playerRecRepo:  &stubPlayerRecordRepositoryForLockedSong{records: []*entity.PlayerRecord{}},
 				playerDataRepo: &stubPlayerDataRepositoryForLockedSong{},


### PR DESCRIPTION
### Motivation

- Ensure a player's overpower value and percent are updated whenever they lock or unlock songs so displayed stats remain accurate.
- Provide the usecase with necessary repositories to read player records and target stats for recalculation.

### Description

- Extended `PlayerLockedSongUsecase` constructor and struct to accept `PlayerRecordRepository` and `PlayerDataRepository`, and updated DI in `NewRouter` to pass these repos.
- After creating or deleting a locked song, call a new `recalculatePlayerOverpower` method to recompute `Player.OverpowerValue` and `Player.OverpowerPercent` and persist the player via `playerRepo.Save`.
- Implemented `recalculatePlayerOverpower` which aggregates best overpower per song from player records while excluding locked songs, computes totals and percent against `GetOverpowerTargetStats`, and includes helper `lockedSongKey` for locked-song set handling.
- Updated imports and adjusted unit tests in `player_locked_song_usecase_impl_test.go` by adding stubs for `PlayerRecordRepository` and `PlayerDataRepository`, capturing saved player objects, and wiring the new dependencies for tests.

### Testing

- Ran the updated unit tests for the player locked song usecase using `go test ./internal/usecase -run TestPlayerLockedSong*`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff647f2fcc832d9383f74e1a43287c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ロック／アンロック後にプレイヤーのオーバーパワーをトランザクション内で再計算するよう改善し、重複ロック排除や欠損データのスキップ、値の丸め・上限適用、割合算出の精度向上で一貫性と安定性を向上しました。
* **テスト**
  * ロック関連の振る舞いと再計算・保存処理を検証するテストを拡充しました。
* **雑多（Chore）**
  * ULTIMA 表記を定数化し、ツールチェーンの小バージョンを更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chunisupport/chunisupport-api/pull/92)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->