### PR TITLE
fix: honorsテーブルのimage_urlを非NULLに変更し、ユニーク制約を(name, honor_type_id, ima…

### DIFF
--- a/internal/infra/repository/honor_repository_impl.go
+++ b/internal/infra/repository/honor_repository_impl.go
@@ -22,12 +22,13 @@ func NewHonorRepository(db *sqlx.DB) repository.HonorRepository {
 // EnsureHonor は称号を登録または既存のIDを取得します。
 // 称号が存在しなければ登録され、存在すれば既存のIDが返されます。
 func (r *honorRepository) EnsureHonor(ctx context.Context, exec repository.Executor, title string, honorTypeID int, imageURL *string) (int, error) {
+	storedTitle := strings.TrimSpace(title)
 	storedImageURL := ""
 	if imageURL != nil {
 		storedImageURL = strings.TrimSpace(*imageURL)
 	}
 	query := `INSERT INTO honors (name, honor_type_id, image_url) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`
-	result, err := exec.ExecContext(ctx, query, title, honorTypeID, storedImageURL)
+	result, err := exec.ExecContext(ctx, query, storedTitle, honorTypeID, storedImageURL)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/infra/repository/honor_repository_impl.go
+++ b/internal/infra/repository/honor_repository_impl.go
@@ -23,8 +23,12 @@ func NewHonorRepository(db *sqlx.DB) repository.HonorRepository {
 // 称号が存在しなければ登録され、存在すれば既存のIDが返されます。
 // imageURL が指定されている場合は更新します。
 func (r *honorRepository) EnsureHonor(ctx context.Context, exec repository.Executor, title string, honorTypeID int, imageURL *string) (int, error) {
-	query := `INSERT INTO honors (name, honor_type_id, image_url) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id), image_url = VALUES(image_url)`
-	result, err := exec.ExecContext(ctx, query, title, honorTypeID, imageURL)
+	storedImageURL := ""
+	if imageURL != nil {
+		storedImageURL = strings.TrimSpace(*imageURL)
+	}
+	query := `INSERT INTO honors (name, honor_type_id, image_url) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`
+	result, err := exec.ExecContext(ctx, query, title, honorTypeID, storedImageURL)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/infra/repository/honor_repository_impl.go
+++ b/internal/infra/repository/honor_repository_impl.go
@@ -21,7 +21,6 @@ func NewHonorRepository(db *sqlx.DB) repository.HonorRepository {
 
 // EnsureHonor は称号を登録または既存のIDを取得します。
 // 称号が存在しなければ登録され、存在すれば既存のIDが返されます。
-// imageURL が指定されている場合は更新します。
 func (r *honorRepository) EnsureHonor(ctx context.Context, exec repository.Executor, title string, honorTypeID int, imageURL *string) (int, error) {
 	storedImageURL := ""
 	if imageURL != nil {

--- a/internal/infra/repository/honor_repository_impl_test.go
+++ b/internal/infra/repository/honor_repository_impl_test.go
@@ -28,7 +28,7 @@ func TestEnsureHonor_称号の一意キー単位でUpsertする(t *testing.T) {
 	repo := &honorRepository{}
 
 	// When
-	id, err := repo.EnsureHonor(context.Background(), exec, "称号A", 2, &imageURL)
+	id, err := repo.EnsureHonor(context.Background(), exec, " 称号A ", 2, &imageURL)
 
 	// Then
 	require.NoError(t, err)

--- a/internal/infra/repository/honor_repository_impl_test.go
+++ b/internal/infra/repository/honor_repository_impl_test.go
@@ -1,0 +1,54 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type honorEnsureExec struct {
+	baseExecutor
+	query string
+	args  []any
+}
+
+func (e *honorEnsureExec) ExecContext(_ context.Context, query string, args ...any) (sql.Result, error) {
+	e.query = query
+	e.args = args
+	return rowsAffectedResult{lastInsertID: 10, rowsAffected: 1}, nil
+}
+
+func TestEnsureHonor_称号の一意キー単位でUpsertする(t *testing.T) {
+	// Given
+	imageURL := " https://example.com/honor.png "
+	exec := &honorEnsureExec{}
+	repo := &honorRepository{}
+
+	// When
+	id, err := repo.EnsureHonor(context.Background(), exec, "称号A", 2, &imageURL)
+
+	// Then
+	require.NoError(t, err)
+	assert.Equal(t, 10, id)
+	assert.Contains(t, exec.query, "INSERT INTO honors (name, honor_type_id, image_url)")
+	assert.Contains(t, exec.query, "ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)")
+	assert.NotContains(t, exec.query, "image_url = VALUES(image_url)")
+	assert.Equal(t, []any{"称号A", 2, "https://example.com/honor.png"}, exec.args)
+}
+
+func TestEnsureHonor_画像URLがnilの場合は空文字でUpsertする(t *testing.T) {
+	// Given
+	exec := &honorEnsureExec{}
+	repo := &honorRepository{}
+
+	// When
+	id, err := repo.EnsureHonor(context.Background(), exec, "称号A", 2, nil)
+
+	// Then
+	require.NoError(t, err)
+	assert.Equal(t, 10, id)
+	assert.Equal(t, []any{"称号A", 2, ""}, exec.args)
+}

--- a/internal/infra/repository/player_repository_impl.go
+++ b/internal/infra/repository/player_repository_impl.go
@@ -54,7 +54,7 @@ func (r *playerRepository) FindByIDWithHonors(ctx context.Context, exec reposito
 			ph.slot AS honor_slot,
 			h.name AS honor_name,
 			ht.name AS honor_type_name,
-			h.image_url AS honor_image_url
+			NULLIF(h.image_url, '') AS honor_image_url
 		FROM players p
 		LEFT JOIN player_honors ph ON ph.player_id = p.id
 		LEFT JOIN honors h ON ph.honor_id = h.id
@@ -121,7 +121,7 @@ func (r *playerRepository) FindByIDWithHonors(ctx context.Context, exec reposito
 // FindHonorsByPlayerID はプレイヤーIDで称号情報を取得します。スロット順（1,2,3）でソートされます。
 func (r *playerRepository) FindHonorsByPlayerID(ctx context.Context, exec repository.Executor, playerID int) ([]*entity.PlayerHonor, error) {
 	query := `
-		SELECT ph.slot, h.name, ht.name AS type_name, h.image_url
+		SELECT ph.slot, h.name, ht.name AS type_name, NULLIF(h.image_url, '') AS image_url
 		FROM player_honors ph
 		INNER JOIN honors h ON ph.honor_id = h.id
 		INNER JOIN honor_types ht ON h.honor_type_id = ht.id

--- a/internal/usecase/player_data_usecase_impl.go
+++ b/internal/usecase/player_data_usecase_impl.go
@@ -524,7 +524,21 @@ func (us *playerDataUsecase) applyHonors(ctx context.Context, tx repository.Exec
 			continue
 		}
 
-		honorID, err := us.honorRepo.EnsureHonor(ctx, tx, honor.Title, typeItem.ID, honor.Img)
+		if honorTypeKey == "sp" && (honor.Img == nil || strings.TrimSpace(*honor.Img) == "") {
+			skipped = append(skipped, api_internal.SkippedRecord{
+				RecordType: "honor",
+				Reason:     "sp honor image_url is required",
+				Details:    fmt.Sprintf("slot=%d, title=%s", slot, honor.Title),
+			})
+			continue
+		}
+
+		honorTitle := honor.Title
+		if honorTypeKey == "sp" {
+			honorTitle = ""
+		}
+
+		honorID, err := us.honorRepo.EnsureHonor(ctx, tx, honorTitle, typeItem.ID, honor.Img)
 		if err != nil {
 			skipped = append(skipped, api_internal.SkippedRecord{
 				RecordType: "honor",

--- a/internal/usecase/player_data_usecase_impl_test.go
+++ b/internal/usecase/player_data_usecase_impl_test.go
@@ -1,9 +1,11 @@
 package usecase
 
 import (
+	"context"
 	"testing"
 
 	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
+	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	mastervo "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
 	"github.com/chunisupport/chunisupport-api/internal/info"
 	"github.com/stretchr/testify/assert"
@@ -278,8 +280,125 @@ func TestResolveClassEmblemIDs(t *testing.T) {
 	}
 }
 
+func TestApplyHonors_SP称号はタイトル空文字と画像URLで登録する(t *testing.T) {
+	img1 := "https://example.com/sp-1.png"
+	img2 := "https://example.com/sp-2.png"
+	honorRepo := &stubHonorRepositoryForApplyHonorsTest{}
+	uc := &playerDataUsecase{honorRepo: honorRepo}
+	masters := newApplyHonorsTestMasters()
+
+	skipped, err := uc.applyHonors(context.Background(), nil, 100, map[string]PlayerDataHonorPayload{
+		"1": {Title: "ペイロード上の称号名", Class: "sp", Img: &img1},
+		"2": {Class: "sp", Img: &img2},
+	}, masters)
+
+	require.NoError(t, err)
+	assert.Empty(t, skipped)
+	assert.Equal(t, 1, honorRepo.deleteCount)
+	require.Len(t, honorRepo.ensureCalls, 2)
+	assert.ElementsMatch(t, []string{img1, img2}, honorRepo.ensureImageURLs())
+	assert.ElementsMatch(t, []string{"", ""}, honorRepo.ensureTitles())
+	assert.Len(t, honorRepo.assignments, 2)
+}
+
+func TestApplyHonors_SP称号で画像URLがない場合はスキップする(t *testing.T) {
+	honorRepo := &stubHonorRepositoryForApplyHonorsTest{}
+	uc := &playerDataUsecase{honorRepo: honorRepo}
+	masters := newApplyHonorsTestMasters()
+
+	skipped, err := uc.applyHonors(context.Background(), nil, 100, map[string]PlayerDataHonorPayload{
+		"1": {Class: "sp"},
+	}, masters)
+
+	require.NoError(t, err)
+	require.Len(t, skipped, 1)
+	assert.Equal(t, "sp honor image_url is required", skipped[0].Reason)
+	assert.Empty(t, honorRepo.ensureCalls)
+	assert.Empty(t, honorRepo.assignments)
+}
+
+func TestApplyHonors_通常称号はタイトルと空画像URLで登録する(t *testing.T) {
+	honorRepo := &stubHonorRepositoryForApplyHonorsTest{}
+	uc := &playerDataUsecase{honorRepo: honorRepo}
+	masters := newApplyHonorsTestMasters()
+
+	skipped, err := uc.applyHonors(context.Background(), nil, 100, map[string]PlayerDataHonorPayload{
+		"1": {Title: "通常称号", Class: "normal"},
+	}, masters)
+
+	require.NoError(t, err)
+	assert.Empty(t, skipped)
+	require.Len(t, honorRepo.ensureCalls, 1)
+	assert.Equal(t, "通常称号", honorRepo.ensureCalls[0].title)
+	assert.Nil(t, honorRepo.ensureCalls[0].imageURL)
+}
+
 func TestNewPlayerDataUsecase_PlayerRecRepoがnilの場合はpanicする(t *testing.T) {
 	assert.PanicsWithValue(t, "player record repository is required", func() {
 		NewPlayerDataUsecase(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	})
+}
+
+type honorEnsureCallForApplyHonorsTest struct {
+	title       string
+	honorTypeID int
+	imageURL    *string
+}
+
+type stubHonorRepositoryForApplyHonorsTest struct {
+	deleteCount int
+	ensureCalls []honorEnsureCallForApplyHonorsTest
+	assignments []repository.HonorAssignment
+	nextHonorID int
+}
+
+func (s *stubHonorRepositoryForApplyHonorsTest) EnsureHonor(_ context.Context, _ repository.Executor, title string, honorTypeID int, imageURL *string) (int, error) {
+	s.ensureCalls = append(s.ensureCalls, honorEnsureCallForApplyHonorsTest{
+		title:       title,
+		honorTypeID: honorTypeID,
+		imageURL:    imageURL,
+	})
+	s.nextHonorID++
+	return s.nextHonorID, nil
+}
+
+func (s *stubHonorRepositoryForApplyHonorsTest) DeletePlayerHonors(_ context.Context, _ repository.Executor, _ int) error {
+	s.deleteCount++
+	return nil
+}
+
+func (s *stubHonorRepositoryForApplyHonorsTest) BulkAssignHonors(_ context.Context, _ repository.Executor, assignments []repository.HonorAssignment) error {
+	s.assignments = append(s.assignments, assignments...)
+	return nil
+}
+
+func (s *stubHonorRepositoryForApplyHonorsTest) ensureImageURLs() []string {
+	imageURLs := make([]string, 0, len(s.ensureCalls))
+	for _, call := range s.ensureCalls {
+		if call.imageURL == nil {
+			imageURLs = append(imageURLs, "")
+			continue
+		}
+		imageURLs = append(imageURLs, *call.imageURL)
+	}
+	return imageURLs
+}
+
+func (s *stubHonorRepositoryForApplyHonorsTest) ensureTitles() []string {
+	titles := make([]string, 0, len(s.ensureCalls))
+	for _, call := range s.ensureCalls {
+		titles = append(titles, call.title)
+	}
+	return titles
+}
+
+func newApplyHonorsTestMasters() *playerDataMaster {
+	return &playerDataMaster{
+		PlayerDataMasters: &domainmasterdata.PlayerDataMasters{
+			HonorTypes: map[string]mastervo.HonorType{
+				"normal": {ID: 1, Name: "normal"},
+				"sp":     {ID: 11, Name: "sp"},
+			},
+		},
+	}
 }

--- a/migration/MIGRATION.md
+++ b/migration/MIGRATION.md
@@ -167,3 +167,4 @@ go install -tags 'mysql sqlite' github.com/golang-migrate/migrate/v4/cmd/migrate
 - **000014**: プレイヤーごとの解禁済み楽曲を保持する `player_locked_songs` テーブルを追加。
 - **000015**: `genres` テーブルに `sort_order` カラムを追加し、ジャンルの表示順を投入。
 - **000016**: `songs` テーブルに楽曲の読みを保持する `reading` カラムを追加。
+- **000017**: `honors` テーブルの `image_url` を空文字デフォルトの非NULLに変更し、称号のユニーク制約を `(name, honor_type_id, image_url)` へ変更。`sp` 称号は空文字の `name` と画像URLの組み合わせで一意に扱えるようにする。

--- a/migration/mysql/000017_update_honor_unique_key.down.sql
+++ b/migration/mysql/000017_update_honor_unique_key.down.sql
@@ -13,7 +13,7 @@ INNER JOIN (
         AND duplicated_group.keep_id <> h1.id
 ) duplicated ON duplicated.id = h.id
 SET h.name = CONCAT(
-    CASE WHEN h.name = '' THEN 'honor' ELSE h.name END,
+    LEFT(CASE WHEN h.name = '' THEN 'honor' ELSE h.name END, 479),
     '#',
     h.id
 );

--- a/migration/mysql/000017_update_honor_unique_key.down.sql
+++ b/migration/mysql/000017_update_honor_unique_key.down.sql
@@ -1,0 +1,24 @@
+UPDATE honors h
+INNER JOIN (
+    SELECT h1.id
+    FROM honors h1
+    INNER JOIN (
+        SELECT name, honor_type_id, MIN(id) AS keep_id
+        FROM honors
+        GROUP BY name, honor_type_id
+        HAVING COUNT(*) > 1
+    ) duplicated_group
+        ON duplicated_group.honor_type_id = h1.honor_type_id
+        AND duplicated_group.name = h1.name
+        AND duplicated_group.keep_id <> h1.id
+) duplicated ON duplicated.id = h.id
+SET h.name = CONCAT(
+    CASE WHEN h.name = '' THEN 'honor' ELSE h.name END,
+    '#',
+    h.id
+);
+
+ALTER TABLE honors
+    DROP INDEX unique_honor_name_type_image_url,
+    MODIFY COLUMN image_url VARCHAR(255) NULL,
+    ADD UNIQUE KEY unique_honor_name_type (name, honor_type_id);

--- a/migration/mysql/000017_update_honor_unique_key.up.sql
+++ b/migration/mysql/000017_update_honor_unique_key.up.sql
@@ -1,0 +1,8 @@
+UPDATE honors
+SET image_url = ''
+WHERE image_url IS NULL;
+
+ALTER TABLE honors
+    MODIFY COLUMN image_url VARCHAR(255) NOT NULL DEFAULT '',
+    DROP INDEX unique_honor_name_type,
+    ADD UNIQUE KEY unique_honor_name_type_image_url (name, honor_type_id, image_url);

--- a/migration/schema_mysql.sql
+++ b/migration/schema_mysql.sql
@@ -111,10 +111,10 @@ CREATE TABLE `honors` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL,
   `honor_type_id` tinyint unsigned NOT NULL,
-  `image_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `image_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unique_honor_name_type` (`name`,`honor_type_id`),
+  UNIQUE KEY `unique_honor_name_type_image_url` (`name`,`honor_type_id`,`image_url`),
   KEY `honor_type_id` (`honor_type_id`),
   CONSTRAINT `honors_ibfk_1` FOREIGN KEY (`honor_type_id`) REFERENCES `honor_types` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
…ge_url)に更新

test: SP称号のタイトルを空文字と画像URLで登録するテストを追加
test: 画像URLがない場合はスキップするテストを追加
fix: EnsureHonor関数でimageURLのトリミングを実施

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 既存の称号がある場合、画像URLが未指定だと既存の画像が上書きされないよう修正しました。
  * 取得時に空文字の画像URLをNULLとして扱うよう正規化しました。

* **New Features**
  * SP称号は画像URLが必須となり、画像URLがない場合は該当称号をスキップします。
  * SP称号はタイトルを空文字として登録できるようになりました。

* **Chores / Migration**
  * 画像URLを含めた一意性とデフォルト値変更のマイグレーションを追加しました。

* **Tests**
  * 称号の登録・更新と適用ロジックに関する単体テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chunisupport/chunisupport-api/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->