### PR TITLE
Add design doc for Firebase ID token verification optimization

### DIFF
--- a/_report/firebase_verifyidtoken_design.md
+++ b/_report/firebase_verifyidtoken_design.md
@@ -34,26 +34,15 @@
 
 ## 4. 設計案
 
-## 4.1 Usecase 抽象の拡張
+## 4.1 Usecase 構成（案Bに統一）
 
-`internal/usecase/firebase_auth_usecase.go` の `TokenVerifier` は現状 `VerifyIDToken` のみです。実装側で revoke チェック有無を切り替えられるよう、以下のいずれかを採用します。
+`internal/usecase/firebase_auth_usecase.go` の `TokenVerifier` インターフェース自体は変更せず、実装の注入を切り替える構成とする。
 
-### 案A（推奨）: 検証モード対応インターフェースを追加
+- revoke チェックありの厳格実装と、revoke チェックなしの read 最適化実装を用意する。
+- ルーター組み立て時に read 用 / write 用で `FirebaseAuthUsecase` を別インスタンスとして生成し、適切な実装を注入する。
+- ユースケース層はインフラ詳細（失効チェック有無）を意識せず、`TokenVerifier.VerifyIDToken` の呼び出しに統一する。
 
-- 新規インターフェース `TokenVerifierWithMode` を usecase 層に追加する。
-- 例:
-  - `VerifyIDToken(ctx, idToken)`（既存）
-  - `VerifyIDTokenWithoutRevocationCheck(ctx, idToken)`（新規）
-- `firebaseAuthUsecase` は通常モードを維持しつつ、read向け usecase だけ non-revocation メソッドを呼ぶ実装を追加する。
-
-**利点**: 依存逆転を守りつつ意図が明確。
-
-### 案B: Usecase を2種類用意
-
-- `firebaseAuthUsecase` に `checkRevoked bool` を持たせる。
-- ルーター組み立て時に read 用 / write 用で別インスタンスを作る。
-
-**利点**: 変更範囲が比較的狭い。
+**利点**: Clean Architecture の依存方向を保ちながら、既存の usecase 抽象への影響を最小化できる。
 
 ## 4.2 Infra 実装の拡張
 

--- a/_report/firebase_verifyidtoken_design.md
+++ b/_report/firebase_verifyidtoken_design.md
@@ -2,72 +2,72 @@
 
 ## 1. 背景と目的
 
-現状の認証実装は `VerifyIDTokenAndCheckRevoked` を利用しており、IDトークン検証時に revoke / disabled の確認まで行っています。これにより安全性は高い一方で、読み取り系エンドポイントでも毎回外部問い合わせ寄りの検証コストが発生します。.
+現状の認証実装は `VerifyIDTokenAndCheckRevoked` を利用しており、IDトークン検証時に revoke / disabled の確認まで行っています。これにより安全性は高い一方で、読み取り系エンドポイントでも毎回外部問い合わせ寄りの検証コストが発生します。
 
-本提案の目的は、**read系エンドポイントでは `VerifyIDToken` を利用してサーバ内検証中心に切り替え、レイテンシと外部依存を低減する**ことです。.
+本提案の目的は、**read系エンドポイントでは `VerifyIDToken` を利用してサーバ内検証中心に切り替え、レイテンシと外部依存を低減する**ことです。
 
 ## 2. 現状整理
 
 ### 2.1 認証フロー
 
-- `FirebaseIDTokenMiddleware` / `OptionalFirebaseIDTokenMiddleware` が Bearer トークンを受け取り、`FirebaseAuthenticator` を呼び出す。.
-- `FirebaseAuthUsecase` が `TokenVerifier.VerifyIDToken` を通じて UID を取得し、ユーザーを解決する。.
-- `tokenVerifier` 実装は `VerifyIDTokenAndCheckRevoked` を使用している。.
+- `FirebaseIDTokenMiddleware` / `OptionalFirebaseIDTokenMiddleware` が Bearer トークンを受け取り、`FirebaseAuthenticator` を呼び出す。
+- `FirebaseAuthUsecase` が `TokenVerifier.VerifyIDToken` を通じて UID を取得し、ユーザーを解決する。
+- `tokenVerifier` 実装は `VerifyIDTokenAndCheckRevoked` を使用している。
 
 ### 2.2 ルーティング上の適用候補
 
-`/internal/users` と `/internal/songs` の公開GET群は `optionalFirebaseAuth` を使う read 系であり、`VerifyIDToken` 適用優先度が高い。.
+`/internal/users` と `/internal/songs` の公開GET群は `optionalFirebaseAuth` を使う read 系であり、`VerifyIDToken` 適用優先度が高い。
 
 ## 3. 要件定義
 
 ### 3.1 機能要件
 
-- 読み取り系 API の認証では `VerifyIDToken` を利用可能にする。.
-- 書き込み系 API の認証では従来どおり revoke / disabled を確認する。.
-- 退会など recent sign-in を要する処理は既存の厳格検証を維持する。.
+- 読み取り系 API の認証では `VerifyIDToken` を利用可能にする。
+- 書き込み系 API の認証では従来どおり revoke / disabled を確認する。
+- 退会など recent sign-in を要する処理は既存の厳格検証を維持する。
 
 ### 3.2 非機能要件
 
-- Clean Architecture の依存方向を維持する。.
-- 既存の公開 API 仕様は変更しない。.
-- 既存テストを壊さない。.
+- Clean Architecture の依存方向を維持する。
+- 既存の公開 API 仕様は変更しない。
+- 既存テストを壊さない。
 
 ## 4. 設計案
 
 ## 4.1 Usecase 抽象の拡張
 
-`internal/usecase/firebase_auth_usecase.go` の `TokenVerifier` は現状 `VerifyIDToken` のみです。実装側で revoke チェック有無を切り替えられるよう、以下のいずれかを採用します。.
+`internal/usecase/firebase_auth_usecase.go` の `TokenVerifier` は現状 `VerifyIDToken` のみです。実装側で revoke チェック有無を切り替えられるよう、以下のいずれかを採用します。
 
 ### 案A（推奨）: 検証モード対応インターフェースを追加
 
-- 新規インターフェース `TokenVerifierWithMode` を usecase 層に追加する。.
+- 新規インターフェース `TokenVerifierWithMode` を usecase 層に追加する。
 - 例:
   - `VerifyIDToken(ctx, idToken)`（既存）
   - `VerifyIDTokenWithoutRevocationCheck(ctx, idToken)`（新規）
-- `firebaseAuthUsecase` は通常モードを維持しつつ、read向け usecase だけ non-revocation メソッドを呼ぶ実装を追加する。.
+- `firebaseAuthUsecase` は通常モードを維持しつつ、read向け usecase だけ non-revocation メソッドを呼ぶ実装を追加する。
 
-**利点**: 依存逆転を守りつつ意図が明確。.
+**利点**: 依存逆転を守りつつ意図が明確。
 
 ### 案B: Usecase を2種類用意
 
-- `firebaseAuthUsecase` に `checkRevoked bool` を持たせる。.
-- ルーター組み立て時に read 用 / write 用で別インスタンスを作る。.
+- `firebaseAuthUsecase` に `checkRevoked bool` を持たせる。
+- ルーター組み立て時に read 用 / write 用で別インスタンスを作る。
 
-**利点**: 変更範囲が比較的狭い。.
+**利点**: 変更範囲が比較的狭い。
 
 ## 4.2 Infra 実装の拡張
 
-`internal/infra/firebaseauth/token_verifier.go` に以下を追加する。.
+`internal/infra/firebaseauth/token_verifier.go` に以下を追加する。
 
 - `VerifyIDTokenWithoutRevocationCheck(ctx, idToken)`
   - Firebase Admin SDK の `VerifyIDToken` を使用。
-  - 既存のエラー変換ポリシー（`ErrInvalidIDToken` / `ErrInternalError`）を踏襲。.
+  - 既存のエラー変換ポリシー（`ErrInvalidIDToken` / `ErrInternalError`）を踏襲。
 
-既存の `VerifyRecentSignIn` と `VerifyIDTokenAndCheckRevoked` ベースの厳格経路は残す。.
+既存の `VerifyRecentSignIn` と `VerifyIDTokenAndCheckRevoked` ベースの厳格経路は残す。
 
 ## 4.3 Router での適用分離
 
-`internal/app/router.go` の `registerRoutes` で、認証ミドルウェアを read/write で分離する。.
+`internal/app/router.go` の `registerRoutes` で、認証ミドルウェアを read/write で分離する。
 
 - `firebaseAuthStrict`（従来: revoke チェックあり）
 - `firebaseAuthReadOptimized`（新規: revoke チェックなし）
@@ -86,7 +86,6 @@
   - `/:username`
 - `/internal/songs` 公開GET群
   - `/updated-at`
-  - ``
   - `/:displayid`
   - `/:displayid/stats/:difficulty`
   - `/worldsend`
@@ -106,31 +105,31 @@
 
 ## 5. 実装手順（TDD）
 
-1. **Red**: `token_verifier` の新メソッドに対するテストを先に追加する。.
-2. **Green**: `VerifyIDTokenWithoutRevocationCheck` を実装し、エラー変換を揃える。.
-3. **Red**: `firebase_auth_usecase` に read最適化経路のテストを追加する。.
-4. **Green**: usecase を実装し、既存ケースが壊れないことを確認する。.
-5. **Red**: `router` で read系に新認証を適用するテストを追加する。.
-6. **Green**: ルート配線を実装する。.
-7. **Refactor**: 命名整理・重複削減。.
-8. `go test ./...` 実行。.
-9. `gofmt -s -w .` 実行。.
+1. **Red**: `token_verifier` の新メソッドに対するテストを先に追加する。
+2. **Green**: `VerifyIDTokenWithoutRevocationCheck` を実装し、エラー変換を揃える。
+3. **Red**: `firebase_auth_usecase` に read最適化経路のテストを追加する。
+4. **Green**: usecase を実装し、既存ケースが壊れないことを確認する。
+5. **Red**: `router` で read系に新認証を適用するテストを追加する。
+6. **Green**: ルート配線を実装する。
+7. **Refactor**: 命名整理・重複削減。
+8. `go test ./...` 実行。
+9. `gofmt -s -w .` 実行。
 
 ## 6. リスクと対策
 
-- リスク: revoke 直後のトークンが read系で一時的に通る可能性。.
-  - 対策: 書き込み・権限操作は strict 経路を維持。.
-- リスク: 実装分岐が増えて認証責務が複雑化。.
-  - 対策: 認証モードを enum/定数化し、ユースケースの責務境界を明示。.
+- リスク: revoke 直後のトークンが read系で一時的に通る可能性。
+  - 対策: 書き込み・権限操作は strict 経路を維持。
+- リスク: 実装分岐が増えて認証責務が複雑化。
+  - 対策: 認証モードを enum/定数化し、ユースケースの責務境界を明示。
 
 ## 7. 受け入れ条件
 
-- read系対象ルートで `VerifyIDToken` が利用される。.
-- write/critical ルートで revoke チェックが維持される。.
-- 既存 API 仕様とレスポンス互換性を維持。.
-- 既存・追加テストがすべて成功。.
+- read系対象ルートで `VerifyIDToken` が利用される。
+- write/critical ルートで revoke チェックが維持される。
+- 既存 API 仕様とレスポンス互換性を維持。
+- 既存・追加テストがすべて成功。
 
 ## 8. 将来拡張案
 
-- read経路に短TTLのサーバ内キャッシュを追加し、同一トークン検証のCPUコストをさらに低減する。.
-- メトリクス（strict/read の検証回数、失敗率、レイテンシ）を導入して、適用範囲を継続的に評価する。.
+- read経路に短TTLのサーバ内キャッシュを追加し、同一トークン検証のCPUコストをさらに低減する。
+- メトリクス（strict/read の検証回数、失敗率、レイテンシ）を導入して、適用範囲を継続的に評価する。

--- a/_report/firebase_verifyidtoken_design.md
+++ b/_report/firebase_verifyidtoken_design.md
@@ -1,0 +1,136 @@
+# Firebase IDトークン検証最適化 設計・実装案
+
+## 1. 背景と目的
+
+現状の認証実装は `VerifyIDTokenAndCheckRevoked` を利用しており、IDトークン検証時に revoke / disabled の確認まで行っています。これにより安全性は高い一方で、読み取り系エンドポイントでも毎回外部問い合わせ寄りの検証コストが発生します。.
+
+本提案の目的は、**read系エンドポイントでは `VerifyIDToken` を利用してサーバ内検証中心に切り替え、レイテンシと外部依存を低減する**ことです。.
+
+## 2. 現状整理
+
+### 2.1 認証フロー
+
+- `FirebaseIDTokenMiddleware` / `OptionalFirebaseIDTokenMiddleware` が Bearer トークンを受け取り、`FirebaseAuthenticator` を呼び出す。.
+- `FirebaseAuthUsecase` が `TokenVerifier.VerifyIDToken` を通じて UID を取得し、ユーザーを解決する。.
+- `tokenVerifier` 実装は `VerifyIDTokenAndCheckRevoked` を使用している。.
+
+### 2.2 ルーティング上の適用候補
+
+`/internal/users` と `/internal/songs` の公開GET群は `optionalFirebaseAuth` を使う read 系であり、`VerifyIDToken` 適用優先度が高い。.
+
+## 3. 要件定義
+
+### 3.1 機能要件
+
+- 読み取り系 API の認証では `VerifyIDToken` を利用可能にする。.
+- 書き込み系 API の認証では従来どおり revoke / disabled を確認する。.
+- 退会など recent sign-in を要する処理は既存の厳格検証を維持する。.
+
+### 3.2 非機能要件
+
+- Clean Architecture の依存方向を維持する。.
+- 既存の公開 API 仕様は変更しない。.
+- 既存テストを壊さない。.
+
+## 4. 設計案
+
+## 4.1 Usecase 抽象の拡張
+
+`internal/usecase/firebase_auth_usecase.go` の `TokenVerifier` は現状 `VerifyIDToken` のみです。実装側で revoke チェック有無を切り替えられるよう、以下のいずれかを採用します。.
+
+### 案A（推奨）: 検証モード対応インターフェースを追加
+
+- 新規インターフェース `TokenVerifierWithMode` を usecase 層に追加する。.
+- 例:
+  - `VerifyIDToken(ctx, idToken)`（既存）
+  - `VerifyIDTokenWithoutRevocationCheck(ctx, idToken)`（新規）
+- `firebaseAuthUsecase` は通常モードを維持しつつ、read向け usecase だけ non-revocation メソッドを呼ぶ実装を追加する。.
+
+**利点**: 依存逆転を守りつつ意図が明確。.
+
+### 案B: Usecase を2種類用意
+
+- `firebaseAuthUsecase` に `checkRevoked bool` を持たせる。.
+- ルーター組み立て時に read 用 / write 用で別インスタンスを作る。.
+
+**利点**: 変更範囲が比較的狭い。.
+
+## 4.2 Infra 実装の拡張
+
+`internal/infra/firebaseauth/token_verifier.go` に以下を追加する。.
+
+- `VerifyIDTokenWithoutRevocationCheck(ctx, idToken)`
+  - Firebase Admin SDK の `VerifyIDToken` を使用。
+  - 既存のエラー変換ポリシー（`ErrInvalidIDToken` / `ErrInternalError`）を踏襲。.
+
+既存の `VerifyRecentSignIn` と `VerifyIDTokenAndCheckRevoked` ベースの厳格経路は残す。.
+
+## 4.3 Router での適用分離
+
+`internal/app/router.go` の `registerRoutes` で、認証ミドルウェアを read/write で分離する。.
+
+- `firebaseAuthStrict`（従来: revoke チェックあり）
+- `firebaseAuthReadOptimized`（新規: revoke チェックなし）
+- `optionalFirebaseAuthReadOptimized`（新規: revoke チェックなし）
+
+### 適用対象（推奨）
+
+#### `VerifyIDToken` 適用
+
+- `/internal/users` 公開GET群
+  - `/:username/profile`
+  - `/:username/updated-at`
+  - `/:username/rating`
+  - `/:username/record`
+  - `/:username/locked-songs`
+  - `/:username`
+- `/internal/songs` 公開GET群
+  - `/updated-at`
+  - ``
+  - `/:displayid`
+  - `/:displayid/stats/:difficulty`
+  - `/worldsend`
+  - `/worldsend/:displayid`
+
+#### strict 維持
+
+- `/internal/me` の PUT/POST/DELETE
+- `/internal/users` の管理系操作
+- `/internal/songs` の編集系操作
+- `/internal/me` の `DELETE`（recent sign-in 要件あり）
+
+### 条件付き（運用判断）
+
+- `/internal/me` の GET (`/me`, `/me/goals`)
+- `/internal/master` の GET (`/master`, `/master/versions`)
+
+## 5. 実装手順（TDD）
+
+1. **Red**: `token_verifier` の新メソッドに対するテストを先に追加する。.
+2. **Green**: `VerifyIDTokenWithoutRevocationCheck` を実装し、エラー変換を揃える。.
+3. **Red**: `firebase_auth_usecase` に read最適化経路のテストを追加する。.
+4. **Green**: usecase を実装し、既存ケースが壊れないことを確認する。.
+5. **Red**: `router` で read系に新認証を適用するテストを追加する。.
+6. **Green**: ルート配線を実装する。.
+7. **Refactor**: 命名整理・重複削減。.
+8. `go test ./...` 実行。.
+9. `gofmt -s -w .` 実行。.
+
+## 6. リスクと対策
+
+- リスク: revoke 直後のトークンが read系で一時的に通る可能性。.
+  - 対策: 書き込み・権限操作は strict 経路を維持。.
+- リスク: 実装分岐が増えて認証責務が複雑化。.
+  - 対策: 認証モードを enum/定数化し、ユースケースの責務境界を明示。.
+
+## 7. 受け入れ条件
+
+- read系対象ルートで `VerifyIDToken` が利用される。.
+- write/critical ルートで revoke チェックが維持される。.
+- 既存 API 仕様とレスポンス互換性を維持。.
+- 既存・追加テストがすべて成功。.
+
+## 8. 将来拡張案
+
+- read経路に短TTLのサーバ内キャッシュを追加し、同一トークン検証のCPUコストをさらに低減する。.
+- メトリクス（strict/read の検証回数、失敗率、レイテンシ）を導入して、適用範囲を継続的に評価する。.


### PR DESCRIPTION
### Motivation

- Reduce latency and external dependency for read-only endpoints by switching from `VerifyIDTokenAndCheckRevoked` to server-side `VerifyIDToken` where revocation check is not required. 
- Preserve stronger verification (revocation/disabled/recent-sign-in) for write and sensitive endpoints to avoid weakening security guarantees.

### Description

- Add `_report/firebase_verifyidtoken_design.md` describing the design to support a non-revocation verification path and router-level separation of authentication modes. 
- Propose a new interface option `TokenVerifierWithMode` and a new method `VerifyIDTokenWithoutRevocationCheck` on the infra implementation (`internal/infra/firebaseauth/token_verifier.go`) to provide the lighter verification path. 
- Recommend router changes to introduce `firebaseAuthStrict`, `firebaseAuthReadOptimized`, and `optionalFirebaseAuthReadOptimized` middleware variants and map read-only routes (e.g. public GETs under `/internal/users` and `/internal/songs`) to the optimized path. 
- Provide a TDD implementation plan including adding tests for the new verifier, updating `firebase_auth_usecase` tests, adding router tests, running `go test ./...`, and formatting with `gofmt -s -w .`.

### Testing

- This PR only adds a design document and does not modify production code or run automated tests. 
- The design recommends adding unit tests for `VerifyIDTokenWithoutRevocationCheck`, usecase tests, and router tests and then running `go test ./...`, which is expected to pass once implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7107ff84832d8aa4707801f70cc7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Firebase IDトークン検証の最適化設計ドキュメントを追加しました。読み取り系と書き込み系で検証レベルを使い分ける方針、検証モードごとのルート分類、検証フローとテスト手順、リスクと対策、受け入れ条件、将来的な改善案（短TTLキャッシュや検証メトリクス導入）を記載しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chunisupport/chunisupport-api/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->