### PR TITLE
fix: OP再計算のスキップ内容をログ出力

### DIFF
--- a/internal/usecase/overpower_record_converter.go
+++ b/internal/usecase/overpower_record_converter.go
@@ -11,28 +11,58 @@ import (
 // failOnMissingRelatedがtrueの場合、関連エンティティ欠損を不整合としてエラーを返し、
 // falseの場合は欠損レコードを安全にスキップする。
 func playerRecordsToOverpowerRecords(records []*entity.PlayerRecord, failOnMissingRelated bool, include func(*entity.PlayerRecord) bool) ([]domainservice.OverpowerRecord, error) {
+	overpowerRecords, _, err := playerRecordsToOverpowerRecordsWithSkipped(records, failOnMissingRelated, func(record *entity.PlayerRecord) (bool, string) {
+		if include == nil || include(record) {
+			return true, ""
+		}
+		return false, "excluded"
+	})
+	return overpowerRecords, err
+}
+
+type skippedOverpowerRecord struct {
+	Index     int    `json:"index"`
+	PlayerID  int    `json:"player_id,omitempty"`
+	SongID    int    `json:"song_id,omitempty"`
+	SongTitle string `json:"song_title,omitempty"`
+	ChartID   int    `json:"chart_id,omitempty"`
+	Reason    string `json:"reason"`
+}
+
+func playerRecordsToOverpowerRecordsWithSkipped(records []*entity.PlayerRecord, failOnMissingRelated bool, include func(*entity.PlayerRecord) (bool, string)) ([]domainservice.OverpowerRecord, []skippedOverpowerRecord, error) {
 	overpowerRecords := make([]domainservice.OverpowerRecord, 0, len(records))
+	skipped := make([]skippedOverpowerRecord, 0)
 	for i, record := range records {
 		if record == nil {
 			if failOnMissingRelated {
-				return nil, fmt.Errorf("player record is nil at index=%d", i)
+				return nil, nil, fmt.Errorf("player record is nil at index=%d", i)
 			}
+			skipped = append(skipped, skippedOverpowerRecord{Index: i, Reason: "record_nil"})
 			continue
 		}
 		if record.Song == nil {
 			if failOnMissingRelated {
-				return nil, fmt.Errorf("song is nil in player record at index=%d", i)
+				return nil, nil, fmt.Errorf("song is nil in player record at index=%d", i)
 			}
+			skipped = append(skipped, newSkippedOverpowerRecord(i, record, "song_nil"))
 			continue
 		}
 		if record.Chart == nil {
 			if failOnMissingRelated {
-				return nil, fmt.Errorf("chart is nil in player record at index=%d", i)
+				return nil, nil, fmt.Errorf("chart is nil in player record at index=%d", i)
 			}
+			skipped = append(skipped, newSkippedOverpowerRecord(i, record, "chart_nil"))
 			continue
 		}
-		if include != nil && !include(record) {
-			continue
+		if include != nil {
+			included, reason := include(record)
+			if !included {
+				if reason == "" {
+					reason = "excluded"
+				}
+				skipped = append(skipped, newSkippedOverpowerRecord(i, record, reason))
+				continue
+			}
 		}
 
 		overpowerRecords = append(overpowerRecords, domainservice.OverpowerRecord{
@@ -42,5 +72,19 @@ func playerRecordsToOverpowerRecords(records []*entity.PlayerRecord, failOnMissi
 			ComboLampID: record.ComboLampID,
 		})
 	}
-	return overpowerRecords, nil
+	return overpowerRecords, skipped, nil
+}
+
+func newSkippedOverpowerRecord(index int, record *entity.PlayerRecord, reason string) skippedOverpowerRecord {
+	skipped := skippedOverpowerRecord{Index: index, Reason: reason}
+	if record == nil {
+		return skipped
+	}
+	skipped.PlayerID = record.PlayerID
+	skipped.ChartID = record.ChartID
+	if record.Song != nil {
+		skipped.SongID = record.Song.ID
+		skipped.SongTitle = record.Song.Title
+	}
+	return skipped
 }

--- a/internal/usecase/overpower_record_converter_test.go
+++ b/internal/usecase/overpower_record_converter_test.go
@@ -1,0 +1,45 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/chartconstant"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/score"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlayerRecordsToOverpowerRecordsWithSkipped(t *testing.T) {
+	// Given
+	recordScore, err := score.NewScore(1_000_000)
+	require.NoError(t, err)
+	chartConst, err := chartconstant.NewChartConstant(10.0)
+	require.NoError(t, err)
+
+	records := []*entity.PlayerRecord{
+		nil,
+		{PlayerID: 1, ChartID: 10, Score: recordScore, Chart: &entity.Chart{ID: 10, Const: chartConst}},
+		{PlayerID: 1, ChartID: 11, Score: recordScore, Song: &entity.Song{ID: 100, Title: "テスト曲"}},
+		{PlayerID: 1, ChartID: 12, Score: recordScore, Song: &entity.Song{ID: 101, Title: "除外曲"}, Chart: &entity.Chart{ID: 12, Const: chartConst}},
+		{PlayerID: 1, ChartID: 13, Score: recordScore, Song: &entity.Song{ID: 102, Title: "集計曲"}, Chart: &entity.Chart{ID: 13, Const: chartConst}},
+	}
+
+	// When
+	overpowerRecords, skipped, err := playerRecordsToOverpowerRecordsWithSkipped(records, false, func(record *entity.PlayerRecord) (bool, string) {
+		if record.Song.ID == 101 {
+			return false, "locked_song"
+		}
+		return true, ""
+	})
+
+	// Then
+	require.NoError(t, err)
+	assert.Len(t, overpowerRecords, 1)
+	assert.Equal(t, []skippedOverpowerRecord{
+		{Index: 0, Reason: "record_nil"},
+		{Index: 1, PlayerID: 1, ChartID: 10, Reason: "song_nil"},
+		{Index: 2, PlayerID: 1, SongID: 100, SongTitle: "テスト曲", ChartID: 11, Reason: "chart_nil"},
+		{Index: 3, PlayerID: 1, SongID: 101, SongTitle: "除外曲", ChartID: 12, Reason: "locked_song"},
+	}, skipped)
+}

--- a/internal/usecase/player_data_usecase_impl.go
+++ b/internal/usecase/player_data_usecase_impl.go
@@ -1335,21 +1335,24 @@ func calculateOverpowerSummaryFromPlayerRecords(records []*entity.PlayerRecord, 
 		}
 		lockedSet[lockedSongKey(lockedSong.SongID, lockedSong.IsUltima)] = struct{}{}
 	}
-	overpowerRecords, err := playerRecordsToOverpowerRecords(records, false, func(record *entity.PlayerRecord) bool {
+	overpowerRecords, skippedRecords, err := playerRecordsToOverpowerRecordsWithSkipped(records, false, func(record *entity.PlayerRecord) (bool, string) {
 		if len(lockedSet) == 0 {
-			return true
+			return true, ""
 		}
 		if record.ChartDifficulty == nil {
-			return false
+			return false, "chart_difficulty_nil"
 		}
 		_, exists := lockedSet[lockedSongKey(record.Song.ID, record.ChartDifficulty.Name == info.DifficultyNameUltima)]
-		return !exists
+		if exists {
+			return false, "locked_song"
+		}
+		return true, ""
 	})
 	if err != nil {
 		return calculatedOverpowerSummary{}, err
 	}
-	if len(overpowerRecords) != len(records) {
-		slog.Warn("skipped player records with missing related data during overpower recalculation", "total_records", len(records), "aggregated_records", len(overpowerRecords))
+	if len(skippedRecords) > 0 {
+		slog.Warn("skipped player records during overpower recalculation", "total_records", len(records), "aggregated_records", len(overpowerRecords), "skipped_records", skippedRecords)
 	}
 	value, percent := service.CalcOverpowerSummary(overpowerRecords, maxOverpowerTotal)
 	return calculatedOverpowerSummary{Value: &value, Percent: &percent}, nil

--- a/internal/usecase/player_data_usecase_impl_test.go
+++ b/internal/usecase/player_data_usecase_impl_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/chunisupport/chunisupport-api/internal/domain/entity"
 	domainmasterdata "github.com/chunisupport/chunisupport-api/internal/domain/masterdata"
 	"github.com/chunisupport/chunisupport-api/internal/domain/repository"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/chartconstant"
 	mastervo "github.com/chunisupport/chunisupport-api/internal/domain/vo/master"
+	"github.com/chunisupport/chunisupport-api/internal/domain/vo/score"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,11 +33,12 @@ func TestValidatePlayerDataPayload_AppVersionを検証しない(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// 最小限のペイロードを作成（スコアは空）
+			rating := 0.0
 			payload := &PlayerDataPayload{
 				AppVersion: tt.appVersion,
 				Name:       "テストプレイヤー",
 				Level:      1,
-				Rating:     new(0.0),
+				Rating:     &rating,
 				LastPlayed: "2024/01/01 00:00",
 				Overpower: PlayerDataOverpowerPayload{
 					Value:      0.0,
@@ -163,8 +166,8 @@ func TestResolveClassEmblemIDs(t *testing.T) {
 				MedalClass: "06",
 				BaseClass:  "06",
 			},
-			wantClassID: new(6),
-			wantBaseID:  new(6),
+			wantClassID: intPtrForApplyScoresTest(6),
+			wantBaseID:  intPtrForApplyScoresTest(6),
 		},
 		{
 			name: "infの直接指定も従来通り解決できる",
@@ -172,8 +175,8 @@ func TestResolveClassEmblemIDs(t *testing.T) {
 				MedalClass: "INF",
 				BaseClass:  "inf",
 			},
-			wantClassID: new(6),
-			wantBaseID:  new(6),
+			wantClassID: intPtrForApplyScoresTest(6),
+			wantBaseID:  intPtrForApplyScoresTest(6),
 		},
 		{
 			name: "未定義値はnil扱いになる",
@@ -377,4 +380,240 @@ func newApplyHonorsTestMasters() *playerDataMaster {
 			},
 		},
 	}
+}
+
+func TestCalculateOverpowerSummaryFromPlayerRecords(t *testing.T) {
+	t.Run("ChartDifficultyがnilのレコードをスキップしWARNログを出力する", func(t *testing.T) {
+		// Arrange
+		logBuffer := captureDefaultSlog(t)
+		recordScore, err := score.NewScore(1_000_000)
+		require.NoError(t, err)
+		chartConst, err := chartconstant.NewChartConstant(10.0)
+		require.NoError(t, err)
+
+		records := []*entity.PlayerRecord{
+			// ChartDifficultyがnilのレコード（スキップされる）
+			{
+				PlayerID: 1,
+				ChartID:  10,
+				Score:    recordScore,
+				Song:     &entity.Song{ID: 100, Title: "テスト曲1"},
+				Chart:    &entity.Chart{ID: 10, Const: chartConst},
+				// ChartDifficulty: nil
+			},
+			// 正常なレコード（集計される）
+			{
+				PlayerID: 1,
+				ChartID:  11,
+				Score:    recordScore,
+				Song:     &entity.Song{ID: 101, Title: "テスト曲2"},
+				Chart:    &entity.Chart{ID: 11, Const: chartConst},
+				ChartDifficulty: &entity.ChartDifficulty{
+					ID:   1,
+					Name: "MASTER",
+				},
+			},
+		}
+
+		lockedSongs := []*entity.PlayerLockedSong{
+			{PlayerID: 1, SongID: 200, IsUltima: false},
+		}
+
+		// Act
+		result, err := calculateOverpowerSummaryFromPlayerRecords(records, lockedSongs, 100.0)
+
+		// Assert
+		require.NoError(t, err)
+		assert.NotNil(t, result.Value)
+		assert.NotNil(t, result.Percent)
+
+		// WARNログが出力されていることを確認
+		logOutput := logBuffer.String()
+		assert.Contains(t, logOutput, "level=WARN")
+		assert.Contains(t, logOutput, "skipped player records during overpower recalculation")
+		assert.Contains(t, logOutput, "chart_difficulty_nil")
+	})
+
+	t.Run("ロック楽曲のレコードをスキップしWARNログを出力する", func(t *testing.T) {
+		// Arrange
+		logBuffer := captureDefaultSlog(t)
+		recordScore, err := score.NewScore(1_000_000)
+		require.NoError(t, err)
+		chartConst, err := chartconstant.NewChartConstant(10.0)
+		require.NoError(t, err)
+
+		records := []*entity.PlayerRecord{
+			// ロックされている楽曲（スキップされる）
+			{
+				PlayerID: 1,
+				ChartID:  10,
+				Score:    recordScore,
+				Song:     &entity.Song{ID: 100, Title: "ロック曲"},
+				Chart:    &entity.Chart{ID: 10, Const: chartConst},
+				ChartDifficulty: &entity.ChartDifficulty{
+					ID:   1,
+					Name: "MASTER",
+				},
+			},
+			// 正常なレコード（集計される）
+			{
+				PlayerID: 1,
+				ChartID:  11,
+				Score:    recordScore,
+				Song:     &entity.Song{ID: 101, Title: "通常曲"},
+				Chart:    &entity.Chart{ID: 11, Const: chartConst},
+				ChartDifficulty: &entity.ChartDifficulty{
+					ID:   1,
+					Name: "MASTER",
+				},
+			},
+		}
+
+		lockedSongs := []*entity.PlayerLockedSong{
+			{PlayerID: 1, SongID: 100, IsUltima: false},
+		}
+
+		// Act
+		result, err := calculateOverpowerSummaryFromPlayerRecords(records, lockedSongs, 100.0)
+
+		// Assert
+		require.NoError(t, err)
+		assert.NotNil(t, result.Value)
+		assert.NotNil(t, result.Percent)
+
+		// WARNログが出力されていることを確認
+		logOutput := logBuffer.String()
+		assert.Contains(t, logOutput, "level=WARN")
+		assert.Contains(t, logOutput, "skipped player records during overpower recalculation")
+		assert.Contains(t, logOutput, "locked_song")
+	})
+
+	t.Run("ULTIMAのロック楽曲も正しくスキップする", func(t *testing.T) {
+		// Arrange
+		logBuffer := captureDefaultSlog(t)
+		recordScore, err := score.NewScore(1_000_000)
+		require.NoError(t, err)
+		chartConst, err := chartconstant.NewChartConstant(10.0)
+		require.NoError(t, err)
+
+		records := []*entity.PlayerRecord{
+			// ULTIMAでロックされている楽曲（スキップされる）
+			{
+				PlayerID: 1,
+				ChartID:  10,
+				Score:    recordScore,
+				Song:     &entity.Song{ID: 100, Title: "ULTIMA曲"},
+				Chart:    &entity.Chart{ID: 10, Const: chartConst},
+				ChartDifficulty: &entity.ChartDifficulty{
+					ID:   5,
+					Name: "ULTIMA",
+				},
+			},
+			// 同じ曲の別の難易度（スキップされない）
+			{
+				PlayerID: 1,
+				ChartID:  11,
+				Score:    recordScore,
+				Song:     &entity.Song{ID: 100, Title: "ULTIMA曲"},
+				Chart:    &entity.Chart{ID: 11, Const: chartConst},
+				ChartDifficulty: &entity.ChartDifficulty{
+					ID:   1,
+					Name: "MASTER",
+				},
+			},
+		}
+
+		lockedSongs := []*entity.PlayerLockedSong{
+			{PlayerID: 1, SongID: 100, IsUltima: true},
+		}
+
+		// Act
+		result, err := calculateOverpowerSummaryFromPlayerRecords(records, lockedSongs, 100.0)
+
+		// Assert
+		require.NoError(t, err)
+		assert.NotNil(t, result.Value)
+		assert.NotNil(t, result.Percent)
+
+		// WARNログが出力されていることを確認
+		logOutput := logBuffer.String()
+		assert.Contains(t, logOutput, "level=WARN")
+		assert.Contains(t, logOutput, "skipped player records during overpower recalculation")
+		assert.Contains(t, logOutput, "locked_song")
+	})
+
+	t.Run("ロック楽曲がない場合はスキップ処理をバイパスする", func(t *testing.T) {
+		// Arrange
+		logBuffer := captureDefaultSlog(t)
+		recordScore, err := score.NewScore(1_000_000)
+		require.NoError(t, err)
+		chartConst, err := chartconstant.NewChartConstant(10.0)
+		require.NoError(t, err)
+
+		records := []*entity.PlayerRecord{
+			{
+				PlayerID: 1,
+				ChartID:  10,
+				Score:    recordScore,
+				Song:     &entity.Song{ID: 100, Title: "通常曲"},
+				Chart:    &entity.Chart{ID: 10, Const: chartConst},
+				// ChartDifficultyがnilでもロック楽曲が空ならスキップチェックはバイパスされる
+			},
+		}
+
+		lockedSongs := []*entity.PlayerLockedSong{}
+
+		// Act
+		result, err := calculateOverpowerSummaryFromPlayerRecords(records, lockedSongs, 100.0)
+
+		// Assert
+		require.NoError(t, err)
+		assert.NotNil(t, result.Value)
+		assert.NotNil(t, result.Percent)
+
+		// ロック楽曲がないのでWARNログは出力されない（または別の理由でスキップされた場合のみ出力される）
+		logOutput := logBuffer.String()
+		// この場合はChartDifficultyがnilでもスキップロジックがバイパスされるため、WARNログは出ない
+		assert.NotContains(t, logOutput, "chart_difficulty_nil")
+		assert.NotContains(t, logOutput, "locked_song")
+	})
+
+	t.Run("スキップレコードが空の場合はWARNログを出力しない", func(t *testing.T) {
+		// Arrange
+		logBuffer := captureDefaultSlog(t)
+		recordScore, err := score.NewScore(1_000_000)
+		require.NoError(t, err)
+		chartConst, err := chartconstant.NewChartConstant(10.0)
+		require.NoError(t, err)
+
+		records := []*entity.PlayerRecord{
+			{
+				PlayerID: 1,
+				ChartID:  10,
+				Score:    recordScore,
+				Song:     &entity.Song{ID: 100, Title: "通常曲"},
+				Chart:    &entity.Chart{ID: 10, Const: chartConst},
+				ChartDifficulty: &entity.ChartDifficulty{
+					ID:   1,
+					Name: "MASTER",
+				},
+			},
+		}
+
+		lockedSongs := []*entity.PlayerLockedSong{
+			{PlayerID: 1, SongID: 200, IsUltima: false}, // 別の曲をロック
+		}
+
+		// Act
+		result, err := calculateOverpowerSummaryFromPlayerRecords(records, lockedSongs, 100.0)
+
+		// Assert
+		require.NoError(t, err)
+		assert.NotNil(t, result.Value)
+		assert.NotNil(t, result.Percent)
+
+		// スキップレコードがないのでWARNログは出力されない
+		logOutput := logBuffer.String()
+		assert.NotContains(t, logOutput, "skipped player records during overpower recalculation")
+	})
 }


### PR DESCRIPTION
### Motivation
- OVER POWER 再計算時に出る警告ログが件数だけで、どのレコードが何故スキップされたか分からなかったため、デバッグしやすくする目的で詳細をログに残すようにする。 
- スキップ理由を `record_nil` / `song_nil` / `chart_nil` / `chart_difficulty_nil` / `locked_song` 等で明示し、運用時の原因切り分けを容易にする。 

### Description
- スキップ詳細を保持する構造体 `skippedOverpowerRecord` を追加し、`playerRecordsToOverpowerRecordsWithSkipped` を実装してスキップ理由と関連情報を収集するようにした。 
- 既存の `playerRecordsToOverpowerRecords` は新関数をラップして互換性を維持するように変更した。 
- `calculateOverpowerSummaryFromPlayerRecords` 側でスキップ詳細を受け取り、WARNログに `skipped_records` フィールドとして出力するように変更した。 
- スキップ挙動を検証するユニットテスト `TestPlayerRecordsToOverpowerRecordsWithSkipped` を追加した。 

### Testing
- `go test ./internal/usecase -run TestPlayerRecordsToOverpowerRecordsWithSkipped -count=1` を実行しテストが成功したことを確認した。 
- `go test ./...` を実行しリポジトリ全体のテストが成功したことを確認した。 
- `gofmt -s -w .` を実行してコード整形を行い問題ないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1eec0418832dbde3d3f34363bc8c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 変換処理で除外されたレコードの理由を記録できるようになりました。
  * 欠損データや条件による除外も、どのようにスキップされたかを追跡しやすくなりました。

* **バグ修正**
  * レコード変換時の欠損・除外ケースが、単純に見落とされずに記録されるよう改善しました。
  * POWER再計算時の対象外レコードの扱いがより一貫しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->