### PR TITLE
refactor: クエリ引数スライスの割り当てを最適化

### DIFF
--- a/internal/infra/repository/player_data_repository_impl.go
+++ b/internal/infra/repository/player_data_repository_impl.go
@@ -287,7 +287,9 @@ func selectModelsInChunks[T any, M any](ctx context.Context, exec repository.Exe
 	for i := 0; i < len(items); i += batchSize {
 		end := min(i+batchSize, len(items))
 		batch := items[i:end]
-		args := append(append([]any{}, leadingArgs...), batch)
+		args := make([]any, 0, len(leadingArgs)+1)
+		args = append(args, leadingArgs...)
+		args = append(args, batch)
 		batchQuery, batchArgs, err := sqlx.In(query, args...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build %s query: %w", queryName, err)


### PR DESCRIPTION
### Motivation
- `selectModelsInChunks` 内で `append(append(...))` を使うと不要なスライス割り当てが発生するため、パフォーマンスとメモリ割り当てを改善するために事前に容量を確保してから要素を追加するようにする。ファイル: `internal/infra/repository/player_data_repository_impl.go`。

### Description
- `selectModelsInChunks` のクエリ引数生成を変更し、`append(append([]any{}, leadingArgs...), batch)` を事前に容量を確保した `make([]any, 0, len(leadingArgs)+1)` に置き換え、`args = append(args, leadingArgs...)` と `args = append(args, batch)` で要素を追加するようにした。これにより余分なメモリ割り当てを削減する。

### Testing
- `go test ./...` を実行し、全パッケージのテストが成功したことを確認した。 
- `gofmt -s -w` を実行してコード整形を適用し、`git diff --check` を実行して問題がないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a78a90c4832d841e61156fa0d147)