### PR TITLE
feat: read系でFirebase IDトークン検証を最適化

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -143,7 +143,8 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	masterDataUsecase := usecase.NewMasterDataUsecase(masterCache, chartStatsMasterProvider)
 
 	// DI - Handlers
-	firebaseAuthUsecase := usecase.NewFirebaseAuthUsecase(db, userRepo, firebaseTokenVerifier)
+	firebaseAuthUsecaseStrict := usecase.NewFirebaseAuthUsecase(db, userRepo, firebaseTokenVerifier)
+	firebaseAuthUsecaseReadOptimized := usecase.NewFirebaseAuthUsecase(db, userRepo, usecase.NewReadOptimizedTokenVerifier(firebaseTokenVerifier))
 	signupUsecase := usecase.NewSignupUsecase(tm, userRepo, firebaseTokenVerifier, masterCache)
 	handlers := &Handlers{
 		Signup:              api_internal.NewSignupHandler(signupUsecase),
@@ -182,7 +183,7 @@ func NewRouter(db *sqlx.DB, staticDB *sqlx.DB, cfg config.Config, masterCache *m
 	e.GET("/health", handleHealth(db), middleware.APITokenMiddleware(apiTokenUsecase), middleware.RequireRole(info.AccountTypeAdmin))
 
 	// ルートの登録
-	registerRoutes(e, handlers, firebaseAuthUsecase, apiTokenUsecase, cfg)
+	registerRoutes(e, handlers, firebaseAuthUsecaseStrict, firebaseAuthUsecaseReadOptimized, apiTokenUsecase, cfg)
 
 	return e
 }
@@ -201,13 +202,13 @@ func requireRecentSignInVerifier(firebaseTokenVerifier usecase.TokenVerifier) us
 }
 
 // registerRoutes はすべてのルートを登録します
-func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator middleware.FirebaseAuthenticator, apiTokenUsecase usecase.APITokenUsecase, cfg config.Config) {
+func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticatorStrict middleware.FirebaseAuthenticator, firebaseAuthenticatorReadOptimized middleware.FirebaseAuthenticator, apiTokenUsecase usecase.APITokenUsecase, cfg config.Config) {
 	// api.chunisupport.net/internal
 	internal := e.Group("/internal")
 
 	// Firebase認証ミドルウェア
-	firebaseAuth := middleware.FirebaseIDTokenMiddleware(firebaseAuthenticator)
-	optionalFirebaseAuth := middleware.OptionalFirebaseIDTokenMiddleware(firebaseAuthenticator)
+	firebaseAuthStrict := middleware.FirebaseIDTokenMiddleware(firebaseAuthenticatorStrict)
+	optionalFirebaseAuthReadOptimized := middleware.OptionalFirebaseIDTokenMiddleware(firebaseAuthenticatorReadOptimized)
 	anonymousRateLimit := middleware.AnonymousIPRateLimitMiddleware(middleware.RateLimitConfig{
 		Requests: info.InternalPublicRateLimitRequests,
 		Window:   info.InternalPublicRateLimitWindow,
@@ -227,14 +228,14 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator midd
 			Requests: info.RegisterRateLimitRequests,
 			Window:   info.RegisterRateLimitWindow,
 		}))
-		authGroup.GET("/api-tokens", handlers.APIToken.GetStatus, firebaseAuth)
-		authGroup.POST("/api-tokens", handlers.APIToken.Generate, firebaseAuth)
-		authGroup.DELETE("/api-tokens", handlers.APIToken.Delete, firebaseAuth)
+		authGroup.GET("/api-tokens", handlers.APIToken.GetStatus, firebaseAuthStrict)
+		authGroup.POST("/api-tokens", handlers.APIToken.Generate, firebaseAuthStrict)
+		authGroup.DELETE("/api-tokens", handlers.APIToken.Delete, firebaseAuthStrict)
 	}
 
 	// api.chunisupport.net/internal/me
 	meGroup := internal.Group("/me")
-	meGroup.Use(firebaseAuth)
+	meGroup.Use(firebaseAuthStrict)
 	{
 		meGroup.GET("", handlers.Profile.Me)
 		meGroup.PUT("/privacy", handlers.Profile.UpdatePrivacy)
@@ -262,14 +263,14 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator midd
 		Requests: info.TempDataRateLimitPerMin,
 		Window:   info.TempDataRateLimitWindow,
 	}))
-	temporaryPlayerDataGroup.POST("/commit", handlers.TemporaryPlayerData.CommitTemporaryData, firebaseAuth, middleware.UserRateLimitMiddleware(middleware.RateLimitConfig{
+	temporaryPlayerDataGroup.POST("/commit", handlers.TemporaryPlayerData.CommitTemporaryData, firebaseAuthStrict, middleware.UserRateLimitMiddleware(middleware.RateLimitConfig{
 		Requests: info.RegisterDataRateLimitRequests,
 		Window:   info.RegisterDataRateLimitWindow,
 	}))
 
 	// api.chunisupport.net/internal/users
 	publicUsersGroup := internal.Group("/users")
-	publicUsersGroup.Use(optionalFirebaseAuth, anonymousRateLimit)
+	publicUsersGroup.Use(optionalFirebaseAuthReadOptimized, anonymousRateLimit)
 	{
 		publicUsersGroup.GET("/:username/profile", handlers.User.GetUserProfile)
 		publicUsersGroup.GET("/:username/updated-at", handlers.User.GetUserUpdatedAt)
@@ -280,7 +281,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator midd
 	}
 
 	usersGroup := internal.Group("/users")
-	usersGroup.Use(firebaseAuth)
+	usersGroup.Use(firebaseAuthStrict)
 	{
 		usersGroup.GET("/", handlers.AdminUser.GetAllUsers, requireAdmin)
 		usersGroup.DELETE("/:username", handlers.User.DeleteUser, requireAdmin)
@@ -288,7 +289,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator midd
 
 	// api.chunisupport.net/internal/songs
 	publicSongsGroup := internal.Group("/songs")
-	publicSongsGroup.Use(optionalFirebaseAuth, anonymousRateLimit)
+	publicSongsGroup.Use(optionalFirebaseAuthReadOptimized, anonymousRateLimit)
 	{
 		publicSongsGroup.GET("/updated-at", handlers.Song.GetSongsUpdatedAt)
 		publicSongsGroup.GET("", handlers.Song.GetSongs)
@@ -304,7 +305,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator midd
 	}
 
 	songsGroup := internal.Group("/songs")
-	songsGroup.Use(firebaseAuth)
+	songsGroup.Use(firebaseAuthStrict)
 	{
 		songsGroup.POST("", handlers.Song.CreateSong, requireAdmin)
 		songsGroup.PUT("", handlers.Song.UpdateSongs, requireEditor)
@@ -322,7 +323,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator midd
 	}
 
 	editorSongsGroup := internal.Group("/editor/songs")
-	editorSongsGroup.Use(firebaseAuth, requireEditor)
+	editorSongsGroup.Use(firebaseAuthStrict, requireEditor)
 	{
 		editorSongsGroup.GET("", handlers.Song.GetEditorSongs)
 		editorSongsGroup.GET("/:displayid", handlers.Song.GetEditorSong)
@@ -332,7 +333,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticator midd
 
 	// api.chunisupport.net/internal/master
 	masterGroup := internal.Group("/master")
-	masterGroup.Use(firebaseAuth)
+	masterGroup.Use(firebaseAuthStrict)
 	{
 		masterGroup.GET("", handlers.MasterData.GetMasterData)
 	}

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -208,6 +208,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticatorStric
 
 	// Firebase認証ミドルウェア
 	firebaseAuthStrict := middleware.FirebaseIDTokenMiddleware(firebaseAuthenticatorStrict)
+	optionalFirebaseAuthStrict := middleware.OptionalFirebaseIDTokenMiddleware(firebaseAuthenticatorStrict)
 	optionalFirebaseAuthReadOptimized := middleware.OptionalFirebaseIDTokenMiddleware(firebaseAuthenticatorReadOptimized)
 	anonymousRateLimit := middleware.AnonymousIPRateLimitMiddleware(middleware.RateLimitConfig{
 		Requests: info.InternalPublicRateLimitRequests,
@@ -270,7 +271,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticatorStric
 
 	// api.chunisupport.net/internal/users
 	publicUsersGroup := internal.Group("/users")
-	publicUsersGroup.Use(optionalFirebaseAuthReadOptimized, anonymousRateLimit)
+	publicUsersGroup.Use(optionalFirebaseAuthStrict, anonymousRateLimit)
 	{
 		publicUsersGroup.GET("/:username/profile", handlers.User.GetUserProfile)
 		publicUsersGroup.GET("/:username/updated-at", handlers.User.GetUserUpdatedAt)

--- a/internal/app/router_authorization_test.go
+++ b/internal/app/router_authorization_test.go
@@ -56,7 +56,7 @@ func TestRegisterRoutes_楽曲追加削除はEDITORを拒否する(t *testing.T)
 			// Given
 			e := echo.New()
 			e.HTTPErrorHandler = appmiddleware.CustomHTTPErrorHandler
-			registerRoutes(e, newAuthorizationTestHandlers(), stubFirebaseAuthenticator{}, nil, config.Config{})
+			registerRoutes(e, newAuthorizationTestHandlers(), stubFirebaseAuthenticator{}, stubFirebaseAuthenticator{}, nil, config.Config{})
 
 			req := httptest.NewRequest(tt.method, tt.path, nil)
 			req.Header.Set(echo.HeaderAuthorization, "Bearer editor-token")

--- a/internal/app/router_authorization_test.go
+++ b/internal/app/router_authorization_test.go
@@ -74,7 +74,7 @@ func TestRegisterRoutes_楽曲追加削除はEDITORを拒否する(t *testing.T)
 			e.HTTPErrorHandler = appmiddleware.CustomHTTPErrorHandler
 			registerRoutes(e, newAuthorizationTestHandlers(), stubFirebaseAuthenticator{}, stubFirebaseAuthenticator{}, nil, config.Config{})
 
-			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req := httptest.NewRequestWithContext(context.Background(), tt.method, tt.path, nil)
 			req.Header.Set(echo.HeaderAuthorization, "Bearer editor-token")
 			rec := httptest.NewRecorder()
 
@@ -97,12 +97,12 @@ func TestRegisterRoutes_公開GETはread最適化認証を使い書き込みはs
 	registerRoutes(e, newAuthorizationTestHandlers(), strictAuth, readOptimizedAuth, nil, config.Config{})
 
 	// When
-	getReq := httptest.NewRequest(http.MethodGet, "/internal/songs", nil)
+	getReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/internal/songs", nil)
 	getReq.Header.Set(echo.HeaderAuthorization, "Bearer any-token")
 	getRec := httptest.NewRecorder()
 	e.ServeHTTP(getRec, getReq)
 
-	postReq := httptest.NewRequest(http.MethodPost, "/internal/songs", nil)
+	postReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/internal/songs", nil)
 	postReq.Header.Set(echo.HeaderAuthorization, "Bearer any-token")
 	postRec := httptest.NewRecorder()
 	e.ServeHTTP(postRec, postReq)

--- a/internal/app/router_authorization_test.go
+++ b/internal/app/router_authorization_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/config"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/info"
+	"github.com/chunisupport/chunisupport-api/internal/usecase"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,21 @@ func (stubFirebaseAuthenticator) Authenticate(ctx context.Context, idToken strin
 
 func (stubFirebaseAuthenticator) AuthenticateOptional(ctx context.Context, idToken string) (*entity.User, error) {
 	return authenticateTestUser(idToken), nil
+}
+
+type countingAuthenticator struct {
+	authenticateCalls         int
+	authenticateOptionalCalls int
+}
+
+func (a *countingAuthenticator) Authenticate(_ context.Context, _ string) (*entity.User, error) {
+	a.authenticateCalls++
+	return nil, usecase.ErrInvalidIDToken
+}
+
+func (a *countingAuthenticator) AuthenticateOptional(_ context.Context, _ string) (*entity.User, error) {
+	a.authenticateOptionalCalls++
+	return nil, usecase.ErrInvalidIDToken
 }
 
 func authenticateTestUser(idToken string) *entity.User {
@@ -70,6 +86,34 @@ func TestRegisterRoutes_楽曲追加削除はEDITORを拒否する(t *testing.T)
 			assert.Contains(t, rec.Body.String(), "forbidden")
 		})
 	}
+}
+
+func TestRegisterRoutes_公開GETはread最適化認証を使い書き込みはstrict認証を使う(t *testing.T) {
+	// Given
+	e := echo.New()
+	e.HTTPErrorHandler = appmiddleware.CustomHTTPErrorHandler
+	strictAuth := &countingAuthenticator{}
+	readOptimizedAuth := &countingAuthenticator{}
+	registerRoutes(e, newAuthorizationTestHandlers(), strictAuth, readOptimizedAuth, nil, config.Config{})
+
+	// When
+	getReq := httptest.NewRequest(http.MethodGet, "/internal/songs", nil)
+	getReq.Header.Set(echo.HeaderAuthorization, "Bearer any-token")
+	getRec := httptest.NewRecorder()
+	e.ServeHTTP(getRec, getReq)
+
+	postReq := httptest.NewRequest(http.MethodPost, "/internal/songs", nil)
+	postReq.Header.Set(echo.HeaderAuthorization, "Bearer any-token")
+	postRec := httptest.NewRecorder()
+	e.ServeHTTP(postRec, postReq)
+
+	// Then
+	require.Equal(t, http.StatusUnauthorized, getRec.Code)
+	require.Equal(t, http.StatusUnauthorized, postRec.Code)
+	assert.Equal(t, 1, readOptimizedAuth.authenticateOptionalCalls)
+	assert.Equal(t, 0, readOptimizedAuth.authenticateCalls)
+	assert.Equal(t, 1, strictAuth.authenticateCalls)
+	assert.Equal(t, 0, strictAuth.authenticateOptionalCalls)
 }
 
 func newAuthorizationTestHandlers() *Handlers {

--- a/internal/app/router_authorization_test.go
+++ b/internal/app/router_authorization_test.go
@@ -116,6 +116,26 @@ func TestRegisterRoutes_公開GETはread最適化認証を使い書き込みはs
 	assert.Equal(t, 0, strictAuth.authenticateOptionalCalls)
 }
 
+func TestRegisterRoutes_users公開GETはstrict認証を使う(t *testing.T) {
+	// Given
+	e := echo.New()
+	e.HTTPErrorHandler = appmiddleware.CustomHTTPErrorHandler
+	strictAuth := &countingAuthenticator{}
+	readOptimizedAuth := &countingAuthenticator{}
+	registerRoutes(e, newAuthorizationTestHandlers(), strictAuth, readOptimizedAuth, nil, config.Config{})
+
+	// When
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/internal/users/test/profile", nil)
+	req.Header.Set(echo.HeaderAuthorization, "Bearer any-token")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	// Then
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, 1, strictAuth.authenticateOptionalCalls)
+	assert.Equal(t, 0, readOptimizedAuth.authenticateOptionalCalls)
+}
+
 func newAuthorizationTestHandlers() *Handlers {
 	return &Handlers{
 		Signup:              new(internalhandler.SignupHandler),

--- a/internal/infra/firebaseauth/token_verifier.go
+++ b/internal/infra/firebaseauth/token_verifier.go
@@ -53,7 +53,8 @@ func (v *tokenVerifier) VerifyIDToken(ctx context.Context, idToken string) (stri
 	return normalizeUID(token.UID), nil
 }
 
-// VerifyIDTokenWithoutRevocationCheck は Firebase ID トークンを失効確認なしで検証し、UID を返します。
+// VerifyIDTokenWithoutRevocationCheck は read 系の性能最適化向けに、Firebase ID トークンを失効確認なしで検証し UID を返します。
+// 公開 read エンドポイントに限定して利用し、書き込み・権限変更・セキュリティクリティカルな操作では利用してはいけません。
 func (v *tokenVerifier) VerifyIDTokenWithoutRevocationCheck(ctx context.Context, idToken string) (string, error) {
 	token, err := v.verifyTokenWithoutRevocationCheck(ctx, idToken)
 	if err != nil {

--- a/internal/infra/firebaseauth/token_verifier.go
+++ b/internal/infra/firebaseauth/token_verifier.go
@@ -12,6 +12,7 @@ import (
 )
 
 type authClient interface {
+	VerifyIDToken(ctx context.Context, idToken string) (*firebaseauthsdk.Token, error)
 	VerifyIDTokenAndCheckRevoked(ctx context.Context, idToken string) (*firebaseauthsdk.Token, error)
 }
 
@@ -44,7 +45,7 @@ func NewTokenVerifierFromApp(ctx context.Context, app *firebase.App) (usecase.To
 
 // VerifyIDToken は Firebase ID トークンを検証し、失効・無効化も含めて UID を返します。
 func (v *tokenVerifier) VerifyIDToken(ctx context.Context, idToken string) (string, error) {
-	token, err := v.verifyToken(ctx, idToken)
+	token, err := v.verifyTokenWithRevocationCheck(ctx, idToken)
 	if err != nil {
 		return "", err
 	}
@@ -53,8 +54,19 @@ func (v *tokenVerifier) VerifyIDToken(ctx context.Context, idToken string) (stri
 }
 
 // VerifyRecentSignIn は Firebase ID トークンを検証し、UID と auth_time を返します。
+
+// VerifyIDTokenWithoutRevocationCheck は Firebase ID トークンを失効確認なしで検証し、UID を返します。
+func (v *tokenVerifier) VerifyIDTokenWithoutRevocationCheck(ctx context.Context, idToken string) (string, error) {
+	token, err := v.verifyTokenWithoutRevocationCheck(ctx, idToken)
+	if err != nil {
+		return "", err
+	}
+
+	return normalizeUID(token.UID), nil
+}
+
 func (v *tokenVerifier) VerifyRecentSignIn(ctx context.Context, idToken string) (*usecase.RecentSignInInfo, error) {
-	token, err := v.verifyToken(ctx, idToken)
+	token, err := v.verifyTokenWithRevocationCheck(ctx, idToken)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +80,7 @@ func (v *tokenVerifier) VerifyRecentSignIn(ctx context.Context, idToken string) 
 	}, nil
 }
 
-func (v *tokenVerifier) verifyToken(ctx context.Context, idToken string) (*firebaseauthsdk.Token, error) {
+func (v *tokenVerifier) verifyTokenWithRevocationCheck(ctx context.Context, idToken string) (*firebaseauthsdk.Token, error) {
 	if v.client == nil {
 		return nil, errors.Join(usecase.ErrInternalError, errors.New("firebase auth client is nil"))
 	}
@@ -95,3 +107,24 @@ func normalizeUID(uid string) string {
 
 var _ usecase.TokenVerifier = (*tokenVerifier)(nil)
 var _ usecase.RecentSignInVerifier = (*tokenVerifier)(nil)
+
+func (v *tokenVerifier) verifyTokenWithoutRevocationCheck(ctx context.Context, idToken string) (*firebaseauthsdk.Token, error) {
+	if v.client == nil {
+		return nil, errors.Join(usecase.ErrInternalError, errors.New("firebase auth client is nil"))
+	}
+
+	token, err := v.client.VerifyIDToken(ctx, idToken)
+	if err != nil {
+		if isFirebaseInvalidIDToken(err) {
+			return nil, errors.Join(usecase.ErrInvalidIDToken, err)
+		}
+
+		return nil, errors.Join(usecase.ErrInternalError, err)
+	}
+
+	if token == nil || normalizeUID(token.UID) == "" {
+		return nil, errors.Join(usecase.ErrInternalError, errors.New("firebase token uid is empty"))
+	}
+
+	return token, nil
+}

--- a/internal/infra/firebaseauth/token_verifier.go
+++ b/internal/infra/firebaseauth/token_verifier.go
@@ -53,8 +53,6 @@ func (v *tokenVerifier) VerifyIDToken(ctx context.Context, idToken string) (stri
 	return normalizeUID(token.UID), nil
 }
 
-// VerifyRecentSignIn は Firebase ID トークンを検証し、UID と auth_time を返します。
-
 // VerifyIDTokenWithoutRevocationCheck は Firebase ID トークンを失効確認なしで検証し、UID を返します。
 func (v *tokenVerifier) VerifyIDTokenWithoutRevocationCheck(ctx context.Context, idToken string) (string, error) {
 	token, err := v.verifyTokenWithoutRevocationCheck(ctx, idToken)
@@ -65,6 +63,7 @@ func (v *tokenVerifier) VerifyIDTokenWithoutRevocationCheck(ctx context.Context,
 	return normalizeUID(token.UID), nil
 }
 
+// VerifyRecentSignIn は Firebase ID トークンを検証し、UID と auth_time を返します。
 func (v *tokenVerifier) VerifyRecentSignIn(ctx context.Context, idToken string) (*usecase.RecentSignInInfo, error) {
 	token, err := v.verifyTokenWithRevocationCheck(ctx, idToken)
 	if err != nil {

--- a/internal/infra/firebaseauth/token_verifier_test.go
+++ b/internal/infra/firebaseauth/token_verifier_test.go
@@ -16,22 +16,19 @@ type stubAuthClient struct {
 	verifyIDTokenToken *firebaseauthsdk.Token
 	verifyIDTokenErr   error
 
-	token         *firebaseauthsdk.Token
-	err           error
-	receivedToken string
+	verifyIDTokenAndCheckRevokedToken *firebaseauthsdk.Token
+	verifyIDTokenAndCheckRevokedErr   error
+	receivedToken                     string
 }
 
 func (s *stubAuthClient) VerifyIDToken(_ context.Context, idToken string) (*firebaseauthsdk.Token, error) {
 	s.receivedToken = idToken
-	if s.verifyIDTokenToken != nil || s.verifyIDTokenErr != nil {
-		return s.verifyIDTokenToken, s.verifyIDTokenErr
-	}
-	return s.token, s.err
+	return s.verifyIDTokenToken, s.verifyIDTokenErr
 }
 
 func (s *stubAuthClient) VerifyIDTokenAndCheckRevoked(_ context.Context, idToken string) (*firebaseauthsdk.Token, error) {
 	s.receivedToken = idToken
-	return s.token, s.err
+	return s.verifyIDTokenAndCheckRevokedToken, s.verifyIDTokenAndCheckRevokedErr
 }
 
 func TestTokenVerifier_VerifyIDToken(t *testing.T) {
@@ -67,44 +64,44 @@ func TestTokenVerifier_VerifyIDToken(t *testing.T) {
 	}{
 		{
 			name:    "UID を返せる場合はそのまま返す",
-			client:  &stubAuthClient{token: &firebaseauthsdk.Token{UID: "firebase-uid"}},
+			client:  &stubAuthClient{verifyIDTokenAndCheckRevokedToken: &firebaseauthsdk.Token{UID: "firebase-uid"}},
 			idToken: "valid-token",
 			wantUID: "firebase-uid",
 		},
 		{
 			name:    "UID に前後空白が含まれる場合は正規化して返す",
-			client:  &stubAuthClient{token: &firebaseauthsdk.Token{UID: "  firebase-uid  "}},
+			client:  &stubAuthClient{verifyIDTokenAndCheckRevokedToken: &firebaseauthsdk.Token{UID: "  firebase-uid  "}},
 			idToken: "valid-token-with-space",
 			wantUID: "firebase-uid",
 		},
 		{
 			name:    "SDK が不正トークンエラーを返す場合は ErrInvalidIDToken を返す",
-			client:  &stubAuthClient{err: invalidErr},
+			client:  &stubAuthClient{verifyIDTokenAndCheckRevokedErr: invalidErr},
 			idToken: "invalid-token",
 			wantErr: usecase.ErrInvalidIDToken,
 		},
 		{
 			name:    "SDK が失効済みトークンエラーを返す場合は ErrInvalidIDToken を返す",
-			client:  &stubAuthClient{err: revokedErr},
+			client:  &stubAuthClient{verifyIDTokenAndCheckRevokedErr: revokedErr},
 			idToken: "revoked-token",
 			wantErr: usecase.ErrInvalidIDToken,
 		},
 		{
 			name:    "SDK が無効化済みユーザーエラーを返す場合は ErrInvalidIDToken を返す",
-			client:  &stubAuthClient{err: disabledErr},
+			client:  &stubAuthClient{verifyIDTokenAndCheckRevokedErr: disabledErr},
 			idToken: "disabled-user-token",
 			wantErr: usecase.ErrInvalidIDToken,
 		},
 		{
 			name:      "SDK の内部エラーは ErrInternalError で返す",
-			client:    &stubAuthClient{err: errors.New("verify failed")},
+			client:    &stubAuthClient{verifyIDTokenAndCheckRevokedErr: errors.New("verify failed")},
 			idToken:   "internal-error-token",
 			wantErr:   usecase.ErrInternalError,
 			wantErrIn: "verify failed",
 		},
 		{
 			name:      "UID が空なら ErrInternalError を返す",
-			client:    &stubAuthClient{token: &firebaseauthsdk.Token{}},
+			client:    &stubAuthClient{verifyIDTokenAndCheckRevokedToken: &firebaseauthsdk.Token{}},
 			idToken:   "empty-uid-token",
 			wantErr:   usecase.ErrInternalError,
 			wantErrIn: "firebase token uid is empty",
@@ -181,28 +178,28 @@ func TestTokenVerifier_VerifyRecentSignIn(t *testing.T) {
 	}{
 		{
 			name:         "AuthTime を返せる場合は recent sign-in 情報を返す",
-			client:       &stubAuthClient{token: &firebaseauthsdk.Token{UID: "firebase-uid", AuthTime: 1704067200}},
+			client:       &stubAuthClient{verifyIDTokenAndCheckRevokedToken: &firebaseauthsdk.Token{UID: "firebase-uid", AuthTime: 1704067200}},
 			idToken:      "valid-token",
 			wantUID:      "firebase-uid",
 			wantAuthTime: 1704067200,
 		},
 		{
 			name:         "recent sign-in UID に前後空白が含まれる場合は正規化して返す",
-			client:       &stubAuthClient{token: &firebaseauthsdk.Token{UID: "  firebase-uid  ", AuthTime: 1704067200}},
+			client:       &stubAuthClient{verifyIDTokenAndCheckRevokedToken: &firebaseauthsdk.Token{UID: "  firebase-uid  ", AuthTime: 1704067200}},
 			idToken:      "valid-token-with-space",
 			wantUID:      "firebase-uid",
 			wantAuthTime: 1704067200,
 		},
 		{
 			name:      "AuthTime が空なら専用の recent sign-in エラーを返す",
-			client:    &stubAuthClient{token: &firebaseauthsdk.Token{UID: "firebase-uid"}},
+			client:    &stubAuthClient{verifyIDTokenAndCheckRevokedToken: &firebaseauthsdk.Token{UID: "firebase-uid"}},
 			idToken:   "missing-auth-time-token",
 			wantErr:   usecase.ErrRecentSignInAuthTimeMissing,
 			wantErrIn: "firebase token auth_time is empty",
 		},
 		{
 			name:      "SDK が不正トークンエラーを返す場合は ErrInvalidIDToken を返す",
-			client:    &stubAuthClient{err: invalidErr},
+			client:    &stubAuthClient{verifyIDTokenAndCheckRevokedErr: invalidErr},
 			idToken:   "invalid-token",
 			wantErr:   usecase.ErrInvalidIDToken,
 			wantErrIn: "invalid token from firebase sdk",

--- a/internal/infra/firebaseauth/token_verifier_test.go
+++ b/internal/infra/firebaseauth/token_verifier_test.go
@@ -13,9 +13,20 @@ import (
 )
 
 type stubAuthClient struct {
+	verifyIDTokenToken *firebaseauthsdk.Token
+	verifyIDTokenErr   error
+
 	token         *firebaseauthsdk.Token
 	err           error
 	receivedToken string
+}
+
+func (s *stubAuthClient) VerifyIDToken(_ context.Context, idToken string) (*firebaseauthsdk.Token, error) {
+	s.receivedToken = idToken
+	if s.verifyIDTokenToken != nil || s.verifyIDTokenErr != nil {
+		return s.verifyIDTokenToken, s.verifyIDTokenErr
+	}
+	return s.token, s.err
 }
 
 func (s *stubAuthClient) VerifyIDTokenAndCheckRevoked(_ context.Context, idToken string) (*firebaseauthsdk.Token, error) {
@@ -219,6 +230,38 @@ func TestTokenVerifier_VerifyRecentSignIn(t *testing.T) {
 				assert.Equal(t, tt.wantUID, info.UID)
 				assert.Equal(t, time.Unix(tt.wantAuthTime, 0).UTC(), info.AuthTime)
 			}
+		})
+	}
+}
+
+func TestTokenVerifier_VerifyIDTokenWithoutRevocationCheck(t *testing.T) {
+	originalIsFirebaseInvalidIDToken := isFirebaseInvalidIDToken
+	t.Cleanup(func() { isFirebaseInvalidIDToken = originalIsFirebaseInvalidIDToken })
+	invalidErr := errors.New("invalid token from firebase sdk")
+	isFirebaseInvalidIDToken = func(err error) bool { return errors.Is(err, invalidErr) }
+
+	tests := []struct {
+		name    string
+		client  authClient
+		idToken string
+		wantUID string
+		wantErr error
+	}{
+		{name: "UID を返せる", client: &stubAuthClient{verifyIDTokenToken: &firebaseauthsdk.Token{UID: "uid"}}, idToken: "ok", wantUID: "uid"},
+		{name: "不正トークンは ErrInvalidIDToken", client: &stubAuthClient{verifyIDTokenErr: invalidErr}, idToken: "invalid", wantErr: usecase.ErrInvalidIDToken},
+		{name: "内部エラーは ErrInternalError", client: &stubAuthClient{verifyIDTokenErr: errors.New("boom")}, idToken: "err", wantErr: usecase.ErrInternalError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verifier := &tokenVerifier{client: tt.client}
+			uid, err := verifier.VerifyIDTokenWithoutRevocationCheck(context.Background(), tt.idToken)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantUID, uid)
 		})
 	}
 }

--- a/internal/usecase/read_optimized_token_verifier.go
+++ b/internal/usecase/read_optimized_token_verifier.go
@@ -1,0 +1,31 @@
+package usecase
+
+import "context"
+
+type readOptimizedCapableVerifier interface {
+	TokenVerifier
+	VerifyIDTokenWithoutRevocationCheck(ctx context.Context, idToken string) (string, error)
+}
+
+// ReadOptimizedTokenVerifier は読み取り系向けに失効チェックなし検証を優先するラッパーです。
+type ReadOptimizedTokenVerifier struct {
+	strict readOptimizedCapableVerifier
+}
+
+// NewReadOptimizedTokenVerifier は read 系向け TokenVerifier を生成します。
+func NewReadOptimizedTokenVerifier(strict TokenVerifier) TokenVerifier {
+	if strict == nil {
+		return nil
+	}
+
+	verifier, ok := strict.(readOptimizedCapableVerifier)
+	if !ok {
+		return strict
+	}
+
+	return &ReadOptimizedTokenVerifier{strict: verifier}
+}
+
+func (v *ReadOptimizedTokenVerifier) VerifyIDToken(ctx context.Context, idToken string) (string, error) {
+	return v.strict.VerifyIDTokenWithoutRevocationCheck(ctx, idToken)
+}

--- a/internal/usecase/read_optimized_token_verifier_test.go
+++ b/internal/usecase/read_optimized_token_verifier_test.go
@@ -1,0 +1,86 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubReadOptimizedCapableVerifier struct {
+	verifyIDTokenCalled                       bool
+	verifyIDTokenWithoutRevocationCheckCalled bool
+	wantIDToken                               string
+	verifyIDTokenWithoutRevocationCheckErr    error
+}
+
+func (s *stubReadOptimizedCapableVerifier) VerifyIDToken(_ context.Context, idToken string) (string, error) {
+	s.verifyIDTokenCalled = true
+	s.wantIDToken = idToken
+	return "strict-uid", nil
+}
+
+func (s *stubReadOptimizedCapableVerifier) VerifyIDTokenWithoutRevocationCheck(_ context.Context, idToken string) (string, error) {
+	s.verifyIDTokenWithoutRevocationCheckCalled = true
+	s.wantIDToken = idToken
+	if s.verifyIDTokenWithoutRevocationCheckErr != nil {
+		return "", s.verifyIDTokenWithoutRevocationCheckErr
+	}
+	return "read-uid", nil
+}
+
+type stubOnlyTokenVerifier struct {
+	called bool
+}
+
+func (s *stubOnlyTokenVerifier) VerifyIDToken(_ context.Context, _ string) (string, error) {
+	s.called = true
+	return "only-strict-uid", nil
+}
+
+func TestNewReadOptimizedTokenVerifier(t *testing.T) {
+	t.Run("nil を渡すと nil を返す", func(t *testing.T) {
+		got := NewReadOptimizedTokenVerifier(nil)
+		assert.Nil(t, got)
+	})
+
+	t.Run("readOptimizedCapableVerifier を渡すとラッパー化され失効確認なし検証へ委譲される", func(t *testing.T) {
+		strict := &stubReadOptimizedCapableVerifier{}
+
+		got := NewReadOptimizedTokenVerifier(strict)
+		wrapped, ok := got.(*ReadOptimizedTokenVerifier)
+		require.True(t, ok)
+		require.NotNil(t, wrapped)
+
+		uid, err := got.VerifyIDToken(context.Background(), "token-1")
+		require.NoError(t, err)
+		assert.Equal(t, "read-uid", uid)
+		assert.True(t, strict.verifyIDTokenWithoutRevocationCheckCalled)
+		assert.False(t, strict.verifyIDTokenCalled)
+		assert.Equal(t, "token-1", strict.wantIDToken)
+	})
+
+	t.Run("readOptimizedCapableVerifier を実装しない TokenVerifier はそのまま返す", func(t *testing.T) {
+		strict := &stubOnlyTokenVerifier{}
+
+		got := NewReadOptimizedTokenVerifier(strict)
+		assert.Same(t, strict, got)
+
+		uid, err := got.VerifyIDToken(context.Background(), "token-2")
+		require.NoError(t, err)
+		assert.Equal(t, "only-strict-uid", uid)
+		assert.True(t, strict.called)
+	})
+
+	t.Run("ラッパー化後に失効確認なし検証が失敗したらエラーを返す", func(t *testing.T) {
+		strict := &stubReadOptimizedCapableVerifier{verifyIDTokenWithoutRevocationCheckErr: errors.New("verify failed")}
+		got := NewReadOptimizedTokenVerifier(strict)
+
+		uid, err := got.VerifyIDToken(context.Background(), "token-3")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "verify failed")
+		assert.Empty(t, uid)
+	})
+}


### PR DESCRIPTION
### Motivation
- 公開の読み取り系エンドポイントで Firebase の失効チェックを毎回行うとレイテンシと外部依存が増えるため、read 系では失効チェックなしの検証を使えるようにして性能と可用性を改善する。 
- 書き込みや権限変更などの重要操作では従来どおり失効/無効化チェックを残し、安全性を維持する。 

### Description
- `internal/infra/firebaseauth/token_verifier.go` に失効チェックなし検証の経路を追加し、`VerifyIDTokenWithoutRevocationCheck` と内部の `verifyTokenWithoutRevocationCheck` を実装した。 
- `internal/infra/firebaseauth/token_verifier_test.go` に失効チェックなし経路向けのテストを追加して、正常系・不正トークン・内部エラーの挙動を検証するテストを追加した。 
- `internal/usecase/read_optimized_token_verifier.go` を追加して、既存の `TokenVerifier` 抽象を壊さずに read 最適化用のラッパー `ReadOptimizedTokenVerifier` を提供するようにした。 
- ルーターで strict / read-optimized の認証経路を分離し、公開 GET 群（`/internal/users`、`/internal/songs` の optional 認証）に read 最適化経路を適用し、書き込み/管理系は strict 経路を維持するように `internal/app/router.go` を変更した。 
- ルート関連のテスト呼び出しを単純に合わせるために `internal/app/router_authorization_test.go` のテスト呼び出しを更新した。 

変更した主なファイル: `internal/infra/firebaseauth/token_verifier.go`, `internal/infra/firebaseauth/token_verifier_test.go`, `internal/usecase/read_optimized_token_verifier.go`, `internal/app/router.go`, `internal/app/router_authorization_test.go`。

### Testing
- 自動テストを実行してすべて成功を確認した: `go test ./...` は成功（関連パッケージ含む）。 
- コード整形を実行した: `gofmt -s -w .` を実行し、その後再度 `go test ./...` を実行して問題がないことを確認した。 
- 追加したユニットテスト（`token_verifier` の新しいケース、ルーター権限制御テストの引数適合）は通過した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8843d50c832d9bbd56f4e24e1849)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 公開読み取り向けに失効確認を省く「読み取り最適化」認証モードと、失効確認なしのトークン検証経路を追加

* **Refactor**
  * 内部向けルーティングを読み取りは読み取り最適化、書き込みは厳密認証へ分岐する認証割当に変更
  * トークン検証処理を失効確認あり/なしの二系統に整理

* **Tests**
  * 認証振る舞い（公開GETは読み取り最適化、書き込みは厳密）と新検証経路を検証する単体テストを追加・拡張

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chunisupport/chunisupport-api/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->