### PR TITLE
feat: locked-song一括追加/削除バッチAPIを追加

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -118,6 +118,7 @@
 | `/internal/me/register-data` | POST | Firebase Bearer | CHUNITHMプレイヤーデータ登録 |
 | `/internal/me/player-data` | DELETE | Firebase Bearer | プレイヤー連携を解除し、プレイヤー関連レコードを削除 |
 | `/internal/me/locked-songs` | POST | Firebase Bearer | 自分の未解禁曲を登録 |
+| `/internal/me/locked-songs/batch` | POST | Firebase Bearer | 自分の未解禁曲をまとめて登録・解除 |
 | `/internal/me/locked-songs/:displayid` | DELETE | Firebase Bearer | 自分の未解禁曲を解除 |
 | `/internal/player-data/temp` | POST | なし | 未ログインでプレイヤーデータを一時受付（gzip JSON） |
 | `/internal/player-data/commit` | POST | Firebase Bearer | 一時受付したプレイヤーデータを確定保存 |
@@ -432,6 +433,41 @@
   - 400 Bad Request (`validation_failed`): `displayid` が未指定または形式不正
   - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
   - 404 Not Found (`player_not_linked`): プレイヤーデータが連携されていない
+  - 500 Internal Server Error (`internal_error`): サーバー内部エラー
+
+### POST `/internal/me/locked-songs/batch`
+- **認証**: Firebase Bearer 必須
+- **概要**: 自分のプレイヤーに対して、未解禁曲の登録（`add`）と解除（`delete`）を1リクエストで実行します。
+- **リクエストボディ**:
+
+```json
+{
+  "add": [
+    { "display_id": "0000000000000001", "is_ultima": false }
+  ],
+  "delete": [
+    { "display_id": "0000000000000002", "is_ultima": true }
+  ]
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+| ---------- | -- | ---- | ---- |
+| `add` | object[] | - | 追加する未解禁曲の配列 |
+| `delete` | object[] | - | 解除する未解禁曲の配列 |
+| `add[].display_id` / `delete[].display_id` | string | ✓ | 楽曲の表示用ID |
+| `add[].is_ultima` / `delete[].is_ultima` | bool | - | true の場合はULTIMA未解禁を対象 |
+
+- **レスポンス**: 204 No Content（ボディなし）
+- **実行順**: `add` を先に実行し、その後 `delete` を実行します。
+
+- **主なエラー**:
+  - 400 Bad Request (`bad_request`): リクエスト形式不正
+  - 400 Bad Request (`validation_failed`): `display_id` が未指定または形式不正
+  - 401 Unauthorized (`missing_token` / `invalid_token`): 認証が必要
+  - 404 Not Found (`player_not_linked`): プレイヤーデータが連携されていない
+  - 404 Not Found (`song_not_found`): 追加対象の楽曲が見つからない、または登録対象外
+  - 404 Not Found (`chart_not_found`): 追加対象で `is_ultima=true` かつ ULTIMA譜面が存在しない
   - 500 Internal Server Error (`internal_error`): サーバー内部エラー
 
 ### POST `/internal/me/register-data`

--- a/internal/app/handler/api_internal/info.go
+++ b/internal/app/handler/api_internal/info.go
@@ -1,0 +1,6 @@
+package api_internal
+
+const (
+	// MaxPlayerLockedSongBatchItems は一括操作で受け付ける最大件数
+	MaxPlayerLockedSongBatchItems = 100
+)

--- a/internal/app/handler/api_internal/player_locked_song_handler.go
+++ b/internal/app/handler/api_internal/player_locked_song_handler.go
@@ -12,6 +12,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+const (
+	// MaxPlayerLockedSongBatchItems is the maximum number of items allowed in a batch operation
+	MaxPlayerLockedSongBatchItems = 1000
+)
+
 type PlayerLockedSongHandler struct {
 	usecase usecase.PlayerLockedSongUsecase
 }
@@ -90,6 +95,11 @@ func (h *PlayerLockedSongHandler) Batch(c echo.Context) error {
 	var req internaldto.PlayerLockedSongBatchRequest
 	if err := apphandler.BindStrictJSON(c, &req); err != nil {
 		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	// Validate total batch size before processing
+	totalItems := len(req.Add) + len(req.Delete)
+	if totalItems > MaxPlayerLockedSongBatchItems {
+		return apierror.ErrValidationFailed
 	}
 	toInputs := func(items []*internaldto.PlayerLockedSongBatchRequestItem) ([]*usecase.PlayerLockedSongInput, error) {
 		inputs := make([]*usecase.PlayerLockedSongInput, 0, len(items))

--- a/internal/app/handler/api_internal/player_locked_song_handler.go
+++ b/internal/app/handler/api_internal/player_locked_song_handler.go
@@ -12,11 +12,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-const (
-	// MaxPlayerLockedSongBatchItems is the maximum number of items allowed in a batch operation
-	MaxPlayerLockedSongBatchItems = 100
-)
-
 type PlayerLockedSongHandler struct {
 	usecase usecase.PlayerLockedSongUsecase
 }
@@ -96,7 +91,7 @@ func (h *PlayerLockedSongHandler) Batch(c echo.Context) error {
 	if err := apphandler.BindStrictJSON(c, &req); err != nil {
 		return apierror.ErrBadRequest.WithInternal(err)
 	}
-	// Validate total batch size before processing
+	// バッチの総件数を処理前に検証する
 	totalItems := len(req.Add) + len(req.Delete)
 	if totalItems > MaxPlayerLockedSongBatchItems {
 		return apierror.ErrValidationFailed

--- a/internal/app/handler/api_internal/player_locked_song_handler.go
+++ b/internal/app/handler/api_internal/player_locked_song_handler.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// MaxPlayerLockedSongBatchItems is the maximum number of items allowed in a batch operation
-	MaxPlayerLockedSongBatchItems = 1000
+	MaxPlayerLockedSongBatchItems = 100
 )
 
 type PlayerLockedSongHandler struct {

--- a/internal/app/handler/api_internal/player_locked_song_handler.go
+++ b/internal/app/handler/api_internal/player_locked_song_handler.go
@@ -91,6 +91,9 @@ func (h *PlayerLockedSongHandler) Batch(c echo.Context) error {
 	if err := apphandler.BindStrictJSON(c, &req); err != nil {
 		return apierror.ErrBadRequest.WithInternal(err)
 	}
+	if err := c.Validate(&req); err != nil {
+		return err
+	}
 	// バッチの総件数を処理前に検証する
 	totalItems := len(req.Add) + len(req.Delete)
 	if totalItems > MaxPlayerLockedSongBatchItems {

--- a/internal/app/handler/api_internal/player_locked_song_handler.go
+++ b/internal/app/handler/api_internal/player_locked_song_handler.go
@@ -81,3 +81,40 @@ func (h *PlayerLockedSongHandler) Unlock(c echo.Context) error {
 	}
 	return c.NoContent(http.StatusNoContent)
 }
+
+func (h *PlayerLockedSongHandler) Batch(c echo.Context) error {
+	user, err := getUser(c)
+	if err != nil {
+		return err
+	}
+	var req internaldto.PlayerLockedSongBatchRequest
+	if err := apphandler.BindStrictJSON(c, &req); err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+	toInputs := func(items []*internaldto.PlayerLockedSongBatchRequestItem) ([]*usecase.PlayerLockedSongInput, error) {
+		inputs := make([]*usecase.PlayerLockedSongInput, 0, len(items))
+		for _, item := range items {
+			if item == nil {
+				return nil, apierror.ErrValidationFailed
+			}
+			displayID, err := displayid.NewDisplayID(item.DisplayID)
+			if err != nil {
+				return nil, apierror.ErrValidationFailed.WithInternal(err)
+			}
+			inputs = append(inputs, &usecase.PlayerLockedSongInput{DisplayID: displayID, IsUltima: item.IsUltima})
+		}
+		return inputs, nil
+	}
+	addInputs, err := toInputs(req.Add)
+	if err != nil {
+		return err
+	}
+	deleteInputs, err := toInputs(req.Delete)
+	if err != nil {
+		return err
+	}
+	if err := h.usecase.Batch(c.Request().Context(), user.ID, &usecase.PlayerLockedSongBatchInput{Add: addInputs, Delete: deleteInputs}); err != nil {
+		return apierror.FromUsecaseError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/internal/app/handler/api_internal/player_locked_song_handler_test.go
+++ b/internal/app/handler/api_internal/player_locked_song_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
@@ -18,6 +19,7 @@ import (
 type mockPlayerLockedSongUsecase struct {
 	listFunc   func(ctx context.Context, username string, requester *entity.User) ([]*usecase.PlayerLockedSongOutput, error)
 	unlockFunc func(ctx context.Context, userID int, input *usecase.PlayerLockedSongInput) error
+	batchFunc  func(ctx context.Context, userID int, input *usecase.PlayerLockedSongBatchInput) error
 }
 
 func (m *mockPlayerLockedSongUsecase) List(ctx context.Context, username string, requester *entity.User) ([]*usecase.PlayerLockedSongOutput, error) {
@@ -34,6 +36,13 @@ func (m *mockPlayerLockedSongUsecase) Lock(ctx context.Context, userID int, inpu
 func (m *mockPlayerLockedSongUsecase) Unlock(ctx context.Context, userID int, input *usecase.PlayerLockedSongInput) error {
 	if m.unlockFunc != nil {
 		return m.unlockFunc(ctx, userID, input)
+	}
+	return nil
+}
+
+func (m *mockPlayerLockedSongUsecase) Batch(ctx context.Context, userID int, input *usecase.PlayerLockedSongBatchInput) error {
+	if m.batchFunc != nil {
+		return m.batchFunc(ctx, userID, input)
 	}
 	return nil
 }
@@ -146,4 +155,35 @@ func TestPlayerLockedSongHandler_Unlock(t *testing.T) {
 			assert.Equal(t, tt.expectUsecaseHit, called)
 		})
 	}
+}
+
+func TestPlayerLockedSongHandler_Batch(t *testing.T) {
+	e := echo.New()
+	body := `{"add":[{"display_id":"1234567890abcdef","is_ultima":true}],"delete":[{"display_id":"fedcba0987654321","is_ultima":false}]}`
+	req := httptest.NewRequest(http.MethodPost, "/internal/me/locked-songs/batch", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("userEntity", &entity.User{ID: 1})
+
+	called := false
+	handler := NewPlayerLockedSongHandler(&mockPlayerLockedSongUsecase{
+		batchFunc: func(ctx context.Context, userID int, input *usecase.PlayerLockedSongBatchInput) error {
+			called = true
+			assert.Equal(t, 1, userID)
+			require.Len(t, input.Add, 1)
+			assert.Equal(t, "1234567890abcdef", input.Add[0].DisplayID.String())
+			assert.True(t, input.Add[0].IsUltima)
+			require.Len(t, input.Delete, 1)
+			assert.Equal(t, "fedcba0987654321", input.Delete[0].DisplayID.String())
+			assert.False(t, input.Delete[0].IsUltima)
+			return nil
+		},
+	})
+
+	err := handler.Batch(c)
+
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }

--- a/internal/app/handler/api_internal/player_locked_song_handler_test.go
+++ b/internal/app/handler/api_internal/player_locked_song_handler_test.go
@@ -159,6 +159,7 @@ func TestPlayerLockedSongHandler_Unlock(t *testing.T) {
 
 func TestPlayerLockedSongHandler_Batch(t *testing.T) {
 	e := echo.New()
+	e.Validator = &testValidator{validator: validator.New()}
 	body := `{"add":[{"display_id":"1234567890abcdef","is_ultima":true}],"delete":[{"display_id":"fedcba0987654321","is_ultima":false}]}`
 	req := httptest.NewRequest(http.MethodPost, "/internal/me/locked-songs/batch", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -249,6 +249,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator midd
 		meGroup.PUT("/goals/:id", handlers.Goal.Update)
 		meGroup.DELETE("/goals/:id", handlers.Goal.Delete)
 		meGroup.POST("/locked-songs", handlers.PlayerLockedSong.Lock)
+		meGroup.POST("/locked-songs/batch", handlers.PlayerLockedSong.Batch)
 		meGroup.DELETE("/locked-songs/:displayid", handlers.PlayerLockedSong.Unlock)
 	}
 

--- a/internal/domain/repository/player_locked_song_repository.go
+++ b/internal/domain/repository/player_locked_song_repository.go
@@ -10,4 +10,6 @@ type PlayerLockedSongRepository interface {
 	ListByPlayerID(ctx context.Context, exec Executor, playerID int) ([]*entity.PlayerLockedSong, error)
 	Create(ctx context.Context, exec Executor, lockedSong *entity.PlayerLockedSong) error
 	Delete(ctx context.Context, exec Executor, playerID int, songID int, isUltima bool) error
+	BulkCreate(ctx context.Context, exec Executor, lockedSongs []*entity.PlayerLockedSong) error
+	BulkDelete(ctx context.Context, exec Executor, playerID int, songIDs []int, isUltimaFlags []bool) error
 }

--- a/internal/dto/api_internal/player_locked_song_dto.go
+++ b/internal/dto/api_internal/player_locked_song_dto.go
@@ -39,6 +39,6 @@ type PlayerLockedSongBatchRequestItem struct {
 }
 
 type PlayerLockedSongBatchRequest struct {
-	Add    []*PlayerLockedSongBatchRequestItem `json:"add"`
-	Delete []*PlayerLockedSongBatchRequestItem `json:"delete"`
+	Add    []*PlayerLockedSongBatchRequestItem `json:"add" validate:"dive"`
+	Delete []*PlayerLockedSongBatchRequestItem `json:"delete" validate:"dive"`
 }

--- a/internal/dto/api_internal/player_locked_song_dto.go
+++ b/internal/dto/api_internal/player_locked_song_dto.go
@@ -32,3 +32,13 @@ type PlayerLockedSongResponseItem struct {
 type PlayerLockedSongsResponse struct {
 	Items []*PlayerLockedSongResponseItem `json:"items"`
 }
+
+type PlayerLockedSongBatchRequestItem struct {
+	DisplayID string `json:"display_id" validate:"required"`
+	IsUltima  bool   `json:"is_ultima"`
+}
+
+type PlayerLockedSongBatchRequest struct {
+	Add    []*PlayerLockedSongBatchRequestItem `json:"add"`
+	Delete []*PlayerLockedSongBatchRequestItem `json:"delete"`
+}

--- a/internal/infra/repository/player_locked_song_repository_impl.go
+++ b/internal/infra/repository/player_locked_song_repository_impl.go
@@ -110,14 +110,14 @@ func (r *PlayerLockedSongRepository) BulkDelete(ctx context.Context, exec domain
 	if len(songIDs) != len(isUltimaFlags) {
 		return wrapPlayerLockedSongRepositoryError("bulk delete", fmt.Errorf("songIDs and isUltimaFlags length mismatch"))
 	}
-	const baseQuery = `DELETE FROM player_locked_songs WHERE player_id = ? AND (`
+	const baseQuery = "DELETE FROM player_locked_songs WHERE player_id = ? AND (song_id, is_ultima) IN ("
 	query := baseQuery
 	args := []interface{}{playerID}
 	for i := range songIDs {
 		if i > 0 {
-			query += " OR "
+			query += ", "
 		}
-		query += "(song_id = ? AND is_ultima = ?)"
+		query += "(?, ?)"
 		args = append(args, songIDs[i], isUltimaFlags[i])
 	}
 	query += ")"

--- a/internal/infra/repository/player_locked_song_repository_impl.go
+++ b/internal/infra/repository/player_locked_song_repository_impl.go
@@ -108,7 +108,7 @@ func (r *PlayerLockedSongRepository) BulkDelete(ctx context.Context, exec domain
 		return nil
 	}
 	if len(songIDs) != len(isUltimaFlags) {
-		return fmt.Errorf("songIDs and isUltimaFlags length mismatch")
+		return wrapPlayerLockedSongRepositoryError("bulk delete", fmt.Errorf("songIDs and isUltimaFlags length mismatch"))
 	}
 	const baseQuery = `DELETE FROM player_locked_songs WHERE player_id = ? AND (`
 	query := baseQuery

--- a/internal/infra/repository/player_locked_song_repository_impl.go
+++ b/internal/infra/repository/player_locked_song_repository_impl.go
@@ -75,6 +75,56 @@ func (r *PlayerLockedSongRepository) Delete(ctx context.Context, exec domainrepo
 	return wrapPlayerLockedSongRepositoryError("delete", err)
 }
 
+func (r *PlayerLockedSongRepository) BulkCreate(ctx context.Context, exec domainrepo.Executor, lockedSongs []*entity.PlayerLockedSong) error {
+	if len(lockedSongs) == 0 {
+		return nil
+	}
+	for _, lockedSong := range lockedSongs {
+		if err := lockedSong.Validate(); err != nil {
+			return err
+		}
+	}
+	const baseQuery = `INSERT INTO player_locked_songs (player_id, song_id, is_ultima) VALUES `
+	const valueClause = `(?, ?, ?)`
+	query := baseQuery
+	args := make([]interface{}, 0, len(lockedSongs)*3)
+	for i, lockedSong := range lockedSongs {
+		if i > 0 {
+			query += ", "
+		}
+		query += valueClause
+		args = append(args, lockedSong.PlayerID, lockedSong.SongID, lockedSong.IsUltima)
+	}
+	query += ` ON DUPLICATE KEY UPDATE player_id = player_id`
+	_, err := exec.ExecContext(ctx, query, args...)
+	if err != nil {
+		return wrapPlayerLockedSongRepositoryError("bulk create", err)
+	}
+	return nil
+}
+
+func (r *PlayerLockedSongRepository) BulkDelete(ctx context.Context, exec domainrepo.Executor, playerID int, songIDs []int, isUltimaFlags []bool) error {
+	if len(songIDs) == 0 {
+		return nil
+	}
+	if len(songIDs) != len(isUltimaFlags) {
+		return fmt.Errorf("songIDs and isUltimaFlags length mismatch")
+	}
+	const baseQuery = `DELETE FROM player_locked_songs WHERE player_id = ? AND (`
+	query := baseQuery
+	args := []interface{}{playerID}
+	for i := range songIDs {
+		if i > 0 {
+			query += " OR "
+		}
+		query += "(song_id = ? AND is_ultima = ?)"
+		args = append(args, songIDs[i], isUltimaFlags[i])
+	}
+	query += ")"
+	_, err := exec.ExecContext(ctx, query, args...)
+	return wrapPlayerLockedSongRepositoryError("bulk delete", err)
+}
+
 func wrapPlayerLockedSongRepositoryError(operation string, err error) error {
 	if err == nil {
 		return nil

--- a/internal/infra/repository/player_song_id_resolver_impl.go
+++ b/internal/infra/repository/player_song_id_resolver_impl.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
-	"strings"
 
 	domainrepo "github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/jmoiron/sqlx"
@@ -27,28 +25,23 @@ func (r *PlayerSongIDResolver) ResolveSongIDsByDisplayIDs(ctx context.Context, e
 	if len(displayIDs) == 0 {
 		return map[string]int{}, nil
 	}
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(displayIDs)), ",")
-	args := make([]any, 0, len(displayIDs))
-	for _, displayID := range displayIDs {
-		args = append(args, displayID)
-	}
-	query := fmt.Sprintf("SELECT display_id, id FROM songs WHERE display_id IN (%s)", placeholders)
-	rows, err := exec.QueryContext(ctx, query, args...)
+	query, args, err := sqlx.In("SELECT display_id, id FROM songs WHERE display_id IN (?)", displayIDs)
 	if err != nil {
 		return nil, wrapPlayerLockedSongRepositoryError("resolve song ids by display ids", err)
 	}
-	defer rows.Close()
-	resolved := make(map[string]int, len(displayIDs))
-	for rows.Next() {
-		var displayID string
-		var songID int
-		if err := rows.Scan(&displayID, &songID); err != nil {
-			return nil, wrapPlayerLockedSongRepositoryError("resolve song ids by display ids", err)
-		}
-		resolved[displayID] = songID
+
+	type songIDResult struct {
+		DisplayID string `db:"display_id"`
+		ID        int    `db:"id"`
 	}
-	if err := rows.Err(); err != nil {
+	results := make([]songIDResult, 0, len(displayIDs))
+	if err := sqlx.SelectContext(ctx, exec, &results, query, args...); err != nil {
 		return nil, wrapPlayerLockedSongRepositoryError("resolve song ids by display ids", err)
+	}
+
+	resolved := make(map[string]int, len(results))
+	for _, result := range results {
+		resolved[result.DisplayID] = result.ID
 	}
 	return resolved, nil
 }

--- a/internal/infra/repository/player_song_id_resolver_impl.go
+++ b/internal/infra/repository/player_song_id_resolver_impl.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"strings"
 
 	domainrepo "github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/jmoiron/sqlx"
@@ -19,4 +21,34 @@ func (r *PlayerSongIDResolver) ResolveSongIDByDisplayID(ctx context.Context, exe
 		return nil, wrapPlayerLockedSongRepositoryError("resolve song id by display id", err)
 	}
 	return &id, nil
+}
+
+func (r *PlayerSongIDResolver) ResolveSongIDsByDisplayIDs(ctx context.Context, exec domainrepo.Executor, displayIDs []string) (map[string]int, error) {
+	if len(displayIDs) == 0 {
+		return map[string]int{}, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(displayIDs)), ",")
+	args := make([]any, 0, len(displayIDs))
+	for _, displayID := range displayIDs {
+		args = append(args, displayID)
+	}
+	query := fmt.Sprintf("SELECT display_id, id FROM songs WHERE display_id IN (%s)", placeholders)
+	rows, err := exec.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, wrapPlayerLockedSongRepositoryError("resolve song ids by display ids", err)
+	}
+	defer rows.Close()
+	resolved := make(map[string]int, len(displayIDs))
+	for rows.Next() {
+		var displayID string
+		var songID int
+		if err := rows.Scan(&displayID, &songID); err != nil {
+			return nil, wrapPlayerLockedSongRepositoryError("resolve song ids by display ids", err)
+		}
+		resolved[displayID] = songID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, wrapPlayerLockedSongRepositoryError("resolve song ids by display ids", err)
+	}
+	return resolved, nil
 }

--- a/internal/usecase/player_locked_song_usecase.go
+++ b/internal/usecase/player_locked_song_usecase.go
@@ -44,4 +44,5 @@ type PlayerLockedSongQueryService interface {
 
 type PlayerSongIDResolver interface {
 	ResolveSongIDByDisplayID(ctx context.Context, exec repository.Executor, displayID string) (*int, error)
+	ResolveSongIDsByDisplayIDs(ctx context.Context, exec repository.Executor, displayIDs []string) (map[string]int, error)
 }

--- a/internal/usecase/player_locked_song_usecase.go
+++ b/internal/usecase/player_locked_song_usecase.go
@@ -23,6 +23,12 @@ type PlayerLockedSongUsecase interface {
 	List(ctx context.Context, username string, requester *entity.User) ([]*PlayerLockedSongOutput, error)
 	Lock(ctx context.Context, userID int, input *PlayerLockedSongInput) error
 	Unlock(ctx context.Context, userID int, input *PlayerLockedSongInput) error
+	Batch(ctx context.Context, userID int, input *PlayerLockedSongBatchInput) error
+}
+
+type PlayerLockedSongBatchInput struct {
+	Add    []*PlayerLockedSongInput
+	Delete []*PlayerLockedSongInput
 }
 
 type PlayerLockedSongReadModel struct {

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -216,6 +216,9 @@ func (u *playerLockedSongUsecase) Batch(ctx context.Context, userID int, input *
 			isUltimaFlagsToDelete = append(isUltimaFlagsToDelete, deleteInput.IsUltima)
 		}
 	}
+	if len(lockedSongsToAdd) == 0 && len(songIDsToDelete) == 0 {
+		return nil
+	}
 
 	// Execute all operations in a single transaction
 	return u.tm.Transactional(ctx, func(tx repository.Executor) error {

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -144,6 +144,23 @@ func (u *playerLockedSongUsecase) Unlock(ctx context.Context, userID int, input 
 	})
 }
 
+func (u *playerLockedSongUsecase) Batch(ctx context.Context, userID int, input *PlayerLockedSongBatchInput) error {
+	if input == nil {
+		return errPlayerLockedSongInputRequired
+	}
+	for _, addInput := range input.Add {
+		if err := u.Lock(ctx, userID, addInput); err != nil {
+			return err
+		}
+	}
+	for _, deleteInput := range input.Delete {
+		if err := u.Unlock(ctx, userID, deleteInput); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (u *playerLockedSongUsecase) recalculatePlayerOverpowerWithTx(ctx context.Context, exec repository.Executor, player *entity.Player) error {
 	if player == nil {
 		return ErrPlayerNotLinked

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -210,11 +210,19 @@ func (u *playerLockedSongUsecase) Batch(ctx context.Context, userID int, input *
 	}
 	songIDsToDelete := make([]int, 0, len(input.Delete))
 	isUltimaFlagsToDelete := make([]bool, 0, len(input.Delete))
+	deleteKeys := make(map[string]struct{}, len(input.Delete))
 	for _, deleteInput := range input.Delete {
-		if songID, ok := resolvedSongIDs[deleteInput.DisplayID.String()]; ok {
-			songIDsToDelete = append(songIDsToDelete, songID)
-			isUltimaFlagsToDelete = append(isUltimaFlagsToDelete, deleteInput.IsUltima)
+		songID, ok := resolvedSongIDs[deleteInput.DisplayID.String()]
+		if !ok {
+			continue
 		}
+		key := fmt.Sprintf("%d:%t", songID, deleteInput.IsUltima)
+		if _, exists := deleteKeys[key]; exists {
+			continue
+		}
+		deleteKeys[key] = struct{}{}
+		songIDsToDelete = append(songIDsToDelete, songID)
+		isUltimaFlagsToDelete = append(isUltimaFlagsToDelete, deleteInput.IsUltima)
 	}
 	if len(lockedSongsToAdd) == 0 && len(songIDsToDelete) == 0 {
 		return nil

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -160,17 +160,26 @@ func (u *playerLockedSongUsecase) Batch(ctx context.Context, userID int, input *
 	}
 
 	// Validate and prepare entities for bulk add
-	lockedSongsToAdd := make([]*entity.PlayerLockedSong, 0, len(input.Add))
+	addDisplayIDs := make([]string, 0, len(input.Add))
 	for _, addInput := range input.Add {
 		if addInput == nil {
 			return errPlayerLockedSongInputRequired
 		}
-		song, err := u.songRepo.FindByDisplayID(ctx, u.db, addInput.DisplayID.String())
-		if err != nil {
-			if errors.Is(err, repository.ErrSongNotFound) {
-				return repository.ErrSongNotFound
-			}
-			return err
+		addDisplayIDs = append(addDisplayIDs, addInput.DisplayID.String())
+	}
+	songs, err := u.songRepo.FindByDisplayIDs(ctx, u.db, addDisplayIDs)
+	if err != nil {
+		return err
+	}
+	songByDisplayID := make(map[string]*entity.Song, len(songs))
+	for _, song := range songs {
+		songByDisplayID[song.DisplayID] = song
+	}
+	lockedSongsToAdd := make([]*entity.PlayerLockedSong, 0, len(input.Add))
+	for _, addInput := range input.Add {
+		song, ok := songByDisplayID[addInput.DisplayID.String()]
+		if !ok {
+			return repository.ErrSongNotFound
 		}
 		if song == nil || song.IsDeleted || song.IsWorldsend {
 			return repository.ErrSongNotFound
@@ -188,18 +197,22 @@ func (u *playerLockedSongUsecase) Batch(ctx context.Context, userID int, input *
 	}
 
 	// Validate and prepare song IDs for bulk delete
-	songIDsToDelete := make([]int, 0, len(input.Delete))
-	isUltimaFlagsToDelete := make([]bool, 0, len(input.Delete))
+	deleteDisplayIDs := make([]string, 0, len(input.Delete))
 	for _, deleteInput := range input.Delete {
 		if deleteInput == nil {
 			return errPlayerLockedSongInputRequired
 		}
-		songID, err := u.resolver.ResolveSongIDByDisplayID(ctx, u.db, deleteInput.DisplayID.String())
-		if err != nil {
-			return err
-		}
-		if songID != nil {
-			songIDsToDelete = append(songIDsToDelete, *songID)
+		deleteDisplayIDs = append(deleteDisplayIDs, deleteInput.DisplayID.String())
+	}
+	resolvedSongIDs, err := u.resolver.ResolveSongIDsByDisplayIDs(ctx, u.db, deleteDisplayIDs)
+	if err != nil {
+		return err
+	}
+	songIDsToDelete := make([]int, 0, len(input.Delete))
+	isUltimaFlagsToDelete := make([]bool, 0, len(input.Delete))
+	for _, deleteInput := range input.Delete {
+		if songID, ok := resolvedSongIDs[deleteInput.DisplayID.String()]; ok {
+			songIDsToDelete = append(songIDsToDelete, songID)
 			isUltimaFlagsToDelete = append(isUltimaFlagsToDelete, deleteInput.IsUltima)
 		}
 	}

--- a/internal/usecase/player_locked_song_usecase_impl.go
+++ b/internal/usecase/player_locked_song_usecase_impl.go
@@ -148,17 +148,76 @@ func (u *playerLockedSongUsecase) Batch(ctx context.Context, userID int, input *
 	if input == nil {
 		return errPlayerLockedSongInputRequired
 	}
+	if u.tm == nil {
+		return errPlayerLockedSongNilTM
+	}
+	player, err := u.playerRepo.FindByUserID(ctx, u.db, userID)
+	if err != nil {
+		return err
+	}
+	if player == nil {
+		return ErrPlayerNotLinked
+	}
+
+	// Validate and prepare entities for bulk add
+	lockedSongsToAdd := make([]*entity.PlayerLockedSong, 0, len(input.Add))
 	for _, addInput := range input.Add {
-		if err := u.Lock(ctx, userID, addInput); err != nil {
+		if addInput == nil {
+			return errPlayerLockedSongInputRequired
+		}
+		song, err := u.songRepo.FindByDisplayID(ctx, u.db, addInput.DisplayID.String())
+		if err != nil {
+			if errors.Is(err, repository.ErrSongNotFound) {
+				return repository.ErrSongNotFound
+			}
 			return err
 		}
+		if song == nil || song.IsDeleted || song.IsWorldsend {
+			return repository.ErrSongNotFound
+		}
+		if addInput.IsUltima {
+			if !song.HasDifficultyChart(domainservice.DifficultyIDUltima) {
+				return ErrChartNotFound
+			}
+		}
+		lockedSong, err := entity.NewPlayerLockedSong(player.ID, song.ID, addInput.IsUltima)
+		if err != nil {
+			return err
+		}
+		lockedSongsToAdd = append(lockedSongsToAdd, lockedSong)
 	}
+
+	// Validate and prepare song IDs for bulk delete
+	songIDsToDelete := make([]int, 0, len(input.Delete))
+	isUltimaFlagsToDelete := make([]bool, 0, len(input.Delete))
 	for _, deleteInput := range input.Delete {
-		if err := u.Unlock(ctx, userID, deleteInput); err != nil {
+		if deleteInput == nil {
+			return errPlayerLockedSongInputRequired
+		}
+		songID, err := u.resolver.ResolveSongIDByDisplayID(ctx, u.db, deleteInput.DisplayID.String())
+		if err != nil {
 			return err
 		}
+		if songID != nil {
+			songIDsToDelete = append(songIDsToDelete, *songID)
+			isUltimaFlagsToDelete = append(isUltimaFlagsToDelete, deleteInput.IsUltima)
+		}
 	}
-	return nil
+
+	// Execute all operations in a single transaction
+	return u.tm.Transactional(ctx, func(tx repository.Executor) error {
+		if len(lockedSongsToAdd) > 0 {
+			if err := u.lockedRepo.BulkCreate(ctx, tx, lockedSongsToAdd); err != nil {
+				return err
+			}
+		}
+		if len(songIDsToDelete) > 0 {
+			if err := u.lockedRepo.BulkDelete(ctx, tx, player.ID, songIDsToDelete, isUltimaFlagsToDelete); err != nil {
+				return err
+			}
+		}
+		return u.recalculatePlayerOverpowerWithTx(ctx, tx, player)
+	})
 }
 
 func (u *playerLockedSongUsecase) recalculatePlayerOverpowerWithTx(ctx context.Context, exec repository.Executor, player *entity.Player) error {

--- a/internal/usecase/player_locked_song_usecase_impl_test.go
+++ b/internal/usecase/player_locked_song_usecase_impl_test.go
@@ -51,9 +51,11 @@ func (s *stubPlayerLockedSongPlayerRepository) DeleteByUserID(ctx context.Contex
 }
 
 type spyPlayerLockedSongRepository struct {
-	createCalled bool
-	deleteCalled bool
-	lockedSongs  []*entity.PlayerLockedSong
+	createCalled     bool
+	deleteCalled     bool
+	bulkCreateCalled bool
+	bulkDeleteCalled bool
+	lockedSongs      []*entity.PlayerLockedSong
 }
 
 func (s *spyPlayerLockedSongRepository) ListByPlayerID(ctx context.Context, exec repository.Executor, playerID int) ([]*entity.PlayerLockedSong, error) {
@@ -66,7 +68,7 @@ func (s *spyPlayerLockedSongRepository) Create(ctx context.Context, exec reposit
 }
 
 func (s *spyPlayerLockedSongRepository) BulkCreate(ctx context.Context, exec repository.Executor, lockedSongs []*entity.PlayerLockedSong) error {
-	s.createCalled = true
+	s.bulkCreateCalled = true
 	return nil
 }
 
@@ -76,7 +78,7 @@ func (s *spyPlayerLockedSongRepository) Delete(ctx context.Context, exec reposit
 }
 
 func (s *spyPlayerLockedSongRepository) BulkDelete(ctx context.Context, exec repository.Executor, playerID int, songIDs []int, isUltimaFlags []bool) error {
-	s.deleteCalled = true
+	s.bulkDeleteCalled = true
 	return nil
 }
 
@@ -350,8 +352,8 @@ func TestPlayerLockedSongBatch(t *testing.T) {
 		Delete: []*PlayerLockedSongInput{{DisplayID: displayID2, IsUltima: true}},
 	})
 	require.NoError(t, err)
-	assert.True(t, lockedRepo.createCalled)
-	assert.True(t, lockedRepo.deleteCalled)
+	assert.True(t, lockedRepo.bulkCreateCalled)
+	assert.True(t, lockedRepo.bulkDeleteCalled)
 	songRepo.AssertExpectations(t)
 }
 

--- a/internal/usecase/player_locked_song_usecase_impl_test.go
+++ b/internal/usecase/player_locked_song_usecase_impl_test.go
@@ -88,6 +88,17 @@ func (s *stubPlayerSongIDResolver) ResolveSongIDByDisplayID(ctx context.Context,
 	return s.songID, nil
 }
 
+func (s *stubPlayerSongIDResolver) ResolveSongIDsByDisplayIDs(ctx context.Context, exec repository.Executor, displayIDs []string) (map[string]int, error) {
+	resolved := make(map[string]int, len(displayIDs))
+	if s.songID == nil {
+		return resolved, nil
+	}
+	for _, displayID := range displayIDs {
+		resolved[displayID] = *s.songID
+	}
+	return resolved, nil
+}
+
 type stubPlayerRecordRepositoryForLockedSong struct {
 	records []*entity.PlayerRecord
 }
@@ -321,7 +332,7 @@ func TestPlayerLockedSongBatch(t *testing.T) {
 
 	lockedRepo := &spyPlayerLockedSongRepository{}
 	songRepo := new(MockSongRepository)
-	songRepo.On("FindByDisplayID", mock.Anything, mock.Anything, "0123456789abcdef").Return(&entity.Song{ID: 1, DisplayID: "0123456789abcdef", Charts: []*entity.Chart{}}, nil).Once()
+	songRepo.On("FindByDisplayIDs", mock.Anything, mock.Anything, []string{"0123456789abcdef"}).Return([]*entity.Song{{ID: 1, DisplayID: "0123456789abcdef", Charts: []*entity.Chart{}}}, nil).Once()
 
 	u := &playerLockedSongUsecase{
 		db:             nil,

--- a/internal/usecase/player_locked_song_usecase_impl_test.go
+++ b/internal/usecase/player_locked_song_usecase_impl_test.go
@@ -357,6 +357,8 @@ func TestPlayerLockedSongBatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, lockedRepo.bulkCreateCalled)
 	assert.True(t, lockedRepo.bulkDeleteCalled)
+	assert.False(t, lockedRepo.createCalled)
+	assert.False(t, lockedRepo.deleteCalled)
 	songRepo.AssertExpectations(t)
 }
 

--- a/internal/usecase/player_locked_song_usecase_impl_test.go
+++ b/internal/usecase/player_locked_song_usecase_impl_test.go
@@ -327,6 +327,7 @@ func TestPlayerLockedSongInputRequired(t *testing.T) {
 }
 
 func TestPlayerLockedSongBatch(t *testing.T) {
+	// Given
 	displayID1, err := displayid.NewDisplayID("0123456789abcdef")
 	require.NoError(t, err)
 	displayID2, err := displayid.NewDisplayID("fedcba9876543210")
@@ -347,10 +348,12 @@ func TestPlayerLockedSongBatch(t *testing.T) {
 		resolver:       &stubPlayerSongIDResolver{songID: ptrInt(1)},
 	}
 
+	// When
 	err = u.Batch(context.Background(), 100, &PlayerLockedSongBatchInput{
 		Add:    []*PlayerLockedSongInput{{DisplayID: displayID1, IsUltima: false}},
 		Delete: []*PlayerLockedSongInput{{DisplayID: displayID2, IsUltima: true}},
 	})
+	// Then
 	require.NoError(t, err)
 	assert.True(t, lockedRepo.bulkCreateCalled)
 	assert.True(t, lockedRepo.bulkDeleteCalled)

--- a/internal/usecase/player_locked_song_usecase_impl_test.go
+++ b/internal/usecase/player_locked_song_usecase_impl_test.go
@@ -52,6 +52,7 @@ func (s *stubPlayerLockedSongPlayerRepository) DeleteByUserID(ctx context.Contex
 
 type spyPlayerLockedSongRepository struct {
 	createCalled bool
+	deleteCalled bool
 	lockedSongs  []*entity.PlayerLockedSong
 }
 
@@ -65,7 +66,16 @@ func (s *spyPlayerLockedSongRepository) Create(ctx context.Context, exec reposit
 }
 
 func (s *spyPlayerLockedSongRepository) Delete(ctx context.Context, exec repository.Executor, playerID int, songID int, isUltima bool) error {
+	s.deleteCalled = true
 	return nil
+}
+
+type stubPlayerSongIDResolver struct {
+	songID *int
+}
+
+func (s *stubPlayerSongIDResolver) ResolveSongIDByDisplayID(ctx context.Context, exec repository.Executor, displayID string) (*int, error) {
+	return s.songID, nil
 }
 
 type stubPlayerRecordRepositoryForLockedSong struct {
@@ -270,6 +280,12 @@ func TestPlayerLockedSongInputRequired(t *testing.T) {
 				return u.Unlock(context.Background(), 100, nil)
 			},
 		},
+		{
+			name: "バッチ入力がnilの場合はエラー",
+			run: func(u *playerLockedSongUsecase) error {
+				return u.Batch(context.Background(), 100, nil)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -286,3 +302,36 @@ func TestPlayerLockedSongInputRequired(t *testing.T) {
 		})
 	}
 }
+
+func TestPlayerLockedSongBatch(t *testing.T) {
+	displayID1, err := displayid.NewDisplayID("0123456789abcdef")
+	require.NoError(t, err)
+	displayID2, err := displayid.NewDisplayID("fedcba9876543210")
+	require.NoError(t, err)
+
+	lockedRepo := &spyPlayerLockedSongRepository{}
+	songRepo := new(MockSongRepository)
+	songRepo.On("FindByDisplayID", mock.Anything, mock.Anything, "0123456789abcdef").Return(&entity.Song{ID: 1, DisplayID: "0123456789abcdef", Charts: []*entity.Chart{}}, nil).Once()
+
+	u := &playerLockedSongUsecase{
+		db:             nil,
+		tm:             &passthroughTransactionManager{},
+		playerRepo:     &stubPlayerLockedSongPlayerRepository{player: &entity.Player{ID: 10}},
+		playerRecRepo:  &stubPlayerRecordRepositoryForLockedSong{records: []*entity.PlayerRecord{}},
+		playerDataRepo: &stubPlayerDataRepositoryForLockedSong{},
+		songRepo:       songRepo,
+		lockedRepo:     lockedRepo,
+		resolver:       &stubPlayerSongIDResolver{songID: ptrInt(1)},
+	}
+
+	err = u.Batch(context.Background(), 100, &PlayerLockedSongBatchInput{
+		Add:    []*PlayerLockedSongInput{{DisplayID: displayID1, IsUltima: false}},
+		Delete: []*PlayerLockedSongInput{{DisplayID: displayID2, IsUltima: true}},
+	})
+	require.NoError(t, err)
+	assert.True(t, lockedRepo.createCalled)
+	assert.True(t, lockedRepo.deleteCalled)
+	songRepo.AssertExpectations(t)
+}
+
+func ptrInt(v int) *int { return &v }

--- a/internal/usecase/player_locked_song_usecase_impl_test.go
+++ b/internal/usecase/player_locked_song_usecase_impl_test.go
@@ -65,7 +65,17 @@ func (s *spyPlayerLockedSongRepository) Create(ctx context.Context, exec reposit
 	return nil
 }
 
+func (s *spyPlayerLockedSongRepository) BulkCreate(ctx context.Context, exec repository.Executor, lockedSongs []*entity.PlayerLockedSong) error {
+	s.createCalled = true
+	return nil
+}
+
 func (s *spyPlayerLockedSongRepository) Delete(ctx context.Context, exec repository.Executor, playerID int, songID int, isUltima bool) error {
+	s.deleteCalled = true
+	return nil
+}
+
+func (s *spyPlayerLockedSongRepository) BulkDelete(ctx context.Context, exec repository.Executor, playerID int, songIDs []int, isUltimaFlags []bool) error {
 	s.deleteCalled = true
 	return nil
 }


### PR DESCRIPTION
## 概要
- `/internal/me/locked-songs/batch` エンドポイントを追加しました。
- 1リクエストで `add`（追加）と `delete`（削除）をまとめて実行できます。
- locked-song API のDTO/Handler/Usecase/Routerを拡張し、APIドキュメントも更新しました。

## 変更内容
- ルーティング
  - `POST /internal/me/locked-songs/batch` を追加
- DTO
  - `PlayerLockedSongBatchRequest` と `PlayerLockedSongBatchRequestItem` を追加
- Handler
  - `PlayerLockedSongHandler.Batch` を追加
  - strict JSONデコードで `add`/`delete` の `display_id` を検証して Usecase に委譲
- Usecase
  - `PlayerLockedSongUsecase` に `Batch` を追加
  - `PlayerLockedSongBatchInput` を追加
  - `Batch` は `add` を先に、続けて `delete` を実行
- テスト
  - HandlerのBatchテストを追加
  - UsecaseのBatchテストと input nil エラー検証を追加
- ドキュメント
  - `docs/API.md` に batch エンドポイント仕様を追記

## テスト
- `go test ./internal/usecase ./internal/app/handler/api_internal`
- `gofmt -w` を対象ファイルへ実行

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ef487dd4832da57272e5640317ed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 複数の曲を一括でロック／アンロックするバッチAPIを追加（add/delete 配列、最大100件、成功は204 No Content）。

* **ドキュメント**
  * 新バッチAPIの利用方法を追加（認証、リクエスト構造、実行順序、主要なエラーケースを明記）。

* **テスト**
  * ハンドラとユースケース両方でバッチ処理を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chunisupport/chunisupport-api/pull/99)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->