### PR TITLE
Add ADMIN endpoint to change user account type with domain and repo support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -248,7 +248,7 @@
 
 ### PATCH `/internal/admin/users/:username/account-type`
 - **認証**: Firebase Bearer 必須（ADMIN権限必須）
-- **概要**: 指定ユーザーのアカウント種別を変更します。自分自身の変更、ADMINへの昇格、ADMINからの降格、最後のADMINの降格はいずれも許可されます。
+- **概要**: 指定ユーザーのアカウント種別を変更します。自分自身の変更、ADMINへの昇格、ADMINからの降格を許可します。ただし、ADMINが1人だけ存在する状態でそのユーザーを非ADMINへ変更し、ADMINが0人になる操作だけは拒否します。ADMINが0人の状態から最初のADMINを付与する操作は許可します。
 - **パスパラメータ**:
   - `username`: 変更対象ユーザーのユーザー名
 - **リクエストボディ**:
@@ -282,7 +282,8 @@
 | `updated_at` | string | ユーザー更新日時 (ISO8601) |
 
 - **主なエラー**:
-  - 400 Bad Request (`bad_request`): ID形式、JSON、またはアカウント種別が不正
+  - 400 Bad Request (`bad_request`): ユーザー名形式、JSON、またはアカウント種別が不正
+  - 409 Conflict (`conflict`): 最後のADMINを非ADMINへ変更しようとした
   - 401 Unauthorized (`unauthorized` / `missing_token` / `invalid_token`): 認証が必要
   - 403 Forbidden (`forbidden`): ADMIN権限が不足
   - 404 Not Found (`user_not_found`): ユーザーが存在しない

--- a/docs/API.md
+++ b/docs/API.md
@@ -116,7 +116,7 @@
 | `/internal/auth/api-tokens` | POST | Firebase Bearer | APIトークン発行 |
 | `/internal/auth/api-tokens` | DELETE | Firebase Bearer | APIトークン削除 |
 | `/internal/admin/build-info` | GET | Firebase Bearer (ADMIN+) | 管理者画面向けAPIビルド情報取得 |
-| `/internal/admin/users/:id/account-type` | PATCH | Firebase Bearer (ADMIN+) | ユーザー権限変更 |
+| `/internal/admin/users/:username/account-type` | PATCH | Firebase Bearer (ADMIN+) | ユーザー権限変更 |
 | `/internal/me` | GET | Firebase Bearer | 自身のユーザー情報 |
 | `/internal/me/privacy` | PUT | Firebase Bearer | 非公開設定更新 |
 | `/internal/me` | DELETE | Firebase Bearer + X-Reauth-Token | アカウント物理削除 |
@@ -246,11 +246,11 @@
 | `commit_hash` | string | APIのGit短縮コミットハッシュ。開発起動時は `none` |
 | `go_version` | string | APIバイナリのGoバージョン |
 
-### PATCH `/internal/admin/users/:id/account-type`
+### PATCH `/internal/admin/users/:username/account-type`
 - **認証**: Firebase Bearer 必須（ADMIN権限必須）
 - **概要**: 指定ユーザーのアカウント種別を変更します。自分自身の変更、ADMINへの昇格、ADMINからの降格、最後のADMINの降格はいずれも許可されます。
 - **パスパラメータ**:
-  - `id`: 変更対象ユーザーのID
+  - `username`: 変更対象ユーザーのユーザー名
 - **リクエストボディ**:
 
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -116,6 +116,7 @@
 | `/internal/auth/api-tokens` | POST | Firebase Bearer | APIトークン発行 |
 | `/internal/auth/api-tokens` | DELETE | Firebase Bearer | APIトークン削除 |
 | `/internal/admin/build-info` | GET | Firebase Bearer (ADMIN+) | 管理者画面向けAPIビルド情報取得 |
+| `/internal/admin/users/:id/account-type` | PATCH | Firebase Bearer (ADMIN+) | ユーザー権限変更 |
 | `/internal/me` | GET | Firebase Bearer | 自身のユーザー情報 |
 | `/internal/me/privacy` | PUT | Firebase Bearer | 非公開設定更新 |
 | `/internal/me` | DELETE | Firebase Bearer + X-Reauth-Token | アカウント物理削除 |
@@ -244,6 +245,47 @@
 | `build_date` | string | ビルド日 |
 | `commit_hash` | string | APIのGit短縮コミットハッシュ。開発起動時は `none` |
 | `go_version` | string | APIバイナリのGoバージョン |
+
+### PATCH `/internal/admin/users/:id/account-type`
+- **認証**: Firebase Bearer 必須（ADMIN権限必須）
+- **概要**: 指定ユーザーのアカウント種別を変更します。自分自身の変更、ADMINへの昇格、ADMINからの降格、最後のADMINの降格はいずれも許可されます。
+- **パスパラメータ**:
+  - `id`: 変更対象ユーザーのID
+- **リクエストボディ**:
+
+```json
+{
+  "account_type": "ADMIN"
+}
+```
+
+| フィールド | 型 | 説明 |
+| ---------- | -- | ---- |
+| `account_type` | string | 変更後のアカウント種別（`PLAYER` / `EDITOR` / `ADMIN`）。大文字小文字を厳密に区別し、小文字は不正値として扱います。 |
+
+- **レスポンス**: 200 OK
+
+```json
+{
+  "id": 1,
+  "username": "user1",
+  "account_type": "ADMIN",
+  "updated_at": "2026-06-22T12:34:56Z"
+}
+```
+
+| フィールド | 型 | 説明 |
+| ---------- | -- | ---- |
+| `id` | number | ユーザーID |
+| `username` | string | ユーザー名 |
+| `account_type` | string | 更新後のアカウント種別 |
+| `updated_at` | string | ユーザー更新日時 (ISO8601) |
+
+- **主なエラー**:
+  - 400 Bad Request (`bad_request`): ID形式、JSON、またはアカウント種別が不正
+  - 401 Unauthorized (`unauthorized` / `missing_token` / `invalid_token`): 認証が必要
+  - 403 Forbidden (`forbidden`): ADMIN権限が不足
+  - 404 Not Found (`user_not_found`): ユーザーが存在しない
 
 ---
 

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -45,6 +45,8 @@ func FromUsecaseError(err error) *APIError {
 		return ErrForbidden.WithInternal(err)
 	case errors.Is(err, usecase.ErrInvalidAccountType):
 		return ErrBadRequest.WithInternal(err)
+	case errors.Is(err, repository.ErrUserConflict):
+		return ErrConflict.WithInternal(err)
 	case errors.Is(err, usecase.ErrInvalidAPIToken):
 		return ErrInvalidToken.WithInternal(err)
 	// 楽曲関連エラー

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -43,6 +43,8 @@ func FromUsecaseError(err error) *APIError {
 		return ErrInternalError.WithInternal(err)
 	case errors.Is(err, usecase.ErrAdminRequired):
 		return ErrForbidden.WithInternal(err)
+	case errors.Is(err, usecase.ErrInvalidAccountType):
+		return ErrBadRequest.WithInternal(err)
 	case errors.Is(err, usecase.ErrInvalidAPIToken):
 		return ErrInvalidToken.WithInternal(err)
 	// 楽曲関連エラー

--- a/internal/app/apierror/mapping.go
+++ b/internal/app/apierror/mapping.go
@@ -45,6 +45,8 @@ func FromUsecaseError(err error) *APIError {
 		return ErrForbidden.WithInternal(err)
 	case errors.Is(err, usecase.ErrInvalidAccountType):
 		return ErrBadRequest.WithInternal(err)
+	case errors.Is(err, usecase.ErrLastAdminRequired):
+		return ErrConflict.WithInternal(err)
 	case errors.Is(err, repository.ErrUserConflict):
 		return ErrConflict.WithInternal(err)
 	case errors.Is(err, usecase.ErrInvalidAPIToken):

--- a/internal/app/apierror/mapping_test.go
+++ b/internal/app/apierror/mapping_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/usecase"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,4 +25,12 @@ func TestFromUsecaseError_auth_time欠落は詳細を伏せてrecent_sign_in_req
 	assert.Equal(t, CodeRecentSignInRequired, got.Code)
 	assert.Equal(t, ErrRecentSignInRequired.HTTPStatus, got.HTTPStatus)
 	assert.ErrorIs(t, got.Internal, usecase.ErrRecentSignInAuthTimeMissing)
+}
+
+func TestFromUsecaseError_ドメイン由来の不正な権限種別はBadRequestに変換する(t *testing.T) {
+	got := FromUsecaseError(entity.ErrInvalidAccountType)
+
+	assert.Equal(t, CodeBadRequest, got.Code)
+	assert.Equal(t, ErrBadRequest.HTTPStatus, got.HTTPStatus)
+	assert.ErrorIs(t, got.Internal, entity.ErrInvalidAccountType)
 }

--- a/internal/app/handler/api_internal/admin_user_handler.go
+++ b/internal/app/handler/api_internal/admin_user_handler.go
@@ -64,7 +64,7 @@ func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
 		return err
 	}
 
-	result, err := h.userUsecase.ChangeUserAccountType(c.Request().Context(), requester, username, req.AccountType)
+	result, err := h.userUsecase.ChangeUserAccountType(c.Request().Context(), requester, usernameParam, req.AccountType)
 	if err != nil {
 		return apierror.FromUsecaseError(err)
 	}
@@ -72,11 +72,14 @@ func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
 	return c.JSON(http.StatusOK, newAdminUserAccountTypeResponse(result, req.AccountType))
 }
 
-// bindUpdateUserAccountTypeRequest はBind失敗時のAPIエラー変換をハンドラ本体から分離します。
+// bindUpdateUserAccountTypeRequest はBindと構造体タグ検証をまとめ、境界層で不正な入力を止めます。
 func bindUpdateUserAccountTypeRequest(c echo.Context) (dto_internal.UpdateUserAccountTypeRequest, error) {
 	var req dto_internal.UpdateUserAccountTypeRequest
 	if err := c.Bind(&req); err != nil {
 		return dto_internal.UpdateUserAccountTypeRequest{}, apierror.ErrBadRequest.WithInternal(err)
+	}
+	if err := c.Validate(&req); err != nil {
+		return dto_internal.UpdateUserAccountTypeRequest{}, err
 	}
 	return req, nil
 }

--- a/internal/app/handler/api_internal/admin_user_handler.go
+++ b/internal/app/handler/api_internal/admin_user_handler.go
@@ -53,14 +53,14 @@ func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
 		return apierror.ErrBadRequest
 	}
 
-	var req dto_internal.UpdateUserAccountTypeRequest
-	if err := c.Bind(&req); err != nil {
-		return apierror.ErrBadRequest.WithInternal(err)
-	}
-
 	requester, ok := c.Get("userEntity").(*entity.User)
 	if !ok {
 		return apierror.ErrUnauthorized
+	}
+
+	req, err := bindUpdateUserAccountTypeRequest(c)
+	if err != nil {
+		return err
 	}
 
 	result, err := h.userUsecase.ChangeUserAccountType(c.Request().Context(), requester, username, req.AccountType)
@@ -68,10 +68,24 @@ func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
 		return apierror.FromUsecaseError(err)
 	}
 
-	return c.JSON(http.StatusOK, dto_internal.AdminUserAccountTypeResponse{
-		ID:          result.ID,
-		UserName:    result.Username.String(),
-		AccountType: req.AccountType,
-		UpdatedAt:   result.UpdatedAt,
-	})
+	return c.JSON(http.StatusOK, newAdminUserAccountTypeResponse(result, req.AccountType))
+}
+
+// bindUpdateUserAccountTypeRequest はBind失敗時のAPIエラー変換をハンドラ本体から分離します。
+func bindUpdateUserAccountTypeRequest(c echo.Context) (dto_internal.UpdateUserAccountTypeRequest, error) {
+	var req dto_internal.UpdateUserAccountTypeRequest
+	if err := c.Bind(&req); err != nil {
+		return dto_internal.UpdateUserAccountTypeRequest{}, apierror.ErrBadRequest.WithInternal(err)
+	}
+	return req, nil
+}
+
+// newAdminUserAccountTypeResponse はレスポンス生成を集約し、ハンドラ本体をユースケース呼び出しに集中させます。
+func newAdminUserAccountTypeResponse(user *entity.User, accountType string) dto_internal.AdminUserAccountTypeResponse {
+	return dto_internal.AdminUserAccountTypeResponse{
+		ID:          user.ID,
+		UserName:    user.Username.String(),
+		AccountType: accountType,
+		UpdatedAt:   user.UpdatedAt,
+	}
 }

--- a/internal/app/handler/api_internal/admin_user_handler.go
+++ b/internal/app/handler/api_internal/admin_user_handler.go
@@ -48,8 +48,8 @@ func (h *AdminUserHandler) GetAllUsers(c echo.Context) error {
 
 // UpdateUserAccountType はADMIN専用で、指定ユーザーの権限を変更します。
 func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
-	userID, err := strconv.Atoi(c.Param("id"))
-	if err != nil || userID <= 0 {
+	username := c.Param("username")
+	if username == "" {
 		return apierror.ErrBadRequest
 	}
 
@@ -63,7 +63,7 @@ func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
 		return apierror.ErrUnauthorized
 	}
 
-	result, err := h.userUsecase.ChangeUserAccountType(c.Request().Context(), requester, userID, req.AccountType)
+	result, err := h.userUsecase.ChangeUserAccountType(c.Request().Context(), requester, username, req.AccountType)
 	if err != nil {
 		return apierror.FromUsecaseError(err)
 	}

--- a/internal/app/handler/api_internal/admin_user_handler.go
+++ b/internal/app/handler/api_internal/admin_user_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	vo_username "github.com/chunisupport/chunisupport-api/internal/domain/vo/username"
 	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
 	"github.com/chunisupport/chunisupport-api/internal/info"
 	"github.com/chunisupport/chunisupport-api/internal/usecase"

--- a/internal/app/handler/api_internal/admin_user_handler.go
+++ b/internal/app/handler/api_internal/admin_user_handler.go
@@ -1,10 +1,13 @@
 package api_internal
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
 	"github.com/chunisupport/chunisupport-api/internal/info"
 	"github.com/chunisupport/chunisupport-api/internal/usecase"
 	"github.com/labstack/echo/v4"
@@ -42,4 +45,37 @@ func (h *AdminUserHandler) GetAllUsers(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, users)
+}
+
+// UpdateUserAccountType はADMIN専用で、指定ユーザーの権限を変更します。
+func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
+	userID, err := strconv.Atoi(c.Param("id"))
+	if err != nil || userID <= 0 {
+		return apierror.ErrBadRequest
+	}
+
+	var req dto_internal.UpdateUserAccountTypeRequest
+	if err := c.Bind(&req); err != nil {
+		return apierror.ErrBadRequest.WithInternal(err)
+	}
+
+	requester, ok := c.Get("userEntity").(*entity.User)
+	if !ok {
+		return apierror.ErrUnauthorized
+	}
+
+	result, err := h.userUsecase.ChangeUserAccountType(c.Request().Context(), requester, userID, req.AccountType)
+	if err != nil {
+		if !errors.Is(err, usecase.ErrAdminRequired) && !errors.Is(err, usecase.ErrUserNotFound) && !errors.Is(err, usecase.ErrInvalidAccountType) {
+			return apierror.ErrInternalError.WithInternal(err)
+		}
+		return apierror.FromUsecaseError(err)
+	}
+
+	return c.JSON(http.StatusOK, dto_internal.AdminUserAccountTypeResponse{
+		ID:          result.ID,
+		UserName:    result.Username.String(),
+		AccountType: req.AccountType,
+		UpdatedAt:   result.UpdatedAt,
+	})
 }

--- a/internal/app/handler/api_internal/admin_user_handler.go
+++ b/internal/app/handler/api_internal/admin_user_handler.go
@@ -1,7 +1,6 @@
 package api_internal
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
@@ -66,9 +65,6 @@ func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
 
 	result, err := h.userUsecase.ChangeUserAccountType(c.Request().Context(), requester, userID, req.AccountType)
 	if err != nil {
-		if !errors.Is(err, usecase.ErrAdminRequired) && !errors.Is(err, usecase.ErrUserNotFound) && !errors.Is(err, usecase.ErrInvalidAccountType) {
-			return apierror.ErrInternalError.WithInternal(err)
-		}
 		return apierror.FromUsecaseError(err)
 	}
 

--- a/internal/app/handler/api_internal/admin_user_handler.go
+++ b/internal/app/handler/api_internal/admin_user_handler.go
@@ -48,9 +48,9 @@ func (h *AdminUserHandler) GetAllUsers(c echo.Context) error {
 
 // UpdateUserAccountType はADMIN専用で、指定ユーザーの権限を変更します。
 func (h *AdminUserHandler) UpdateUserAccountType(c echo.Context) error {
-	username := c.Param("username")
-	if username == "" {
-		return apierror.ErrBadRequest
+	usernameParam := c.Param("username")
+	if _, err := vo_username.NewUserName(usernameParam); err != nil {
+		return apierror.FromUsecaseError(err)
 	}
 
 	requester, ok := c.Get("userEntity").(*entity.User)

--- a/internal/app/handler/api_internal/user_handler_test.go
+++ b/internal/app/handler/api_internal/user_handler_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/chunisupport/chunisupport-api/internal/app/apierror"
 	"github.com/chunisupport/chunisupport-api/internal/app/handler/api_internal"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/username"
 	"github.com/chunisupport/chunisupport-api/internal/dto"
 	dto_internal "github.com/chunisupport/chunisupport-api/internal/dto/api_internal"
 	"github.com/chunisupport/chunisupport-api/internal/info"
@@ -69,8 +71,8 @@ func (m *mockUserUsecase) DeleteUser(ctx context.Context, requester *entity.User
 	return args.Error(0)
 }
 
-func (m *mockUserUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error) {
-	args := m.Called(ctx, requester, userID, accountType)
+func (m *mockUserUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, username string, accountType string) (*entity.User, error) {
+	args := m.Called(ctx, requester, username, accountType)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -624,6 +626,44 @@ func TestAdminUserHandler_GetAllUsers(t *testing.T) {
 	assert.Equal(t, true, body[1]["is_private"])
 	assert.Nil(t, body[1]["firebase_uid"])
 	assert.NotContains(t, body[1], "email")
+	mockUsecase.AssertExpectations(t)
+}
+
+func TestAdminUserHandler_UpdateUserAccountTypeUsesUsername(t *testing.T) {
+	e := newTestEcho()
+	mockUsecase := new(mockUserUsecase)
+	h := api_internal.NewAdminUserHandler(mockUsecase)
+	adminUser := &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin}
+	un, err := username.NewUserName("targetuser")
+	assert.NoError(t, err)
+	updatedAt := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+
+	// Given
+	mockUsecase.On("ChangeUserAccountType", mock.Anything, adminUser, "targetuser", "ADMIN").Return(&entity.User{
+		ID:            1,
+		Username:      un,
+		AccountTypeID: info.AccountTypeAdmin,
+		UpdatedAt:     updatedAt,
+	}, nil).Once()
+
+	req := httptest.NewRequest(http.MethodPatch, "/internal/admin/users/targetuser/account-type", strings.NewReader(`{"account_type":"ADMIN"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("username")
+	c.SetParamValues("targetuser")
+	c.Set("userEntity", adminUser)
+
+	// When
+	err = h.UpdateUserAccountType(c)
+
+	// Then
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "targetuser", body["username"])
+	assert.Equal(t, "ADMIN", body["account_type"])
 	mockUsecase.AssertExpectations(t)
 }
 

--- a/internal/app/handler/api_internal/user_handler_test.go
+++ b/internal/app/handler/api_internal/user_handler_test.go
@@ -69,6 +69,14 @@ func (m *mockUserUsecase) DeleteUser(ctx context.Context, requester *entity.User
 	return args.Error(0)
 }
 
+func (m *mockUserUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error) {
+	args := m.Called(ctx, requester, userID, accountType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*entity.User), args.Error(1)
+}
+
 func TestUserHandler_GetUserUpdatedAt(t *testing.T) {
 	e := newTestEcho()
 	mockUsecase := new(mockUserUsecase)

--- a/internal/app/handler/api_v1/user_handler_test.go
+++ b/internal/app/handler/api_v1/user_handler_test.go
@@ -49,6 +49,10 @@ func (m *mockV1UserUsecase) DeleteUser(ctx context.Context, requester *entity.Us
 	return nil
 }
 
+func (m *mockV1UserUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error) {
+	return nil, nil
+}
+
 func TestV1UserHandler_GetUser(t *testing.T) {
 	t.Run("非公開ユーザーはuser_not_foundを返す", func(t *testing.T) {
 		// Given

--- a/internal/app/handler/api_v1/user_handler_test.go
+++ b/internal/app/handler/api_v1/user_handler_test.go
@@ -49,7 +49,7 @@ func (m *mockV1UserUsecase) DeleteUser(ctx context.Context, requester *entity.Us
 	return nil
 }
 
-func (m *mockV1UserUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error) {
+func (m *mockV1UserUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, username string, accountType string) (*entity.User, error) {
 	return nil, nil
 }
 

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -306,7 +306,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticatorStric
 	adminGroup.Use(firebaseAuthStrict, requireAdmin)
 	{
 		adminGroup.GET("/build-info", handleAdminBuildInfo)
-		adminGroup.PATCH("/users/:id/account-type", handlers.AdminUser.UpdateUserAccountType)
+		adminGroup.PATCH("/users/:username/account-type", handlers.AdminUser.UpdateUserAccountType)
 	}
 
 	// api.chunisupport.net/internal/honors

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -306,6 +306,7 @@ func registerRoutes(e *echo.Echo, handlers *Handlers, firebaseAuthenticatorStric
 	adminGroup.Use(firebaseAuthStrict, requireAdmin)
 	{
 		adminGroup.GET("/build-info", handleAdminBuildInfo)
+		adminGroup.PATCH("/users/:id/account-type", handlers.AdminUser.UpdateUserAccountType)
 	}
 
 	// api.chunisupport.net/internal/honors

--- a/internal/domain/constants/account_type.go
+++ b/internal/domain/constants/account_type.go
@@ -1,0 +1,20 @@
+package constants
+
+const (
+	// AccountTypePlayer は一般ユーザー権限を表します。
+	AccountTypePlayer = 1
+	// AccountTypeEditor は編集者権限を表します。
+	AccountTypeEditor = 2
+	// AccountTypeAdmin は管理者権限を表します。
+	AccountTypeAdmin = 3
+)
+
+// IsKnownAccountType は account_type_id がドメイン上で扱える既知ロールかを判定します。
+func IsKnownAccountType(accountTypeID int) bool {
+	switch accountTypeID {
+	case AccountTypePlayer, AccountTypeEditor, AccountTypeAdmin:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/entity/user.go
+++ b/internal/domain/entity/user.go
@@ -1,11 +1,15 @@
 package entity
 
 import (
+	"errors"
 	"strings"
 	"time"
 
+	"github.com/chunisupport/chunisupport-api/internal/domain/constants"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/username"
 )
+
+var ErrInvalidAccountType = errors.New("invalid account type")
 
 // User はユーザーのエンティティを表します。
 type User struct {
@@ -16,8 +20,11 @@ type User struct {
 	UpdatedAt     time.Time
 	PlayerID      *int
 	AccountTypeID int
-	IsSuspicious  bool
-	IsPrivate     bool
+	// OriginalAccountTypeID は永続化から復元した時点の権限IDです。
+	// Save時の競合検知に使い、権限変更の巻き戻しを防ぎます。
+	OriginalAccountTypeID int
+	IsSuspicious          bool
+	IsPrivate             bool
 }
 
 // NewUser は必須項目が設定された新規ユーザーを生成します。
@@ -25,10 +32,11 @@ func NewUser(userName username.UserName, accountTypeID int) *User {
 	now := time.Now()
 
 	return &User{
-		Username:      userName,
-		CreatedAt:     now,
-		UpdatedAt:     now,
-		AccountTypeID: accountTypeID,
+		Username:              userName,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+		AccountTypeID:         accountTypeID,
+		OriginalAccountTypeID: accountTypeID,
 	}
 }
 
@@ -38,11 +46,12 @@ func NewFirebaseUser(userName username.UserName, uid string, accountTypeID int) 
 	normalizedUID := strings.TrimSpace(uid)
 
 	return &User{
-		Username:      userName,
-		FirebaseUID:   &normalizedUID,
-		CreatedAt:     now,
-		UpdatedAt:     now,
-		AccountTypeID: accountTypeID,
+		Username:              userName,
+		FirebaseUID:           &normalizedUID,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+		AccountTypeID:         accountTypeID,
+		OriginalAccountTypeID: accountTypeID,
 	}
 }
 
@@ -65,6 +74,17 @@ func (u *User) HasLinkedFirebase() bool {
 func (u *User) ChangePrivacy(isPrivate bool) {
 	u.IsPrivate = isPrivate
 	u.UpdatedAt = time.Now()
+}
+
+// ChangeAccountType はユーザー権限を変更します。
+// 権限の正当性はユーザー集約の不変条件なので、ハンドラではなくドメインで検証します。
+func (u *User) ChangeAccountType(accountTypeID int) error {
+	if !constants.IsKnownAccountType(accountTypeID) {
+		return ErrInvalidAccountType
+	}
+	u.AccountTypeID = accountTypeID
+	u.UpdatedAt = time.Now()
+	return nil
 }
 
 // LinkFirebaseUID はユーザーに Firebase UID を紐付けます。

--- a/internal/domain/repository/user_repository.go
+++ b/internal/domain/repository/user_repository.go
@@ -25,6 +25,8 @@ type UserRepository interface {
 	FindByFirebaseUID(ctx context.Context, exec Executor, uid string) (*entity.User, error)
 	// LinkFirebaseUID は現在値が一致する場合のみ Firebase UID を更新します。
 	LinkFirebaseUID(ctx context.Context, exec Executor, userID int, currentUID *string, newUID string, updatedAt time.Time) error
+	// CountByAccountType は指定したアカウント種別のユーザー数を取得します。
+	CountByAccountType(ctx context.Context, exec Executor, accountTypeID int) (int, error)
 	// DeleteByID はユーザーを物理削除します。
 	DeleteByID(ctx context.Context, exec Executor, id int) error
 	// Save はユーザーを集約単位で保存します。IDが存在する場合は更新、存在しない場合は作成します。

--- a/internal/dto/api_internal/user_list_dto.go
+++ b/internal/dto/api_internal/user_list_dto.go
@@ -27,5 +27,5 @@ type AdminUserAccountTypeResponse struct {
 
 // UpdateUserAccountTypeRequest はユーザー権限変更APIのリクエストです。
 type UpdateUserAccountTypeRequest struct {
-	AccountType string `json:"account_type"`
+	AccountType string "json:\"account_type\" validate:\"required,oneof=PLAYER EDITOR ADMIN\""
 }

--- a/internal/dto/api_internal/user_list_dto.go
+++ b/internal/dto/api_internal/user_list_dto.go
@@ -27,5 +27,5 @@ type AdminUserAccountTypeResponse struct {
 
 // UpdateUserAccountTypeRequest はユーザー権限変更APIのリクエストです。
 type UpdateUserAccountTypeRequest struct {
-	AccountType string "json:\"account_type\" validate:\"required,oneof=PLAYER EDITOR ADMIN\""
+	AccountType string `json:"account_type" validate:"required,oneof=PLAYER EDITOR ADMIN"`
 }

--- a/internal/dto/api_internal/user_list_dto.go
+++ b/internal/dto/api_internal/user_list_dto.go
@@ -16,3 +16,16 @@ type AdminUserListResponse struct {
 	IsPrivate      bool      `json:"is_private"`
 	FirebaseUID    *string   `json:"firebase_uid"`
 }
+
+// AdminUserAccountTypeResponse はADMINによるユーザー権限変更後のレスポンスです。
+type AdminUserAccountTypeResponse struct {
+	ID          int       `json:"id"`
+	UserName    string    `json:"username"`
+	AccountType string    `json:"account_type"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// UpdateUserAccountTypeRequest はユーザー権限変更APIのリクエストです。
+type UpdateUserAccountTypeRequest struct {
+	AccountType string `json:"account_type"`
+}

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -56,9 +56,9 @@ const (
 	ExternalCORSAllowOrigin      = "https://new.chunithm-net.com"
 
 	// アカウントタイプ定数
-	AccountTypePlayer = 1 // 一般ユーザー
-	AccountTypeEditor = 2 // 編集者
-	AccountTypeAdmin  = 3 // 管理者
+	AccountTypePlayer = constants.AccountTypePlayer // 一般ユーザー
+	AccountTypeEditor = constants.AccountTypeEditor // 編集者
+	AccountTypeAdmin  = constants.AccountTypeAdmin  // 管理者
 
 	// リクエストボディサイズ上限
 	RequestBodyLimit = "5M"
@@ -78,7 +78,11 @@ var (
 )
 
 var (
-	knownAccountTypes       = make(map[int]struct{})
+	accountTypeNameToID = map[string]int{
+		"PLAYER": AccountTypePlayer,
+		"EDITOR": AccountTypeEditor,
+		"ADMIN":  AccountTypeAdmin,
+	}
 	roleAllowedAccountTypes = map[int]map[int]struct{}{
 		AccountTypePlayer: {
 			AccountTypePlayer: {},
@@ -95,16 +99,16 @@ var (
 	}
 )
 
-func init() {
-	for roleID := range roleAllowedAccountTypes {
-		knownAccountTypes[roleID] = struct{}{}
-	}
-}
-
 // IsKnownAccountType は account_type_id が既知ロールかを判定します。
 func IsKnownAccountType(accountTypeID int) bool {
-	_, ok := knownAccountTypes[accountTypeID]
-	return ok
+	return constants.IsKnownAccountType(accountTypeID)
+}
+
+// AccountTypeIDByName は権限名から account_type_id を取得します。
+// 権限名は将来の小文字ロール追加と衝突しないよう、大文字小文字を厳密に区別します。
+func AccountTypeIDByName(name string) (int, bool) {
+	id, ok := accountTypeNameToID[name]
+	return id, ok
 }
 
 // HasRole は account_type_id が requiredRoleID を満たすかを判定します。

--- a/internal/infra/models/user_model.go
+++ b/internal/infra/models/user_model.go
@@ -36,15 +36,16 @@ func (m *UserModel) ToEntity() (*entity.User, error) {
 	}
 
 	return &entity.User{
-		ID:            m.ID,
-		Username:      uname,
-		FirebaseUID:   firebaseUID,
-		CreatedAt:     m.CreatedAt,
-		UpdatedAt:     m.UpdatedAt,
-		PlayerID:      m.PlayerID,
-		AccountTypeID: m.AccountTypeID,
-		IsSuspicious:  m.IsSuspicious,
-		IsPrivate:     m.IsPrivate,
+		ID:                    m.ID,
+		Username:              uname,
+		FirebaseUID:           firebaseUID,
+		CreatedAt:             m.CreatedAt,
+		UpdatedAt:             m.UpdatedAt,
+		PlayerID:              m.PlayerID,
+		AccountTypeID:         m.AccountTypeID,
+		OriginalAccountTypeID: m.AccountTypeID,
+		IsSuspicious:          m.IsSuspicious,
+		IsPrivate:             m.IsPrivate,
 	}, nil
 }
 

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -282,6 +282,16 @@ func (r *userRepository) FindAllWithPlayerForAdmin(ctx context.Context, exec rep
 	return results, nil
 }
 
+// CountByAccountType は指定したアカウント種別のユーザー数を取得します。
+func (r *userRepository) CountByAccountType(ctx context.Context, exec repository.Executor, accountTypeID int) (int, error) {
+	var count int
+	query := `SELECT COUNT(id) FROM users WHERE account_type_id = ?`
+	if err := exec.GetContext(ctx, &count, query, accountTypeID); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 // Save はユーザーを集約単位で保存します。IDが存在する場合は更新、存在しない場合は作成します。
 func (r *userRepository) Save(ctx context.Context, exec repository.Executor, user *entity.User) error {
 	userModel := models.FromUserEntity(user)
@@ -313,9 +323,13 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 	if originalAccountTypeID == 0 {
 		return fmt.Errorf("original account type ID is not initialized")
 	}
-	query := "UPDATE users SET player_id = ?, account_type_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND " + whereClause
-	args := []any{userModel.PlayerID, userModel.AccountTypeID, userModel.IsSuspicious, userModel.IsPrivate, userModel.UpdatedAt, userModel.ID, userModel.Username, originalAccountTypeID}
+	query := "UPDATE users SET player_id = ?, account_type_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND " + whereClause + " AND (? != ? OR ? = ? OR (SELECT COUNT(id) FROM users WHERE account_type_id = ?) != 1)"
+	args := []any{
+		userModel.PlayerID, userModel.AccountTypeID, userModel.IsSuspicious, userModel.IsPrivate, userModel.UpdatedAt,
+		userModel.ID, userModel.Username, originalAccountTypeID,
+	}
 	args = append(args, whereArgs...)
+	args = append(args, originalAccountTypeID, constants.AccountTypeAdmin, userModel.AccountTypeID, constants.AccountTypeAdmin, constants.AccountTypeAdmin)
 
 	result, err := exec.ExecContext(ctx, query, args...)
 	if err != nil {

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/chunisupport/chunisupport-api/internal/domain/constants"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/playername"
@@ -302,10 +303,17 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 		return nil
 	}
 
-	// 更新。部分取得エンティティで取りこぼし得る不変項目は更新前提としてのみ扱います。
+	// 更新。ユーザー集約の状態を保存するため、権限を含む変更可能項目をまとめて更新します。
+	if !constants.IsKnownAccountType(userModel.AccountTypeID) {
+		return repository.ErrUserConflict
+	}
 	whereClause, whereArgs := userFirebaseUIDWhereClause(userModel.FirebaseUID)
-	query := "UPDATE users SET player_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND " + whereClause
-	args := []any{userModel.PlayerID, userModel.IsSuspicious, userModel.IsPrivate, userModel.UpdatedAt, userModel.ID, userModel.Username, userModel.AccountTypeID}
+	originalAccountTypeID := user.OriginalAccountTypeID
+	if originalAccountTypeID == 0 {
+		originalAccountTypeID = userModel.AccountTypeID
+	}
+	query := "UPDATE users SET player_id = ?, account_type_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND " + whereClause
+	args := []any{userModel.PlayerID, userModel.AccountTypeID, userModel.IsSuspicious, userModel.IsPrivate, userModel.UpdatedAt, userModel.ID, userModel.Username, originalAccountTypeID}
 	args = append(args, whereArgs...)
 
 	result, err := exec.ExecContext(ctx, query, args...)

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -303,11 +303,15 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 		return nil
 	}
 
+	if !constants.IsKnownAccountType(userModel.AccountTypeID) {
+		return repository.ErrUserConflict
+	}
+
 	// 更新。ユーザー集約の状態を保存するため、権限を含む変更可能項目をまとめて更新します。
 	whereClause, whereArgs := userFirebaseUIDWhereClause(userModel.FirebaseUID)
 	originalAccountTypeID := user.OriginalAccountTypeID
 	if originalAccountTypeID == 0 {
-		originalAccountTypeID = userModel.AccountTypeID
+		return repository.ErrUserConflict
 	}
 	query := "UPDATE users SET player_id = ?, account_type_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND " + whereClause
 	args := []any{userModel.PlayerID, userModel.AccountTypeID, userModel.IsSuspicious, userModel.IsPrivate, userModel.UpdatedAt, userModel.ID, userModel.Username, originalAccountTypeID}

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/chunisupport/chunisupport-api/internal/domain/constants"
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
 	"github.com/chunisupport/chunisupport-api/internal/domain/vo/playername"
@@ -319,13 +318,12 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 	if originalAccountTypeID == 0 {
 		return fmt.Errorf("original account type ID is not initialized")
 	}
-	query := "UPDATE users SET player_id = ?, account_type_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND " + whereClause + " AND (? != ? OR ? = ? OR (SELECT COUNT(id) FROM users WHERE account_type_id = ?) != 1)"
+	query := "UPDATE users SET player_id = ?, account_type_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND " + whereClause
 	args := []any{
 		userModel.PlayerID, userModel.AccountTypeID, userModel.IsSuspicious, userModel.IsPrivate, userModel.UpdatedAt,
 		userModel.ID, userModel.Username, originalAccountTypeID,
 	}
 	args = append(args, whereArgs...)
-	args = append(args, originalAccountTypeID, constants.AccountTypeAdmin, userModel.AccountTypeID, constants.AccountTypeAdmin, constants.AccountTypeAdmin)
 
 	result, err := exec.ExecContext(ctx, query, args...)
 	if err != nil {

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -313,10 +313,6 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 		return nil
 	}
 
-	if !constants.IsKnownAccountType(userModel.AccountTypeID) {
-		return repository.ErrUserConflict
-	}
-
 	// 更新。ユーザー集約の状態を保存するため、権限を含む変更可能項目をまとめて更新します。
 	whereClause, whereArgs := userFirebaseUIDWhereClause(userModel.FirebaseUID)
 	originalAccountTypeID := user.OriginalAccountTypeID

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -311,7 +311,7 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 	whereClause, whereArgs := userFirebaseUIDWhereClause(userModel.FirebaseUID)
 	originalAccountTypeID := user.OriginalAccountTypeID
 	if originalAccountTypeID == 0 {
-		return repository.ErrUserConflict
+		return fmt.Errorf("original account type ID is not initialized")
 	}
 	query := "UPDATE users SET player_id = ?, account_type_id = ?, is_suspicious = ?, is_private = ?, updated_at = ? WHERE id = ? AND username = ? AND account_type_id = ? AND " + whereClause
 	args := []any{userModel.PlayerID, userModel.AccountTypeID, userModel.IsSuspicious, userModel.IsPrivate, userModel.UpdatedAt, userModel.ID, userModel.Username, originalAccountTypeID}

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -304,9 +304,6 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 	}
 
 	// 更新。ユーザー集約の状態を保存するため、権限を含む変更可能項目をまとめて更新します。
-	if !constants.IsKnownAccountType(userModel.AccountTypeID) {
-		return repository.ErrUserConflict
-	}
 	whereClause, whereArgs := userFirebaseUIDWhereClause(userModel.FirebaseUID)
 	originalAccountTypeID := user.OriginalAccountTypeID
 	if originalAccountTypeID == 0 {

--- a/internal/infra/repository/user_repository_impl.go
+++ b/internal/infra/repository/user_repository_impl.go
@@ -321,7 +321,13 @@ func (r *userRepository) Save(ctx context.Context, exec repository.Executor, use
 		return err
 	}
 
-	return r.validateSingleUserUpdate(ctx, exec, userModel.ID, result)
+	if err := r.validateSingleUserUpdate(ctx, exec, userModel.ID, result); err != nil {
+		return err
+	}
+
+	// 保存成功後、OriginalAccountTypeIDを最新の値に更新して次回の保存時の競合検出基準を同期
+	user.OriginalAccountTypeID = userModel.AccountTypeID
+	return nil
 }
 
 // DeleteByID はユーザーを物理削除します。

--- a/internal/infra/repository/user_repository_save_test.go
+++ b/internal/infra/repository/user_repository_save_test.go
@@ -89,18 +89,16 @@ func TestUserRepositorySaveUpdatesMutableFieldsWhenFirebaseUIDMatches(t *testing
 	assert.True(t, saved.IsSuspicious)
 }
 
-func TestUserRepositorySaveBlocksOnlyOneToZeroAdminDemotion(t *testing.T) {
+func TestUserRepositorySaveUpdatesAdminDemotionWithoutLastAdminRule(t *testing.T) {
 	tests := []struct {
 		name           string
 		adminCount     int
-		wantErr        error
 		wantAccountTyp int
 	}{
 		{
-			name:           "ADMINが1人の場合は非ADMINへの更新を拒否する",
+			name:           "ADMINが1人の場合もユースケース層の保証を前提に更新する",
 			adminCount:     1,
-			wantErr:        domainrepo.ErrUserConflict,
-			wantAccountTyp: info.AccountTypeAdmin,
+			wantAccountTyp: info.AccountTypePlayer,
 		},
 		{
 			name:           "ADMINが2人の場合は非ADMINへの更新を許可する",
@@ -138,11 +136,7 @@ func TestUserRepositorySaveBlocksOnlyOneToZeroAdminDemotion(t *testing.T) {
 			err = repo.Save(ctx, db, user)
 
 			// Then
-			if tt.wantErr != nil {
-				require.ErrorIs(t, err, tt.wantErr)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 			var savedAccountTypeID int
 			err = db.Get(&savedAccountTypeID, `SELECT account_type_id FROM users WHERE id = ?`, 1)
 			require.NoError(t, err)

--- a/internal/infra/repository/user_repository_save_test.go
+++ b/internal/infra/repository/user_repository_save_test.go
@@ -89,39 +89,6 @@ func TestUserRepositorySaveUpdatesMutableFieldsWhenFirebaseUIDMatches(t *testing
 	assert.True(t, saved.IsSuspicious)
 }
 
-func TestUserRepositorySaveProtectsAccountTypeIDFromPartialEntity(t *testing.T) {
-	// Given
-	db := setupUserRepositoryTestDB(t)
-	defer db.Close()
-	ctx := context.Background()
-
-	_, err := db.Exec(`
-		INSERT INTO users (id, username, firebase_uid, account_type_id, is_private, is_suspicious)
-		VALUES (1, 'user01', NULL, 1, 0, 0)
-	`)
-	require.NoError(t, err)
-
-	user := newUserForRepositorySaveTest(t, 1, "user01")
-	user.AccountTypeID = 0
-	user.IsPrivate = true
-	user.UpdatedAt = time.Date(2026, 4, 5, 12, 45, 0, 0, time.UTC)
-
-	repo := &userRepository{db: db}
-
-	// When
-	err = repo.Save(ctx, db, user)
-
-	// Then
-	require.ErrorIs(t, err, domainrepo.ErrUserConflict)
-
-	var saved struct {
-		IsPrivate bool `db:"is_private"`
-	}
-	err = db.Get(&saved, `SELECT is_private FROM users WHERE id = ?`, 1)
-	require.NoError(t, err)
-	assert.False(t, saved.IsPrivate)
-}
-
 func TestUserRepositorySaveBlocksOnlyOneToZeroAdminDemotion(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/infra/repository/user_repository_save_test.go
+++ b/internal/infra/repository/user_repository_save_test.go
@@ -122,6 +122,41 @@ func TestUserRepositorySaveProtectsAccountTypeIDFromPartialEntity(t *testing.T) 
 	assert.False(t, saved.IsPrivate)
 }
 
+func TestUserRepositorySaveReturnsErrorWhenOriginalAccountTypeIDMissing(t *testing.T) {
+	// Given
+	db := setupUserRepositoryTestDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	_, err := db.Exec(`
+		INSERT INTO users (id, username, firebase_uid, account_type_id, is_private, is_suspicious)
+		VALUES (1, 'user01', NULL, 1, 0, 0)
+	`)
+	require.NoError(t, err)
+
+	user := newUserForRepositorySaveTest(t, 1, "user01")
+	user.OriginalAccountTypeID = 0
+	user.AccountTypeID = info.AccountTypeAdmin
+	user.UpdatedAt = time.Date(2026, 4, 5, 13, 30, 0, 0, time.UTC)
+
+	repo := &userRepository{db: db}
+
+	// When
+	err = repo.Save(ctx, db, user)
+
+	// Then
+	require.ErrorIs(t, err, domainrepo.ErrUserConflict)
+
+	var saved struct {
+		AccountTypeID int  `db:"account_type_id"`
+		IsPrivate     bool `db:"is_private"`
+	}
+	err = db.Get(&saved, `SELECT account_type_id, is_private FROM users WHERE id = ?`, 1)
+	require.NoError(t, err)
+	assert.Equal(t, info.AccountTypePlayer, saved.AccountTypeID)
+	assert.False(t, saved.IsPrivate)
+}
+
 func TestUserRepositorySaveReturnsErrUserNotFoundWhenTargetMissing(t *testing.T) {
 	// Given
 	db := setupUserRepositoryTestDB(t)

--- a/internal/infra/repository/user_repository_save_test.go
+++ b/internal/infra/repository/user_repository_save_test.go
@@ -122,6 +122,68 @@ func TestUserRepositorySaveProtectsAccountTypeIDFromPartialEntity(t *testing.T) 
 	assert.False(t, saved.IsPrivate)
 }
 
+func TestUserRepositorySaveBlocksOnlyOneToZeroAdminDemotion(t *testing.T) {
+	tests := []struct {
+		name           string
+		adminCount     int
+		wantErr        error
+		wantAccountTyp int
+	}{
+		{
+			name:           "ADMINが1人の場合は非ADMINへの更新を拒否する",
+			adminCount:     1,
+			wantErr:        domainrepo.ErrUserConflict,
+			wantAccountTyp: info.AccountTypeAdmin,
+		},
+		{
+			name:           "ADMINが2人の場合は非ADMINへの更新を許可する",
+			adminCount:     2,
+			wantAccountTyp: info.AccountTypePlayer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			db := setupUserRepositoryTestDB(t)
+			defer db.Close()
+			ctx := context.Background()
+
+			_, err := db.Exec(`
+				INSERT INTO users (id, username, firebase_uid, account_type_id, is_private, is_suspicious)
+				VALUES (?, ?, NULL, ?, ?, ?)
+			`, 1, "admin01", info.AccountTypeAdmin, 0, 0)
+			require.NoError(t, err)
+			if tt.adminCount == 2 {
+				_, err = db.Exec(`
+					INSERT INTO users (id, username, firebase_uid, account_type_id, is_private, is_suspicious)
+					VALUES (?, ?, NULL, ?, ?, ?)
+				`, 2, "admin02", info.AccountTypeAdmin, 0, 0)
+				require.NoError(t, err)
+			}
+
+			user := newUserForRepositorySaveTest(t, 1, "admin01")
+			user.OriginalAccountTypeID = info.AccountTypeAdmin
+			user.AccountTypeID = info.AccountTypePlayer
+			repo := &userRepository{db: db}
+
+			// When
+			err = repo.Save(ctx, db, user)
+
+			// Then
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			var savedAccountTypeID int
+			err = db.Get(&savedAccountTypeID, `SELECT account_type_id FROM users WHERE id = ?`, 1)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAccountTyp, savedAccountTypeID)
+		})
+	}
+}
+
 func TestUserRepositorySaveReturnsErrorWhenOriginalAccountTypeIDMissing(t *testing.T) {
 	// Given
 	db := setupUserRepositoryTestDB(t)

--- a/internal/infra/repository/user_repository_save_test.go
+++ b/internal/infra/repository/user_repository_save_test.go
@@ -145,7 +145,8 @@ func TestUserRepositorySaveReturnsErrorWhenOriginalAccountTypeIDMissing(t *testi
 	err = repo.Save(ctx, db, user)
 
 	// Then
-	require.ErrorIs(t, err, domainrepo.ErrUserConflict)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, domainrepo.ErrUserConflict)
 
 	var saved struct {
 		AccountTypeID int  `db:"account_type_id"`

--- a/internal/usecase/api_token_usecase_impl_test.go
+++ b/internal/usecase/api_token_usecase_impl_test.go
@@ -96,6 +96,10 @@ func (s *tokenStubUserRepository) FindAllWithPlayerForAdmin(ctx context.Context,
 	return nil, errors.New("not implemented")
 }
 
+func (s *tokenStubUserRepository) CountByAccountType(ctx context.Context, exec repository.Executor, accountTypeID int) (int, error) {
+	return 0, errors.New("not implemented")
+}
+
 func (s *tokenStubUserRepository) Save(ctx context.Context, exec repository.Executor, user *entity.User) error {
 	return errors.New("not implemented")
 }

--- a/internal/usecase/auth_usecase_test_helper_test.go
+++ b/internal/usecase/auth_usecase_test_helper_test.go
@@ -86,6 +86,11 @@ func (m *MockUserRepository) FindAllWithPlayerForAdmin(ctx context.Context, exec
 	return args.Get(0).([]entity.UserWithPlayer), args.Error(1)
 }
 
+func (m *MockUserRepository) CountByAccountType(ctx context.Context, exec repository.Executor, accountTypeID int) (int, error) {
+	args := m.Called(ctx, exec, accountTypeID)
+	return args.Int(0), args.Error(1)
+}
+
 func (m *MockUserRepository) Save(ctx context.Context, exec repository.Executor, user *entity.User) error {
 	args := m.Called(ctx, exec, user)
 	return args.Error(0)

--- a/internal/usecase/errors.go
+++ b/internal/usecase/errors.go
@@ -10,7 +10,8 @@ var (
 	ErrInvalidWorldsendInput = errors.New("invalid worldsend input")
 	ErrInvalidHonorInput     = errors.New("invalid honor input")
 
-	ErrAdminRequired = errors.New("admin permission required")
+	ErrAdminRequired      = errors.New("admin permission required")
+	ErrInvalidAccountType = errors.New("invalid account type")
 
 	ErrRecordFilterNotFound      = errors.New("record filter not found")
 	ErrRecordFilterLimitExceeded = errors.New("record filter limit exceeded")

--- a/internal/usecase/errors.go
+++ b/internal/usecase/errors.go
@@ -1,6 +1,10 @@
 package usecase
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+)
 
 var (
 	ErrInvalidPlayerName = errors.New("invalid player name")
@@ -10,8 +14,11 @@ var (
 	ErrInvalidWorldsendInput = errors.New("invalid worldsend input")
 	ErrInvalidHonorInput     = errors.New("invalid honor input")
 
-	ErrAdminRequired      = errors.New("admin permission required")
-	ErrInvalidAccountType = errors.New("invalid account type")
+	ErrAdminRequired = errors.New("admin permission required")
+	// ErrInvalidAccountType はドメイン層の権限種別エラーと同一インスタンスに揃えます。
+	// ユースケース境界で再公開する名前を残しつつ、errors.Is によるAPIエラー変換が
+	// ドメイン由来のエラーでも同じ結果になるようにします。
+	ErrInvalidAccountType = entity.ErrInvalidAccountType
 	ErrLastAdminRequired  = errors.New("last admin must remain")
 
 	ErrRecordFilterNotFound      = errors.New("record filter not found")

--- a/internal/usecase/errors.go
+++ b/internal/usecase/errors.go
@@ -12,6 +12,7 @@ var (
 
 	ErrAdminRequired      = errors.New("admin permission required")
 	ErrInvalidAccountType = errors.New("invalid account type")
+	ErrLastAdminRequired  = errors.New("last admin must remain")
 
 	ErrRecordFilterNotFound      = errors.New("record filter not found")
 	ErrRecordFilterLimitExceeded = errors.New("record filter limit exceeded")

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -34,4 +34,7 @@ type UserUsecase interface {
 
 	// DeleteUser はユーザーを物理削除します。
 	DeleteUser(ctx context.Context, requester *entity.User, username string) error
+
+	// ChangeUserAccountType はADMIN操作として対象ユーザーの権限を変更し、更新後のユーザー集約を返します。
+	ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error)
 }

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -35,6 +35,6 @@ type UserUsecase interface {
 	// DeleteUser はユーザーを物理削除します。
 	DeleteUser(ctx context.Context, requester *entity.User, username string) error
 
-	// ChangeUserAccountType はADMIN操作として対象ユーザーの権限を変更し、更新後のユーザー集約を返します。
-	ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error)
+	// ChangeUserAccountType はADMIN操作として対象ユーザー名の権限を変更し、更新後のユーザー集約を返します。
+	ChangeUserAccountType(ctx context.Context, requester *entity.User, username string, accountType string) (*entity.User, error)
 }

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -375,9 +375,6 @@ func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *enti
 	}
 
 	if err := user.ChangeAccountType(accountTypeID); err != nil {
-		if errors.Is(err, entity.ErrInvalidAccountType) {
-			return nil, ErrInvalidAccountType
-		}
 		return nil, err
 	}
 

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -326,6 +326,10 @@ func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, us
 		return err
 	}
 
+	if err := s.ensureNotLastAdminRemoval(ctx, user); err != nil {
+		return err
+	}
+
 	firebaseUID := ""
 	if user.FirebaseUID != nil {
 		firebaseUID = *user.FirebaseUID
@@ -366,6 +370,10 @@ func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *enti
 		return nil, err
 	}
 
+	if err := s.ensureNotLastAdminDemotion(ctx, user, accountTypeID); err != nil {
+		return nil, err
+	}
+
 	if err := user.ChangeAccountType(accountTypeID); err != nil {
 		if errors.Is(err, entity.ErrInvalidAccountType) {
 			return nil, ErrInvalidAccountType
@@ -384,6 +392,32 @@ func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *enti
 func (s *userUsecase) ensureAdminPermission(requester *entity.User) error {
 	if requester == nil || !info.HasRole(requester.AccountTypeID, info.AccountTypeAdmin) {
 		return ErrAdminRequired
+	}
+	return nil
+}
+
+func (s *userUsecase) ensureNotLastAdminDemotion(ctx context.Context, user *entity.User, nextAccountTypeID int) error {
+	if user.AccountTypeID != info.AccountTypeAdmin || nextAccountTypeID == info.AccountTypeAdmin {
+		return nil
+	}
+	return s.ensureAdminCountIsNotOne(ctx)
+}
+
+func (s *userUsecase) ensureNotLastAdminRemoval(ctx context.Context, user *entity.User) error {
+	if user.AccountTypeID != info.AccountTypeAdmin {
+		return nil
+	}
+	return s.ensureAdminCountIsNotOne(ctx)
+}
+
+func (s *userUsecase) ensureAdminCountIsNotOne(ctx context.Context) error {
+	adminCount, err := s.userRepo.CountByAccountType(ctx, s.db, info.AccountTypeAdmin)
+	if err != nil {
+		slog.Error("failed to count admin users", "error", err)
+		return err
+	}
+	if adminCount == 1 {
+		return ErrLastAdminRequired
 	}
 	return nil
 }

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -345,6 +345,42 @@ func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, us
 	return nil
 }
 
+// ChangeUserAccountType はADMIN操作としてユーザー権限を変更します。
+// ハンドラの認可ミドルウェアだけに依存しないよう、ユースケースでもADMIN権限を検証します。
+func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error) {
+	if err := s.ensureDeleteUserPermission(requester); err != nil {
+		return nil, err
+	}
+
+	accountTypeID, ok := info.AccountTypeIDByName(accountType)
+	if !ok {
+		return nil, ErrInvalidAccountType
+	}
+
+	user, err := s.userRepo.FindByID(ctx, s.db, userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrUserNotFound) {
+			return nil, ErrUserNotFound
+		}
+		slog.Error("failed to find user by id for account type change", "user_id", userID, "error", err)
+		return nil, err
+	}
+
+	if err := user.ChangeAccountType(accountTypeID); err != nil {
+		if errors.Is(err, entity.ErrInvalidAccountType) {
+			return nil, ErrInvalidAccountType
+		}
+		return nil, err
+	}
+
+	if err := s.userRepo.Save(ctx, s.db, user); err != nil {
+		slog.Error("failed to save user account type", "user_id", userID, "error", err)
+		return nil, err
+	}
+
+	return user, nil
+}
+
 func (s *userUsecase) ensureDeleteUserPermission(requester *entity.User) error {
 	if requester == nil || !info.HasRole(requester.AccountTypeID, info.AccountTypeAdmin) {
 		return ErrAdminRequired

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -408,6 +408,9 @@ func (s *userUsecase) ensureNotLastAdminRemoval(ctx context.Context, user *entit
 }
 
 func (s *userUsecase) ensureAdminCountIsNotOne(ctx context.Context) error {
+	// このアプリでは最初のADMINをDB直接編集で付与する運用を許容しており、
+	// 万一ADMINが0人になってもDBから復旧できる規模のため、
+	// TransactionManagerや行ロックまでは導入せず、通常操作での「1人→0人」だけを防ぎます。
 	adminCount, err := s.userRepo.CountByAccountType(ctx, s.db, info.AccountTypeAdmin)
 	if err != nil {
 		slog.Error("failed to count admin users", "error", err)

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -347,7 +347,7 @@ func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, us
 
 // ChangeUserAccountType はADMIN操作としてユーザー権限を変更します。
 // ハンドラの認可ミドルウェアだけに依存しないよう、ユースケースでもADMIN権限を検証します。
-func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error) {
+func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, username string, accountType string) (*entity.User, error) {
 	if err := s.ensureAdminPermission(requester); err != nil {
 		return nil, err
 	}
@@ -357,12 +357,12 @@ func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *enti
 		return nil, ErrInvalidAccountType
 	}
 
-	user, err := s.userRepo.FindByID(ctx, s.db, userID)
+	user, err := s.userRepo.FindByUsername(ctx, s.db, username)
 	if err != nil {
 		if errors.Is(err, repository.ErrUserNotFound) {
 			return nil, ErrUserNotFound
 		}
-		slog.Error("failed to find user by id for account type change", "user_id", userID, "error", err)
+		slog.Error("failed to find user by username for account type change", "username", username, "error", err)
 		return nil, err
 	}
 
@@ -374,7 +374,7 @@ func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *enti
 	}
 
 	if err := s.userRepo.Save(ctx, s.db, user); err != nil {
-		slog.Error("failed to save user account type", "user_id", userID, "error", err)
+		slog.Error("failed to save user account type", "username", username, "error", err)
 		return nil, err
 	}
 

--- a/internal/usecase/user_usecase_impl.go
+++ b/internal/usecase/user_usecase_impl.go
@@ -312,7 +312,7 @@ func (s *userUsecase) GetAllUsersForAdmin(ctx context.Context, page int, limit i
 // DeleteUser はユーザーを物理削除します。
 // 防御的深度: ハンドラ層のミドルウェアに加え、ユースケース層でもADMIN権限を検証します。
 func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, username string) error {
-	if err := s.ensureDeleteUserPermission(requester); err != nil {
+	if err := s.ensureAdminPermission(requester); err != nil {
 		return err
 	}
 
@@ -348,7 +348,7 @@ func (s *userUsecase) DeleteUser(ctx context.Context, requester *entity.User, us
 // ChangeUserAccountType はADMIN操作としてユーザー権限を変更します。
 // ハンドラの認可ミドルウェアだけに依存しないよう、ユースケースでもADMIN権限を検証します。
 func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *entity.User, userID int, accountType string) (*entity.User, error) {
-	if err := s.ensureDeleteUserPermission(requester); err != nil {
+	if err := s.ensureAdminPermission(requester); err != nil {
 		return nil, err
 	}
 
@@ -381,7 +381,7 @@ func (s *userUsecase) ChangeUserAccountType(ctx context.Context, requester *enti
 	return user, nil
 }
 
-func (s *userUsecase) ensureDeleteUserPermission(requester *entity.User) error {
+func (s *userUsecase) ensureAdminPermission(requester *entity.User) error {
 	if requester == nil || !info.HasRole(requester.AccountTypeID, info.AccountTypeAdmin) {
 		return ErrAdminRequired
 	}

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -1187,7 +1187,7 @@ func TestUserUsecase_ChangeUserAccountType(t *testing.T) {
 			service := NewUserUsecase(nil, tt.repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
 
 			// When
-			got, err := service.ChangeUserAccountType(context.Background(), tt.requester, 1, tt.accountType)
+			got, err := service.ChangeUserAccountType(context.Background(), tt.requester, "testuser", tt.accountType)
 
 			// Then
 			if tt.wantErr != nil {

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -32,7 +32,10 @@ type stubUserRepository struct {
 }
 
 func (s *stubUserRepository) FindByID(ctx context.Context, exec repository.Executor, id int) (*entity.User, error) {
-	return nil, errors.New("not implemented")
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.user, nil
 }
 
 func (s *stubUserRepository) FindByIDForUpdate(ctx context.Context, exec repository.Executor, id int) (*entity.User, error) {
@@ -1113,4 +1116,90 @@ func TestUserUsecase_DeleteUser_NilRequester(t *testing.T) {
 
 	err := service.DeleteUser(context.Background(), nil, "testuser")
 	require.ErrorIs(t, err, ErrAdminRequired)
+}
+
+func TestUserUsecase_ChangeUserAccountType(t *testing.T) {
+	un, err := username.NewUserName("testuser")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		requester       *entity.User
+		accountType     string
+		repo            *stubUserRepository
+		wantErr         error
+		wantAccountType int
+	}{
+		{
+			name:            "ADMINはPLAYERをADMINに変更できる",
+			requester:       &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin},
+			accountType:     "ADMIN",
+			repo:            &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypePlayer}},
+			wantAccountType: info.AccountTypeAdmin,
+		},
+		{
+			name:            "ADMINはADMINをPLAYERに変更できる",
+			requester:       &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin},
+			accountType:     "PLAYER",
+			repo:            &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypeAdmin}},
+			wantAccountType: info.AccountTypePlayer,
+		},
+		{
+			name:            "ADMINは自分自身をEDITORに変更できる",
+			requester:       &entity.User{ID: 1, AccountTypeID: info.AccountTypeAdmin},
+			accountType:     "EDITOR",
+			repo:            &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypeAdmin}},
+			wantAccountType: info.AccountTypeEditor,
+		},
+		{
+			name:        "小文字の権限は拒否する",
+			requester:   &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin},
+			accountType: "admin",
+			repo:        &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypePlayer}},
+			wantErr:     ErrInvalidAccountType,
+		},
+		{
+			name:        "存在しない権限は拒否する",
+			requester:   &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin},
+			accountType: "SUPER_ADMIN",
+			repo:        &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypePlayer}},
+			wantErr:     ErrInvalidAccountType,
+		},
+		{
+			name:        "ADMIN以外は拒否する",
+			requester:   &entity.User{ID: 99, AccountTypeID: info.AccountTypeEditor},
+			accountType: "ADMIN",
+			repo:        &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypePlayer}},
+			wantErr:     ErrAdminRequired,
+		},
+		{
+			name:        "対象ユーザーが存在しない場合はErrUserNotFound",
+			requester:   &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin},
+			accountType: "ADMIN",
+			repo:        &stubUserRepository{err: repository.ErrUserNotFound},
+			wantErr:     ErrUserNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			service := NewUserUsecase(nil, tt.repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
+
+			// When
+			got, err := service.ChangeUserAccountType(context.Background(), tt.requester, 1, tt.accountType)
+
+			// Then
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.NotNil(t, tt.repo.savedUser)
+			assert.Equal(t, tt.wantAccountType, tt.repo.savedUser.AccountTypeID)
+			assert.Equal(t, tt.wantAccountType, got.AccountTypeID)
+		})
+	}
 }

--- a/internal/usecase/user_usecase_impl_test.go
+++ b/internal/usecase/user_usecase_impl_test.go
@@ -29,6 +29,8 @@ type stubUserRepository struct {
 	saveErr         error
 	savedUser       *entity.User
 	deletedUserID   int
+	adminCount      int
+	countErr        error
 }
 
 func (s *stubUserRepository) FindByID(ctx context.Context, exec repository.Executor, id int) (*entity.User, error) {
@@ -61,6 +63,13 @@ func (s *stubUserRepository) FindAllWithPlayerForAdmin(ctx context.Context, exec
 		return nil, s.err
 	}
 	return s.usersWithPlayer, nil
+}
+
+func (s *stubUserRepository) CountByAccountType(ctx context.Context, exec repository.Executor, accountTypeID int) (int, error) {
+	if s.countErr != nil {
+		return 0, s.countErr
+	}
+	return s.adminCount, nil
 }
 
 func (s *stubUserRepository) Save(ctx context.Context, exec repository.Executor, user *entity.User) error {
@@ -1086,6 +1095,21 @@ func TestUserUsecase_DeleteUser_Success(t *testing.T) {
 	assert.Equal(t, 1, repo.deletedUserID)
 }
 
+func TestUserUsecase_DeleteUser_LastAdminRejected(t *testing.T) {
+	un, err := username.NewUserName("adminuser")
+	require.NoError(t, err)
+	adminRequester := &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin}
+	repo := &stubUserRepository{
+		user:       &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypeAdmin},
+		adminCount: 1,
+	}
+	service := NewUserUsecase(nil, repo, &stubPlayerRepository{}, &stubPlayerRecordRepository{}, nil, nil, nil, nil)
+
+	err = service.DeleteUser(context.Background(), adminRequester, "adminuser")
+	require.ErrorIs(t, err, ErrLastAdminRequired)
+	assert.Zero(t, repo.deletedUserID)
+}
+
 func TestUserUsecase_DeleteUser_UserNotFound(t *testing.T) {
 	adminRequester := &entity.User{ID: 99, AccountTypeID: 3}
 	repo := &stubUserRepository{err: repository.ErrUserNotFound}
@@ -1138,17 +1162,34 @@ func TestUserUsecase_ChangeUserAccountType(t *testing.T) {
 			wantAccountType: info.AccountTypeAdmin,
 		},
 		{
-			name:            "ADMINはADMINをPLAYERに変更できる",
+			name:            "ADMINが2人以上いる場合はADMINをPLAYERに変更できる",
 			requester:       &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin},
 			accountType:     "PLAYER",
-			repo:            &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypeAdmin}},
+			repo:            &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypeAdmin}, adminCount: 2},
 			wantAccountType: info.AccountTypePlayer,
 		},
 		{
-			name:            "ADMINは自分自身をEDITORに変更できる",
+			name:        "ADMINが0人の状態ではPLAYERをADMINに変更できる",
+			requester:   &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin},
+			accountType: "ADMIN",
+			repo: &stubUserRepository{
+				user:       &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypePlayer},
+				adminCount: 0,
+			},
+			wantAccountType: info.AccountTypeAdmin,
+		},
+		{
+			name:        "ADMINが1人の場合はADMINからPLAYERへの変更を拒否する",
+			requester:   &entity.User{ID: 99, AccountTypeID: info.AccountTypeAdmin},
+			accountType: "PLAYER",
+			repo:        &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypeAdmin}, adminCount: 1},
+			wantErr:     ErrLastAdminRequired,
+		},
+		{
+			name:            "ADMINが2人以上いる場合は自分自身をEDITORに変更できる",
 			requester:       &entity.User{ID: 1, AccountTypeID: info.AccountTypeAdmin},
 			accountType:     "EDITOR",
-			repo:            &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypeAdmin}},
+			repo:            &stubUserRepository{user: &entity.User{ID: 1, Username: un, AccountTypeID: info.AccountTypeAdmin}, adminCount: 2},
 			wantAccountType: info.AccountTypeEditor,
 		},
 		{


### PR DESCRIPTION
### Motivation

- Provide an ADMIN API to change a user's account type and ensure domain-level validation and safe persistence.
- Prevent invalid role names and enforce role authorization both in handler and in usecase logic.

### Description

- Added PATCH `/internal/admin/users/:id/account-type` route and `AdminUserHandler.UpdateUserAccountType` handler with request/response DTOs in `internal/dto/api_internal` and docs in `docs/API.md`.
- Introduced domain account type constants in `internal/domain/constants/account_type.go` and a domain method `User.ChangeAccountType` that validates account type IDs, plus added `OriginalAccountTypeID` to `entity.User` for optimistic concurrency control.
- Extended `info` package with `AccountTypeIDByName` and wired constants usage; added mapping from name strings (`"PLAYER"/"EDITOR"/"ADMIN"`) to IDs and preserved strict case-sensitivity.
- Updated repository and model mapping to include `OriginalAccountTypeID` and to validate `account_type_id` on `Save`, and updated the `UPDATE` SQL to update `account_type_id` atomically while checking the original value to avoid races.
- Added `ChangeUserAccountType` to the `UserUsecase` interface and implemented it in the usecase to authorize ADMINs, translate role names to IDs, call domain `ChangeAccountType`, and persist the change; added `ErrInvalidAccountType` and mapped it to HTTP 400 in API error mapping.
- Updated router to register the new admin route and updated tests/mocks to include the new usecase call signatures and DTOs.

### Testing

- Ran unit tests including `internal/usecase/user_usecase_impl_test.go` which contains `TestUserUsecase_ChangeUserAccountType`, and updated handler tests; all executed via `go test ./...` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39c3460eec832db6541c48398e8ffe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

## Documentation
* 管理者向け `PATCH /internal/admin/users/:username/account-type` の 仕様（認証要件、 入力/出力例、主なエラー）を API ドキュメントに 追加

## New Features
* ADMIN が ユーザー の アカウント種別（PLAYER/EDITOR/ADMIN）を 変更できる 機能 を 提供（成功時に `id`/`username`/`account_type`/`updated_at` を返却）

## Bug Fixes
* 不正 な 権限指定 や 存在しない種別、ADMIN 以外の実行、整合性 競合 時の 扱い を 一貫化

## Tests
* 主要な 変更経路 の テスト を 追加/更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->