### PR TITLE
feat: プレイヤーデータ登録時のOVER POWER計算で未解禁曲を考慮

### DIFF
--- a/internal/domain/repository/player_data_repository.go
+++ b/internal/domain/repository/player_data_repository.go
@@ -24,6 +24,7 @@ type PlayerDataSaveInput struct {
 type OverpowerTargetFilter struct {
 	ExcludeWorldsend bool
 	ExcludeDeleted   bool
+	PlayerID         *int
 }
 
 // OverpowerTargetStats はOVER POWER割合計算で使う全体集計値です。

--- a/internal/infra/repository/player_data_repository_impl.go
+++ b/internal/infra/repository/player_data_repository_impl.go
@@ -190,7 +190,7 @@ func (r *playerDataRepository) GetOverpowerTargetStats(ctx context.Context, filt
 		MaxConst float64 `db:"max_const"`
 	}
 	if err := executor.SelectContext(ctx, &rows, query, args...); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: failed to select overpower target stats: %v", repository.ErrRepositoryOperationFailed, err)
 	}
 
 	total := 0.0

--- a/internal/infra/repository/player_data_repository_impl.go
+++ b/internal/infra/repository/player_data_repository_impl.go
@@ -144,23 +144,55 @@ func (r *playerDataRepository) GetOverpowerTargetStats(ctx context.Context, filt
 		where = append(where, "s.is_deleted = 0")
 	}
 
+	maxConstExpr := "MAX(c.const)"
 	query := `
 		SELECT
 			s.id AS song_id,
-			MAX(c.const) AS max_const
+			` + maxConstExpr + ` AS max_const
 		FROM songs s
 		INNER JOIN charts c ON c.song_id = s.id
+		INNER JOIN difficulties d ON d.id = c.difficulty_id
 	`
+	args := make([]any, 0, 2)
+	if filter.PlayerID != nil {
+		maxConstExpr = `MAX(
+			CASE
+				WHEN pls_ultima.song_id IS NOT NULL AND d.name = 'ULTIMA' THEN NULL
+				ELSE c.const
+			END
+		)`
+		query = `
+		SELECT
+			s.id AS song_id,
+			` + maxConstExpr + ` AS max_const
+		FROM songs s
+		INNER JOIN charts c ON c.song_id = s.id
+		INNER JOIN difficulties d ON d.id = c.difficulty_id
+	`
+		query += `
+			LEFT JOIN player_locked_songs pls_song
+				ON pls_song.song_id = s.id
+				AND pls_song.player_id = ?
+				AND pls_song.is_ultima = 0
+			LEFT JOIN player_locked_songs pls_ultima
+				ON pls_ultima.song_id = s.id
+				AND pls_ultima.player_id = ?
+				AND pls_ultima.is_ultima = 1
+		`
+		args = append(args, *filter.PlayerID, *filter.PlayerID)
+		where = append(where, "pls_song.song_id IS NULL")
+	}
 	if len(where) > 0 {
 		query += " WHERE " + strings.Join(where, " AND ")
 	}
 	query += " GROUP BY s.id"
+	query += " HAVING max_const IS NOT NULL"
 
 	var rows []struct {
 		SongID   int     `db:"song_id"`
 		MaxConst float64 `db:"max_const"`
 	}
-	if err := executor.SelectContext(ctx, &rows, query); err != nil {
+	if err := executor.SelectContext(ctx, &rows, query, args...); err != nil {
 		return nil, err
 	}
 

--- a/internal/infra/repository/player_data_repository_impl.go
+++ b/internal/infra/repository/player_data_repository_impl.go
@@ -145,15 +145,10 @@ func (r *playerDataRepository) GetOverpowerTargetStats(ctx context.Context, filt
 	}
 
 	maxConstExpr := "MAX(c.const)"
-	query := `
-		SELECT
-			s.id AS song_id,
-			` + maxConstExpr + ` AS max_const
-		FROM songs s
-		INNER JOIN charts c ON c.song_id = s.id
-		INNER JOIN difficulties d ON d.id = c.difficulty_id
-	`
 	args := make([]any, 0, 2)
+	joins := `
+		INNER JOIN charts c ON c.song_id = s.id
+	`
 	if filter.PlayerID != nil {
 		maxConstExpr = `MAX(
 			CASE
@@ -161,15 +156,8 @@ func (r *playerDataRepository) GetOverpowerTargetStats(ctx context.Context, filt
 				ELSE c.const
 			END
 		)`
-		query = `
-		SELECT
-			s.id AS song_id,
-			` + maxConstExpr + ` AS max_const
-		FROM songs s
-		INNER JOIN charts c ON c.song_id = s.id
-		INNER JOIN difficulties d ON d.id = c.difficulty_id
-	`
-		query += `
+		joins += `
+			INNER JOIN difficulties d ON d.id = c.difficulty_id
 			LEFT JOIN player_locked_songs pls_song
 				ON pls_song.song_id = s.id
 				AND pls_song.player_id = ?
@@ -182,11 +170,20 @@ func (r *playerDataRepository) GetOverpowerTargetStats(ctx context.Context, filt
 		args = append(args, *filter.PlayerID, *filter.PlayerID)
 		where = append(where, "pls_song.song_id IS NULL")
 	}
+
+	query := `
+		SELECT
+			s.id AS song_id,
+			` + maxConstExpr + ` AS max_const
+		FROM songs s
+	` + joins
 	if len(where) > 0 {
 		query += " WHERE " + strings.Join(where, " AND ")
 	}
 	query += " GROUP BY s.id"
-	query += " HAVING max_const IS NOT NULL"
+	if filter.PlayerID != nil {
+		query += " HAVING max_const IS NOT NULL"
+	}
 
 	var rows []struct {
 		SongID   int     `db:"song_id"`

--- a/internal/infra/repository/player_data_repository_impl.go
+++ b/internal/infra/repository/player_data_repository_impl.go
@@ -190,7 +190,7 @@ func (r *playerDataRepository) GetOverpowerTargetStats(ctx context.Context, filt
 		MaxConst float64 `db:"max_const"`
 	}
 	if err := executor.SelectContext(ctx, &rows, query, args...); err != nil {
-		return nil, fmt.Errorf("%w: failed to select overpower target stats: %v", repository.ErrRepositoryOperationFailed, err)
+		return nil, fmt.Errorf("%w: failed to select overpower target stats: %w", repository.ErrRepositoryOperationFailed, err)
 	}
 
 	total := 0.0

--- a/internal/infra/repository/player_data_repository_impl_test.go
+++ b/internal/infra/repository/player_data_repository_impl_test.go
@@ -138,7 +138,7 @@ func TestGetOverpowerTargetStats_対象楽曲の最大OP合計を取得する(t 
 				ExcludeDeleted:   true,
 			},
 			wantCount: 2,
-			wantTotal: service.CalcSongMaxOP(15.0) +
+			wantTotal: service.CalcSongMaxOP(15.4) +
 				service.CalcSongMaxOP(14.5),
 		},
 		{
@@ -148,10 +148,21 @@ func TestGetOverpowerTargetStats_対象楽曲の最大OP合計を取得する(t 
 				ExcludeDeleted:   false,
 			},
 			wantCount: 4,
-			wantTotal: service.CalcSongMaxOP(15.0) +
+			wantTotal: service.CalcSongMaxOP(15.4) +
 				service.CalcSongMaxOP(14.5) +
 				service.CalcSongMaxOP(13.0) +
 				service.CalcSongMaxOP(12.0),
+		},
+		{
+			name: "プレイヤー未解禁曲がある場合は通常未解禁曲を除外しULTIMA未解禁時は下位難易度を採用する",
+			filter: domainrepo.OverpowerTargetFilter{
+				ExcludeWorldsend: true,
+				ExcludeDeleted:   true,
+				PlayerID:         intPtrForPlayerDataRepositoryTest(100),
+			},
+			wantCount: 2,
+			wantTotal: service.CalcSongMaxOP(15.0) + // Song1: ULTIMA未解禁のためMASTERを採用
+				service.CalcSongMaxOP(14.5), // Song2: 通常譜面は解禁済み
 		},
 	}
 
@@ -176,9 +187,25 @@ func TestGetOverpowerTargetStats_対象楽曲の最大OP合計を取得する(t 
 				VALUES
 					(1, 1, 3, 13.0, 0, 1000),
 					(2, 1, 4, 15.0, 0, 1200),
+					(6, 1, 5, 15.4, 0, 1250),
 					(3, 2, 4, 14.5, 1, 1100),
 					(4, 3, 4, 13.0, 0, 900),
 					(5, 4, 4, 12.0, 0, 800)
+			`)
+			require.NoError(t, err)
+			_, err = db.Exec(`
+				CREATE TABLE IF NOT EXISTS player_locked_songs (
+					player_id INTEGER NOT NULL,
+					song_id INTEGER NOT NULL,
+					is_ultima BOOLEAN NOT NULL,
+					PRIMARY KEY (player_id, song_id, is_ultima)
+				)
+			`)
+			require.NoError(t, err)
+			_, err = db.Exec(`
+				INSERT INTO player_locked_songs (player_id, song_id, is_ultima)
+				VALUES
+					(100, 1, 1)
 			`)
 			require.NoError(t, err)
 
@@ -194,6 +221,10 @@ func TestGetOverpowerTargetStats_対象楽曲の最大OP合計を取得する(t 
 			assert.InDelta(t, tt.wantTotal, stats.MaxOverpowerTotal, 0.0001)
 		})
 	}
+}
+
+func intPtrForPlayerDataRepositoryTest(value int) *int {
+	return &value
 }
 
 func TestSavePlayerData_execがnilならエラーを返す(t *testing.T) {

--- a/internal/usecase/player_data_usecase_apply_scores_test.go
+++ b/internal/usecase/player_data_usecase_apply_scores_test.go
@@ -61,7 +61,7 @@ func TestApplyScores_通常譜面とWORLDSENDを保存し通常譜面だけをOV
 	}, counts)
 	assert.Empty(t, skipped)
 	require.Equal(t, 1, repo.saveCalls)
-	assert.Equal(t, repository.OverpowerTargetFilter{ExcludeWorldsend: true, ExcludeDeleted: true}, repo.receivedFilter)
+	assert.Equal(t, repository.OverpowerTargetFilter{ExcludeWorldsend: true, ExcludeDeleted: true, PlayerID: intPtrForApplyScoresTest(99)}, repo.receivedFilter)
 
 	require.Len(t, repo.savedInput.FullRecords, 1)
 	assert.Equal(t, repository.PlayerRecordForUpsert{

--- a/internal/usecase/player_data_usecase_impl.go
+++ b/internal/usecase/player_data_usecase_impl.go
@@ -561,6 +561,7 @@ func (us *playerDataUsecase) applyScores(ctx context.Context, tx repository.Exec
 	overpowerTargetStats, err := us.playerDataRepo.GetOverpowerTargetStats(ctx, repository.OverpowerTargetFilter{
 		ExcludeWorldsend: true,
 		ExcludeDeleted:   true,
+		PlayerID:         &playerID,
 	})
 	if err != nil {
 		return counts, skipped, calculatedOverpowerSummary{}, err


### PR DESCRIPTION
### Motivation
- プレイヤーデータを登録した際に算出する OVER POWER の分母に、プレイヤーごとの未解禁（未解放）状態を反映する必要があったため、未解禁曲の扱いを実装しました。 
- 具体的には通常譜面が未解禁であれば集計対象から除外し、ULTIMA が未解禁の場合は ULTIMA 譜面のみ除外して残る難易度の最大定数を採用する挙動を実現します。 

### Description
- `OverpowerTargetFilter` に `PlayerID *int` を追加してプレイヤー単位の絞り込みを可能にしました（`internal/domain/repository/player_data_repository.go`）。
- スコア適用処理 `applyScores` から `GetOverpowerTargetStats` 呼び出し時に `PlayerID` を渡すように変更しました（`internal/usecase/player_data_usecase_impl.go`）。
- `GetOverpowerTargetStats` の SQL を拡張し、`player_locked_songs` と `difficulties` を参照して未解禁を反映するロジックを追加しました（`internal/infra/repository/player_data_repository_impl.go`）。
- 関連テストを更新・追加して仕様を検証しました（`internal/usecase/player_data_usecase_apply_scores_test.go` と `internal/infra/repository/player_data_repository_impl_test.go` にて `PlayerID` を渡すこと、未解禁時の集計結果等を検証）。

### Testing
- コード整形を `gofmt -w` で実行済み（対象ファイルに対して実行）。
- 自動テストを `go test ./...` で実行し、プロジェクトのテストが通過しました（全テスト成功）。
- 変更に関係するテストとして `TestApplyScores_通常譜面とWORLDSENDを保存し通常譜面だけをOVERPOWER集計する` と `TestGetOverpowerTargetStats_対象楽曲の最大OP合計を取得する` を更新・追加して検証しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fff11331c4832d8e78523e4cc51e0b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * OVERPOWER集計をプレイヤー単位で実行可能にし、プレイヤーのロック状態を考慮して集計対象を絞り込みます。

* **改善**
  * ロック済み楽曲の扱いを明確化し、OVERPOWER統計の算出精度と結果の一貫性を向上しました。

* **テスト**
  * プレイヤー別の集計を反映するためのテストデータと期待値を更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chunisupport/chunisupport-api/pull/93)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->