### PR TITLE
docs: 差分計算の同時リクエスト許容を明記

### DIFF
--- a/internal/usecase/player_data_usecase_impl.go
+++ b/internal/usecase/player_data_usecase_impl.go
@@ -596,6 +596,8 @@ func (us *playerDataUsecase) applyScores(ctx context.Context, tx repository.Exec
 		return counts, skipped, nil, calculatedOverpowerSummary{}, err
 	}
 
+	// 差分は保存前状態とupsert予定値から算出するため、理論上は同一プレイヤーの同時リクエストで正しく出力されない場合がある。
+	// ただし通常利用では同時登録が起きない前提のため許容し、発生した場合はユーザの責任として扱う。
 	fullChanges := computeFullRecordChanges(fullBefore, fullRecordsToUpsert, masters)
 	worldsendChanges := computeWorldsendRecordChanges(worldsendBefore, worldsendRecordsToUpsert, masters)
 	changes := append(fullChanges, worldsendChanges...)


### PR DESCRIPTION
### Motivation
- `applyScores` 内で差分を「保存前状態」と「upsert予定値」の比較で先に確定しているため、同一 `playerID` に対する同時リクエストがあるとレスポンスの `changes`/`*_actually_changed` がDB最終状態とずれる可能性があることを明示するため。 

### Description
- `internal/usecase/player_data_usecase_impl.go` の `applyScores` にコメントを追記し、同時リクエスト時の差分出力が理論上正しく出力されない場合があることと、そのケースを通常利用前提で許容する旨を明記しました（該当箇所: `applyScores` 内、`fullChanges` 計算直前）。

### Testing
- 自動テストを `go test ./...` で実行して全テストは成功しました。 
- コード整形は `gofmt -s -w` を実行し、`git diff --check` による警告はありませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a94005cc832da6c2d5eb283f8eee)